### PR TITLE
Add inline tests for go-to-definition functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 tests/symbols/build
+**/.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "home",
  "im",
  "itertools 0.10.5",
+ "line-col",
  "log",
  "lsp-server",
  "lsp-types",
@@ -1526,6 +1527,12 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
 ]
+
+[[package]]
+name = "line-col"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
 
 [[package]]
 name = "linked-hash-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ stderrlog = "0.5.4"
 enum-iterator = "1.2.0"
 num-bigint = "0.4.0"
 home = "0.5.3"
+line-col = "0.2.1"
 
 [target.'cfg(not(target_os= "windows"))'.dependencies]
 pprof = { version = "0.11.0" , features = ["flamegraph" , "protobuf"]}

--- a/src/goto_definition.rs
+++ b/src/goto_definition.rs
@@ -21,6 +21,7 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
+use crate::project::Project;
 
 /// Handles go-to-def request of the language server.
 pub fn on_go_to_def_request(context: &Context, request: &Request) -> lsp_server::Response {
@@ -49,12 +50,8 @@ pub fn on_go_to_def_request(context: &Context, request: &Request) -> lsp_server:
             };
         }
     };
-    let mut handler = Handler::new(fpath.clone(), line, col);
-    handler.addrname_2_addrnum = project.addrname_2_addrnum.clone();
-    project.run_visitor_for_file(&mut handler, &fpath, String::default());
 
-    handler.remove_not_in_loc(&project.global_env);
-    let locations = handler.convert_to_locations();
+    let locations = on_goto_definition(project, fpath, line, col);
 
     let r = Response::new_ok(
         request.id.clone(),
@@ -68,6 +65,20 @@ pub fn on_go_to_def_request(context: &Context, request: &Request) -> lsp_server:
         .unwrap();
     log::trace!("goto definition Success");
     ret_response
+}
+
+pub fn on_goto_definition(
+    project: &Project,
+    ref_fpath: PathBuf,
+    ref_line: u32,
+    ref_col: u32,
+) -> Vec<lsp_types::Location> {
+    let mut handler = Handler::new(ref_fpath.clone(), ref_line, ref_col);
+    handler.addrname_2_addrnum = project.addrname_2_addrnum.clone();
+    project.run_visitor_for_file(&mut handler, &ref_fpath, String::default());
+
+    handler.remove_not_in_loc(&project.global_env);
+    handler.convert_to_locations()
 }
 
 pub(crate) struct Handler {

--- a/tests/test_goto_def_inline.rs
+++ b/tests/test_goto_def_inline.rs
@@ -1,0 +1,629 @@
+use aptos_move_analyzer::goto_definition::on_goto_definition;
+use aptos_move_analyzer::project::Project;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn test_aptos_project(package_root: PathBuf) -> Project {
+    let project = Project::new(package_root, |_| {}).unwrap();
+    assert!(project.load_ok(), "Cannot load");
+    project
+}
+
+fn get_marked_position(source: &str, mark: &str) -> (u32, u32) {
+    let offset = source.find(mark).unwrap();
+    let (line, col) = line_col::LineColLookup::new(&source).get(offset);
+    let ref_line = line - 1; // it's a //^ comment underneath the element
+    let ref_col = col + 2; // we need a position of ^
+                           // it's zero based
+    ((ref_line - 1) as u32, (ref_col - 1) as u32)
+}
+
+fn is_inside_range(pos: lsp_types::Position, range: lsp_types::Range) -> bool {
+    range.start <= pos && pos <= range.end
+}
+
+fn move_test_package(temp_dir: &TempDir, main_source: &str) -> PathBuf {
+    let package_root = temp_dir.path().to_path_buf();
+    fs::create_dir(package_root.join("sources")).unwrap();
+    fs::write(
+        package_root.join("Move.toml"),
+        // language=Toml
+        r#"
+[package]
+name = "MyTestPackage"
+version = "1.0.0"
+authors = []
+
+[addresses]
+std = "0x1"
+        "#,
+    )
+    .unwrap();
+    fs::write(
+        package_root.join("sources").join("main.move"),
+        main_source.trim_start(),
+    )
+    .unwrap();
+    package_root
+}
+
+fn test_resolve_reference(main_source: &str) {
+    let temp = tempfile::tempdir().unwrap();
+    let package_root = move_test_package(&temp, main_source);
+    let aptos_project = test_aptos_project(package_root.clone());
+
+    let source_fpath = package_root.join("sources").join("main.move");
+    let source = fs::read_to_string(source_fpath.clone()).unwrap();
+
+    let (ref_line, ref_col) = get_marked_position(&source, "//^");
+    let (target_line, target_col) = get_marked_position(&source, "//X");
+
+    let locations = on_goto_definition(&aptos_project, source_fpath, ref_line, ref_col);
+    assert!(!locations.is_empty(), "unresolved, locations = {:?}", locations);
+
+    let actual_location = locations.first().unwrap().to_owned();
+    let target_pos = lsp_types::Position::new(target_line, target_col);
+    // todo: check for file
+    assert!(is_inside_range(target_pos, actual_location.range));
+}
+
+#[test]
+fn test_resolve_function_call() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    fun call() {}
+       //X
+    fun main() {
+        call();
+         //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_function_call_another_module() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+               //X
+}
+module std::main {
+    use std::m::call;
+    fun main() {
+        call();
+         //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_function_in_use_stmt() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+               //X
+}
+module std::main {
+    use std::m::call;
+                //^
+}
+    "#);
+}
+
+#[ignore = "not implemented yet"]
+#[test]
+fn test_resolve_function_in_use_stmt_with_numeric_address() {
+    // language=Move
+    test_resolve_reference(r#"
+module 0x1::m {
+    public fun call() {}
+               //X
+}
+module 0x1::main {
+    use 0x1::m::call;
+                //^
+}
+    "#);
+}
+
+#[ignore = "resolution is not implemented for local use statements"]
+#[test]
+fn test_resolve_function_in_local_use_stmt() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+               //X
+}
+module std::main {
+    fun main() {
+        use std::m::call;
+                    //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_function_in_use_group() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+               //X
+}
+module std::main {
+    use std::m::{call};
+                //^
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_module_self_in_use_group() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+          //X
+    public fun call() {}
+}
+module std::main {
+    use std::m::{Self, call};
+                //^
+}
+    "#);
+}
+
+#[ignore = "not implemented yet"]
+#[test]
+fn test_resolve_module_self_in_use_group_multiline() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+          //X
+    public fun call() {}
+}
+module std::main {
+    use std::m::{
+        Self, call};
+        //^
+}
+    "#);
+}
+
+#[ignore = "not implemented yet"]
+#[test]
+fn test_resolve_function_in_use_group_on_separate_line() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+               //X
+}
+module std::main {
+    use std::m::{
+        call
+      //^
+    };
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_from_use_stmt() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    struct S { val: u8 }
+         //X
+}
+module std::main {
+    use std::m::S;
+              //^
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_from_type() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+         //X
+    fun main(): S {
+              //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_from_type_another_module() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    struct S { val: u8 }
+         //X
+}
+module std::main {
+    use std::m::S;
+    fun main(): S {
+              //^
+    }
+}
+    "#);
+}
+
+#[ignore = "not implemented yet"]
+#[test]
+fn test_resolve_struct_from_type_single_line_function() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+         //X
+    fun main(): S {}
+              //^
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_from_struct_literal() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+         //X
+    fun main() {
+        S { val: 1 };
+      //^
+    }
+}
+    "#);
+}
+
+#[ignore = "not implemented yet"]
+#[test]
+fn test_resolve_struct_from_struct_literal_single_line() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+         //X
+    fun main() {
+        S { val: 1 }; }
+      //^
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_from_function_parameter_type() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+         //X
+    fun main(s: S) {
+              //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_function_parameter() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    fun main(s: u8) {
+           //X
+        s;
+      //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_variable() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    fun main() {
+        let s = 1;
+          //X
+        s;
+      //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_variable_with_parameter_shadowing() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    fun main(s: u8) {
+        let s = 1;
+          //X
+        s;
+      //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_variable_with_another_variable_shadowing() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    fun main(s: u8) {
+        let s = 1;
+        let s = 2;
+          //X
+        s;
+      //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_field() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+              //X
+    fun main() {
+        S { val: 1 }
+            //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_field_in_struct_pattern() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+              //X
+    fun main(s: S) {
+        let S { val: myval } = s;
+              //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_struct_field_in_dot_expr() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    struct S { val: u8 }
+              //X
+    fun main() {
+        let s = S { val: 1 };
+        s.val;
+         //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_const() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::main {
+    const MY_ERR: u8 = 1;
+          //X
+    fun main() {
+        MY_ERR;
+      //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_module_in_use_stmt() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+          //X
+}
+module std::main {
+    use std::m;
+           //^
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_module_in_use_item_stmt() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+          //X
+    public fun call() {}
+}
+module std::main {
+    use std::m::call;
+           //^
+}
+    "#);
+}
+
+#[ignore = "bug, i don't know"]
+#[test]
+fn test_resolve_module_in_qualified_ref() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+          //X
+    public fun call() {}
+}
+module std::main {
+    use std::m;
+    fun main() {
+        m::call();
+      //^
+    }
+}
+    "#);
+}
+
+#[ignore = "bug, i don't know"]
+#[test]
+fn test_resolve_module_in_qualified_ref_with_self() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+          //X
+    public fun call() {}
+}
+module std::main {
+    use std::m::Self;
+    fun main() {
+        m::call();
+      //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_module_item_in_qualified_ref() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+              //X
+}
+module std::main {
+    use std::m;
+    fun main() {
+        m::call();
+          //^
+    }
+}
+    "#);
+}
+
+#[test]
+fn test_resolve_module_item_in_qualified_ref_with_self() {
+    // language=Move
+    test_resolve_reference(r#"
+module std::m {
+    public fun call() {}
+              //X
+}
+module std::main {
+    use std::m::Self;
+    fun main() {
+        m::call();
+          //^
+    }
+}
+    "#);
+}
+
+#[ignore = "not implemented"]
+#[test]
+fn test_resolve_module_spec() {
+    // language=Move
+    test_resolve_reference(r#"
+module 0x1::m {
+          //X
+}
+spec 0x1::m {
+        //^
+}
+    "#)
+}
+
+#[ignore = "not implemented"]
+#[test]
+fn test_resolve_function_spec() {
+    // language=Move
+    test_resolve_reference(r#"
+module 0x1::m {
+    fun main() {}
+        //X
+}
+spec 0x1::m {
+    spec main {}
+        //^
+}
+    "#)
+}
+
+#[ignore = "not implemented?"]
+#[test]
+fn test_resolve_struct_spec() {
+    // language=Move
+    test_resolve_reference(r#"
+module 0x1::m {
+    struct S { val: u8 }
+         //X
+}
+spec 0x1::m {
+    spec S {}
+       //^
+}
+    "#)
+}
+
+#[ignore = "not implemented"]
+#[test]
+fn test_resolve_function_call_inside_spec() {
+    // language=Move
+    test_resolve_reference(r#"
+module 0x1::m {
+    fun main() {}
+       //X
+}
+spec 0x1::m {
+    spec main {
+        main();
+       //^
+    }
+}
+    "#)
+}
+
+#[ignore = "not implemented"]
+#[test]
+fn test_resolve_function_call_inside_spec_inside_module() {
+    // language=Move
+    test_resolve_reference(r#"
+module 0x1::m {
+    fun call() {}
+       //X
+    public fun main() {
+    }
+    spec main {
+        call();
+       //^
+    }
+}
+    "#)
+}
+
+
+


### PR DESCRIPTION
It adds a number self-contained tests, that invoke go-to-def directly, instead of through the language server, making them really fast and easy to write. 
Current tests of go-to-definition failing on my machine. 

Part of https://github.com/movebit/aptos-move-analyzer/pull/15