### PR TITLE
Bugfix/250301

### DIFF
--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -130,7 +130,7 @@ export class Context {
         // that is 'Move Language Server'). For more information, see:
         // https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server
         const traceOutputChannel = vscode.window.createOutputChannel(
-            'Move Analyzer Language Server Trace',
+            'Aptos Move Analyzer Language Server Trace',
         );
         const clientOptions: lc.LanguageClientOptions = {
             documentSelector: [{ scheme: 'file', language: 'move' }],

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -4,21 +4,22 @@
 
 import type { Configuration } from './configuration';
 import * as vscode from 'vscode';
-import { CompletionContext as VCompletionContext, CompletionTriggerKind } from 'vscode';
+// import { CompletionContext as VCompletionContext, CompletionTriggerKind } from 'vscode';
 import * as lc from "vscode-languageclient/node";
 import { log } from './log';
 import { sync as commandExistsSync } from 'command-exists';
 import { IndentAction } from 'vscode';
+// import { info } from 'console';
 
-function sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
+// function sleep(ms: number): Promise<void> {
+//     return new Promise(resolve => setTimeout(resolve, ms));
+// }
 
 /** Information passed along to each VS Code command defined by this extension. */
 export class Context {
     // private completeTimer: NodeJS.Timeout | null;
-    private didChangeTimer: NodeJS.Timeout | null;
-    private lastChangeTime: number;
+    // private didChangeTimer: NodeJS.Timeout | null;
+    // private lastChangeTime: number;
     private client: lc.LanguageClient | undefined;
     private constructor(
         private readonly extensionContext: Readonly<vscode.ExtensionContext>,
@@ -26,8 +27,8 @@ export class Context {
         client: lc.LanguageClient | undefined = undefined,
     ) {
         this.client = client;
-        this.didChangeTimer = null;
-        this.lastChangeTime = 0;
+        // this.didChangeTimer = null;
+        // this.lastChangeTime = 0;
         // this.completeTimer = null;
     }
 
@@ -143,35 +144,49 @@ export class Context {
             clientOptions,
         );
 
-        client.middleware.didChange = (data, next) => {
-            const currentTime = Date.now();
-            if (currentTime - this.lastChangeTime < 1000) {
-                this.lastChangeTime = currentTime;
-                if (this.didChangeTimer) {
-                    clearTimeout(this.didChangeTimer);  // 重置定时器
-                }
-                this.didChangeTimer = setTimeout(() => {
-                    next(data);  
-                    this.didChangeTimer = null;  
-                }, 800);
-                return Promise.resolve();
-            }
+        // client.middleware.didChange = (data, next) => {
+        //     const currentTime = Date.now();
+        //     if (currentTime - this.lastChangeTime < 1000) {
+        //         this.lastChangeTime = currentTime;
+        //         if (this.didChangeTimer) {
+        //             clearTimeout(this.didChangeTimer);  // 重置定时器
+        //         }
+        //         this.didChangeTimer = setTimeout(() => {
+        //             next(data);  
+        //             this.didChangeTimer = null;  
+        //         }, 800);
+        //         return Promise.resolve();
+        //     }
 
-            this.lastChangeTime = currentTime;
-            return next(data);
-        };
+        //     this.lastChangeTime = currentTime;
+        //     return next(data);
+        // };
         
-        client.middleware.provideCompletionItem = async (
-            document, position, context, token, next
+        // vscode.workspace.onDidChangeTextDocument(event => {
+        //     console.log(`[Document Change] ${event.document.uri.toString()}`);
+        //     console.log(`Changes:`, event.contentChanges);
+        // });
+        // // vscode.workspace.applyEdit
+
+        // client.middleware.provideCompletionItem = async (
+        //     document, position, context, token, next
+        // ) => {
+        //     const myContext : VCompletionContext = {
+        //         triggerKind: CompletionTriggerKind.TriggerCharacter,
+        //         triggerCharacter: context.triggerCharacter,
+        //     }
+        //     await sleep(800);
+        //     return next(document, position, myContext, token);
+        // }
+        
+        client.middleware.provideDocumentFormattingEdits = async (
+            document, options, token, next
         ) => {
-            const myContext : VCompletionContext = {
-                triggerKind: CompletionTriggerKind.TriggerCharacter,
-                triggerCharacter: context.triggerCharacter,
-            }
-            await sleep(800);
-            return next(document, position, myContext, token);
+            // await sleep(1000);
+            // document.save();
+            return next(document, options, token);
         }
-        
+
         log.info('Starting client...');
         client.start();
         this.client = client;

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -17,7 +17,6 @@ import { IndentAction } from 'vscode';
 
 /** Information passed along to each VS Code command defined by this extension. */
 export class Context {
-    private completeTimer: NodeJS.Timeout | null;
     private didChangeTimer: NodeJS.Timeout | null;
     private lastChangeTime: number;
     private client: lc.LanguageClient | undefined;
@@ -29,7 +28,6 @@ export class Context {
         this.client = client;
         this.didChangeTimer = null;
         this.lastChangeTime = 0;
-        this.completeTimer = null;
     }
 
     static create(
@@ -164,6 +162,13 @@ export class Context {
             return Promise.resolve();
         };
 
+        client.middleware.provideCompletionItem = async (
+            document, position, context, token, next
+        ) => {
+            await sleep(800);
+            return next(document, position, context, token);
+        }
+        
         client.middleware.willSave = (data, next) => {
             if (this.didChangeTimer) {
                 clearTimeout(this.didChangeTimer);  // clear the previous timer
@@ -172,17 +177,6 @@ export class Context {
             return next(data);
         };
 
-        // client.middleware.provideCompletionItem = async (
-        //     document, position, context, token, next
-        // ) => {
-        //     const myContext : VCompletionContext = {
-        //         triggerKind: CompletionTriggerKind.TriggerCharacter,
-        //         triggerCharacter: context.triggerCharacter,
-        //     }
-        //     await sleep(800);
-        //     return next(document, position, myContext, token);
-        // }
-        
         // client.middleware.provideDocumentFormattingEdits = async (
         //     document, options, token, next
         // ) => {
@@ -209,3 +203,7 @@ export class Context {
         return this.client;
     }
 } // Context
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -20,6 +20,7 @@ export class Context {
     private didChangeTimer: NodeJS.Timeout | null;
     private lastChangeTime: number;
     private client: lc.LanguageClient | undefined;
+    private didchange: boolean;
     private constructor(
         private readonly extensionContext: Readonly<vscode.ExtensionContext>,
         readonly configuration: Readonly<Configuration>,
@@ -28,6 +29,7 @@ export class Context {
         this.client = client;
         this.didChangeTimer = null;
         this.lastChangeTime = 0;
+        this.didchange = false;
     }
 
     static create(
@@ -152,6 +154,7 @@ export class Context {
                 }
                 this.didChangeTimer = setTimeout(() => {
                     next(data);  
+                    this.didchange = true;
                     this.didChangeTimer = null;  
                 }, 800);
                 return Promise.resolve();
@@ -165,8 +168,11 @@ export class Context {
         client.middleware.provideCompletionItem = async (
             document, position, context, token, next
         ) => {
-            await sleep(800);
-            return next(document, position, context, token);
+            if (this.didchange) {
+                return next(document, position, context, token);
+            } else {
+                return null;
+            }
         }
         
         client.middleware.willSave = (data, next) => {
@@ -176,14 +182,6 @@ export class Context {
             }
             return next(data);
         };
-
-        // client.middleware.provideDocumentFormattingEdits = async (
-        //     document, options, token, next
-        // ) => {
-        //     // await sleep(1000);
-        //     // document.save();
-        //     return next(document, options, token);
-        // }
 
         log.info('Starting client...');
         client.start();

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -179,13 +179,13 @@ export class Context {
         //     return next(document, position, myContext, token);
         // }
         
-        client.middleware.provideDocumentFormattingEdits = async (
-            document, options, token, next
-        ) => {
-            // await sleep(1000);
-            // document.save();
-            return next(document, options, token);
-        }
+        // client.middleware.provideDocumentFormattingEdits = async (
+        //     document, options, token, next
+        // ) => {
+        //     // await sleep(1000);
+        //     // document.save();
+        //     return next(document, options, token);
+        // }
 
         log.info('Starting client...');
         client.start();

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -17,9 +17,9 @@ import { IndentAction } from 'vscode';
 
 /** Information passed along to each VS Code command defined by this extension. */
 export class Context {
-    // private completeTimer: NodeJS.Timeout | null;
-    // private didChangeTimer: NodeJS.Timeout | null;
-    // private lastChangeTime: number;
+    private completeTimer: NodeJS.Timeout | null;
+    private didChangeTimer: NodeJS.Timeout | null;
+    private lastChangeTime: number;
     private client: lc.LanguageClient | undefined;
     private constructor(
         private readonly extensionContext: Readonly<vscode.ExtensionContext>,
@@ -27,9 +27,9 @@ export class Context {
         client: lc.LanguageClient | undefined = undefined,
     ) {
         this.client = client;
-        // this.didChangeTimer = null;
-        // this.lastChangeTime = 0;
-        // this.completeTimer = null;
+        this.didChangeTimer = null;
+        this.lastChangeTime = 0;
+        this.completeTimer = null;
     }
 
     static create(
@@ -144,29 +144,33 @@ export class Context {
             clientOptions,
         );
 
-        // client.middleware.didChange = (data, next) => {
-        //     const currentTime = Date.now();
-        //     if (currentTime - this.lastChangeTime < 1000) {
-        //         this.lastChangeTime = currentTime;
-        //         if (this.didChangeTimer) {
-        //             clearTimeout(this.didChangeTimer);  // 重置定时器
-        //         }
-        //         this.didChangeTimer = setTimeout(() => {
-        //             next(data);  
-        //             this.didChangeTimer = null;  
-        //         }, 800);
-        //         return Promise.resolve();
-        //     }
+        client.middleware.didChange = (data, next) => {
+            const currentTime = Date.now();
+            if (currentTime - this.lastChangeTime < 1000) {
+                this.lastChangeTime = currentTime;
+                if (this.didChangeTimer) {
+                    clearTimeout(this.didChangeTimer);  // clear the previous timer
+                    this.didChangeTimer = null;
+                }
+                this.didChangeTimer = setTimeout(() => {
+                    next(data);  
+                    this.didChangeTimer = null;  
+                }, 800);
+                return Promise.resolve();
+            }
 
-        //     this.lastChangeTime = currentTime;
-        //     return next(data);
-        // };
-        
-        // vscode.workspace.onDidChangeTextDocument(event => {
-        //     console.log(`[Document Change] ${event.document.uri.toString()}`);
-        //     console.log(`Changes:`, event.contentChanges);
-        // });
-        // // vscode.workspace.applyEdit
+            this.lastChangeTime = currentTime;
+            // return next(data);
+            return Promise.resolve();
+        };
+
+        client.middleware.willSave = (data, next) => {
+            if (this.didChangeTimer) {
+                clearTimeout(this.didChangeTimer);  // clear the previous timer
+                this.didChangeTimer = null;
+            }
+            return next(data);
+        };
 
         // client.middleware.provideCompletionItem = async (
         //     document, position, context, token, next

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -82,15 +82,6 @@ export async function activate(
     log.info('reload_cfg ...  ');
     reload_cfg();
   });
-
-  vscode.workspace.onDidChangeTextDocument(() => {
-    // if (e.document.fileName.includes("Move Analyzer Client")
-    // ) {
-    //   return;
-    // }
-    return;
-    // reload_cfg();
-  });
 }
 
 function updateStatus(status: LspStatus, extraInfo?: string) {

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -21,8 +21,8 @@
         "noImplicitThis": true,
         "noPropertyAccessFromIndexSignature": true,
         "noUncheckedIndexedAccess": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true
+        "noUnusedLocals": false,
+        "noUnusedParameters": false
     },
     "exclude": [
         "node_modules",

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -323,7 +323,6 @@ fn clear_ui_diag(context: &mut Context, fpath: PathBuf) {
     let mut result: HashMap<Url, Vec<lsp_types::Diagnostic>> = HashMap::new();
     let diag_err = proj.err_diags.clone();
     let tokens: Vec<&str> = diag_err.as_str().split("error: ").collect();
-    log::info!("clear_ui_diag diag tokens.len = {:?}", tokens.len());
     for token in tokens {
         let line_vec = token.lines().collect_vec();
         if line_vec.len() < 3 {
@@ -331,7 +330,6 @@ fn clear_ui_diag(context: &mut Context, fpath: PathBuf) {
         }
         let err_msg = line_vec[0];
         let loc_str = line_vec[1];
-        log::error!("clear_ui_diag diag err_msg = {:?}", err_msg);
 
         let mut file_path = "";
         let mut pos = lsp_types::Position::default();
@@ -361,7 +359,6 @@ fn clear_ui_diag(context: &mut Context, fpath: PathBuf) {
                 pos = lsp_types::Position::new(line_num, col_num);
             }
         }
-        log::error!("clear_ui_diag diag file_path = {:?}", file_path);
 
         if file_path.is_empty() {
             continue;
@@ -372,10 +369,7 @@ fn clear_ui_diag(context: &mut Context, fpath: PathBuf) {
             code_str.push_str(line_vec[line_idx]);
             code_str.push_str("\n");
         }
-        log::error!(
-            "clear_ui_diag diag code_str = {:?}",
-            format!("{}\n{}", err_msg, code_str)
-        );
+
         let d = lsp_types::Diagnostic {
             range: lsp_types::Range {
                 start: pos,

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -191,9 +191,9 @@ fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut Analy
         lsp_types::request::DocumentSymbolRequest::METHOD => {
             symbols::on_document_symbol_request(context, request);
         }
-        // lsp_types::request::Formatting::METHOD => {
-        //     on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
-        // }
+        lsp_types::request::Formatting::METHOD => {
+            // on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
+        }
         "move/generate/spec/file" => {
             on_generate_spec_file(context, request, true);
         }
@@ -536,9 +536,20 @@ fn on_notification(context: &mut Context, notification: &Notification) {
                     return;
                 }
             };
+            // if let Some(content) = parameters.text {
+            //     log::info!("{:?}", content.len());
+            // }
+            // log::info!("did save text document: {}", content.len());
 
-            log::info!("did save text document: {}", content);
-
+            let mut movefmt_cfg = commentfmt::Config::default();
+            let content = if let Ok(content_format) =
+            movefmt::core::fmt::format_entry(content.clone(), movefmt_cfg) {
+                std::fs::write(fpath.as_path(), content_format.clone());
+                content_format
+            } else {
+                content
+            };
+            
             clear_ui_diag(context, fpath.clone());
             update_defs_on_changed(context, fpath.clone(), content.clone());
         }

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -20,10 +20,13 @@ use log::{Level, Metadata, Record};
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::{
     notification::Notification as _, request::Request as _, CompletionOptions,
-    HoverProviderCapability, OneOf, SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, WorkDoneProgressOptions,
+    DidSaveTextDocumentParams, HoverProviderCapability, OneOf, SaveOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    WorkDoneProgressOptions,
 };
 use move_command_line_common::files::FileHash;
+use move_compiler::diag;
+use move_core_types::effects::Op;
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 use url::Url;
 
@@ -159,7 +162,7 @@ fn main() {
                                 // It ought to, especially once it begins processing requests that may
                                 // take a long time to respond to.
                             }
-                            _ => on_notification(&mut context, &notification),
+                            _ => on_notification(&mut context, &notification, &analyzer_cfg),
                         }
                     }
                     Err(error) => log::error!("IDE message error: {:?}", error),
@@ -493,7 +496,11 @@ fn report_diag(context: &mut Context, fpath: PathBuf) {
     }
 }
 
-fn on_notification(context: &mut Context, notification: &Notification) {
+fn on_notification(
+    context: &mut Context,
+    notification: &Notification,
+    analyzer_cfg: &AnalyzerConfig,
+) {
     fn update_defs_on_changed(context: &mut Context, fpath: PathBuf, content: String) {
         let file_hash = FileHash::new(content.as_str());
         context.projects.update_defs(fpath.clone(), content.clone());
@@ -520,45 +527,17 @@ fn on_notification(context: &mut Context, notification: &Notification) {
                     .expect("could not deserialize DidSaveTextDocumentParams request");
             let fpath = parameters.text_document.uri.to_file_path().unwrap();
             let fpath = path_concat(&std::env::current_dir().unwrap(), &fpath);
-            let content = std::fs::read_to_string(fpath.as_path());
-            let content = match content {
-                Ok(x) => x,
-                Err(err) => {
-                    log::error!("read file failed,err:{:?}", err);
-                    return;
-                }
-            };
-            // if let Some(content) = parameters.text {
-            //     log::info!("{:?}", content.len());
-            // }
-            // log::info!("did save text document: {}", content.len());
-
-            let mut movefmt_cfg = commentfmt::Config::default();
-            let content = if let Ok(content_format) =
-                movefmt::core::fmt::format_entry(content.clone(), movefmt_cfg)
-            {
-                std::fs::write(fpath.as_path(), content_format.clone());
-                content_format
-            } else {
-                content
-            };
-
+            let content = format_on_did_save(&fpath, parameters.text, &analyzer_cfg);
             clear_ui_diag(context, fpath.clone());
-            update_defs_on_changed(context, fpath.clone(), content.clone());
+            update_defs_on_changed(context, fpath.clone(), content);
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
-            log::info!("did change text doc");
             use lsp_types::DidChangeTextDocumentParams;
             let parameters =
                 serde_json::from_value::<DidChangeTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize DidChangeTextDocumentParams request");
             let fpath = parameters.text_document.uri.to_file_path().unwrap();
             let fpath = path_concat(&std::env::current_dir().unwrap(), &fpath);
-
-            log::info!(
-                "did change text document: {}",
-                parameters.content_changes.last().unwrap().text.clone()
-            );
             clear_ui_diag(context, fpath.clone());
             update_defs_on_changed(
                 context,
@@ -659,4 +638,43 @@ fn send_not_project_file_error(context: &mut Context, fpath: PathBuf, is_open: b
             params: serde_json::to_value(ds).unwrap(),
         }))
         .unwrap();
+}
+
+fn format_on_did_save(
+    fpath: &PathBuf,
+    text: Option<String>,
+    analyzer_cfg: &AnalyzerConfig,
+) -> String {
+    let file_content = if let Some(content) = text {
+        content
+    } else {
+        std::fs::read_to_string(fpath).unwrap()
+    };
+
+    if !analyzer_cfg.movefmt_config.enable {
+        return file_content;
+    }
+
+    let mut movefmt_cfg = commentfmt::Config::default();
+    movefmt_cfg
+        .set()
+        .max_width(analyzer_cfg.movefmt_config.max_width as usize);
+    movefmt_cfg
+        .set()
+        .indent_size(analyzer_cfg.movefmt_config.indent_size as usize);
+
+    match movefmt::core::fmt::format_entry(file_content.clone(), movefmt_cfg) {
+        Ok(result) => {
+            if let Err(err) = std::fs::write(fpath.as_path(), result.clone()) {
+                log::error!("write file failed, err: {:?}", err);
+                file_content
+            } else {
+                result
+            }
+        }
+        Err(err) => {
+            log::error!("format file failed, err: {:?}", err);
+            file_content
+        }
+    }
 }

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -521,6 +521,7 @@ fn on_notification(
 
     match notification.method.as_str() {
         lsp_types::notification::DidSaveTextDocument::METHOD => {
+            log::info!("call did save");
             use lsp_types::DidSaveTextDocumentParams;
             let parameters =
                 serde_json::from_value::<DidSaveTextDocumentParams>(notification.params.clone())
@@ -532,6 +533,7 @@ fn on_notification(
             update_defs_on_changed(context, fpath.clone(), content);
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
+            log::info!("call did change");
             use lsp_types::DidChangeTextDocumentParams;
             let parameters =
                 serde_json::from_value::<DidChangeTextDocumentParams>(notification.params.clone())

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -462,10 +462,7 @@ fn report_diag(context: &mut Context, fpath: PathBuf) {
             code_str.push_str(line_vec[line_idx]);
             code_str.push_str("\n");
         }
-        log::error!(
-            "report diag code_str = {:?}",
-            format!("{}\n{}", err_msg, code_str)
-        );
+
         let d = lsp_types::Diagnostic {
             range: lsp_types::Range {
                 start: pos,
@@ -476,12 +473,13 @@ fn report_diag(context: &mut Context, fpath: PathBuf) {
             ..Default::default()
         };
         let url = url::Url::from_file_path(PathBuf::from(file_path).as_path()).unwrap();
-        result.insert(url, vec![d]);
+        result.entry(url)
+            .or_insert(Vec::new())
+            .push(d);
+        
     }
-    log::info!("report diag result = {:?}", result);
     for (k, v) in result.clone().into_iter() {
         let ds = lsp_types::PublishDiagnosticsParams::new(k.clone(), v, None);
-        log::info!("report diag ds = {:?}", serde_json::to_value(ds.clone()));
         context
             .connection
             .sender

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -229,15 +229,6 @@ fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut Analy
                     }))
                     .unwrap();
                 eprintln!("--------------------- unregister inlay_hint ---------------------");
-                // context
-                //     .connection
-                //     .sender
-                //     .send(lsp_server::Message::Request(Request{
-                //         id: "inlay_hints".to_string().into(),
-                //         method: lsp_types::request::InlayHintRefreshRequest::METHOD.to_string(),
-                //         params: serde_json::json!({}),
-                //     })).unwrap();
-                // eprintln!("--------------------- refresh inlay_hint ---------------------");
             } else {
                 let params = lsp_types::RegistrationParams {
                     registrations: vec![lsp_types::Registration {

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -173,7 +173,6 @@ fn main() {
 }
 
 fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut AnalyzerConfig) {
-    // log::info!("aptos receive method:{}", request.method.as_str());
     match request.method.as_str() {
         lsp_types::request::GotoDefinition::METHOD => {
             goto_definition::on_go_to_def_request(context, request);
@@ -193,9 +192,9 @@ fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut Analy
         lsp_types::request::DocumentSymbolRequest::METHOD => {
             symbols::on_document_symbol_request(context, request);
         }
-        // lsp_types::request::Formatting::METHOD => {
-        //     // on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
-        // }
+        lsp_types::request::Formatting::METHOD => {
+            on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
+        }
         "move/generate/spec/file" => {
             on_generate_spec_file(context, request, true);
         }

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -128,6 +128,9 @@ fn main() {
         definition_provider: Some(OneOf::Left(true)),
         references_provider: Some(OneOf::Left(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
+        document_formatting_provider: None, // 没有提供格式化功能
+        document_range_formatting_provider: None,
+        document_on_type_formatting_provider: None,
         ..Default::default()
     })
     .expect("could not serialize server capabilities");
@@ -191,9 +194,9 @@ fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut Analy
         lsp_types::request::DocumentSymbolRequest::METHOD => {
             symbols::on_document_symbol_request(context, request);
         }
-        lsp_types::request::Formatting::METHOD => {
-            // on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
-        }
+        // lsp_types::request::Formatting::METHOD => {
+        //     // on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
+        // }
         "move/generate/spec/file" => {
             on_generate_spec_file(context, request, true);
         }

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -193,6 +193,9 @@ fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut Analy
             symbols::on_document_symbol_request(context, request);
         }
         lsp_types::request::Formatting::METHOD => {
+            // This handler needs to be kept to handle a bug
+            // where the client keeps waiting for the analyzer to return formatting results
+            // when 'format on save' is enabled in VSCode settings
             on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
         }
         "move/generate/spec/file" => {

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -536,16 +536,22 @@ fn on_notification(context: &mut Context, notification: &Notification) {
                     return;
                 }
             };
+
+            log::info!("did save text document: {}", content);
+
             clear_ui_diag(context, fpath.clone());
             update_defs_on_changed(context, fpath.clone(), content.clone());
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
+            log::info!("did change text doc");
             use lsp_types::DidChangeTextDocumentParams;
             let parameters =
                 serde_json::from_value::<DidChangeTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize DidChangeTextDocumentParams request");
             let fpath = parameters.text_document.uri.to_file_path().unwrap();
             let fpath = path_concat(&std::env::current_dir().unwrap(), &fpath);
+            
+            log::info!("did change text document: {}", parameters.content_changes.last().unwrap().text.clone());
             clear_ui_diag(context, fpath.clone());
             update_defs_on_changed(
                 context,

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -89,7 +89,6 @@ fn main() {
         projects: MultiProject::new(),
         connection,
         diag_version: FileDiags::new(),
-        debounce: Debounce::new(1000),
     };
 
     let (id, _client_response) = context
@@ -470,10 +469,7 @@ fn report_diag(context: &mut Context, fpath: PathBuf) {
             ..Default::default()
         };
         let url = url::Url::from_file_path(PathBuf::from(file_path).as_path()).unwrap();
-        result.entry(url)
-            .or_insert(Vec::new())
-            .push(d);
-        
+        result.entry(url).or_insert(Vec::new()).push(d);
     }
     for (k, v) in result.clone().into_iter() {
         let ds = lsp_types::PublishDiagnosticsParams::new(k.clone(), v, None);
@@ -546,13 +542,14 @@ fn on_notification(context: &mut Context, notification: &Notification) {
 
             let mut movefmt_cfg = commentfmt::Config::default();
             let content = if let Ok(content_format) =
-            movefmt::core::fmt::format_entry(content.clone(), movefmt_cfg) {
+                movefmt::core::fmt::format_entry(content.clone(), movefmt_cfg)
+            {
                 std::fs::write(fpath.as_path(), content_format.clone());
                 content_format
             } else {
                 content
             };
-            
+
             clear_ui_diag(context, fpath.clone());
             update_defs_on_changed(context, fpath.clone(), content.clone());
         }
@@ -564,8 +561,11 @@ fn on_notification(context: &mut Context, notification: &Notification) {
                     .expect("could not deserialize DidChangeTextDocumentParams request");
             let fpath = parameters.text_document.uri.to_file_path().unwrap();
             let fpath = path_concat(&std::env::current_dir().unwrap(), &fpath);
-            
-            log::info!("did change text document: {}", parameters.content_changes.last().unwrap().text.clone());
+
+            log::info!(
+                "did change text document: {}",
+                parameters.content_changes.last().unwrap().text.clone()
+            );
             clear_ui_diag(context, fpath.clone());
             update_defs_on_changed(
                 context,

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -191,9 +191,9 @@ fn on_request(context: &mut Context, request: &Request, analyzer_cfg: &mut Analy
         lsp_types::request::DocumentSymbolRequest::METHOD => {
             symbols::on_document_symbol_request(context, request);
         }
-        lsp_types::request::Formatting::METHOD => {
-            on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
-        }
+        // lsp_types::request::Formatting::METHOD => {
+        //     on_movefmt_request(context, request, &analyzer_cfg.movefmt_config);
+        // }
         "move/generate/spec/file" => {
             on_generate_spec_file(context, request, true);
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,6 @@ pub struct Context {
     pub connection: Connection,
     pub projects: MultiProject,
     pub diag_version: FileDiags,
-    pub debounce: Debounce,
 }
 #[derive(Default)]
 pub struct Debounce {

--- a/src/goto_definition.rs
+++ b/src/goto_definition.rs
@@ -250,7 +250,7 @@ impl Handler {
         let mut res_capture_items_span = vec![];
         let mut res_result_candidates = vec![];
         let mut indexes_to_retain = vec![];
-        log::info!(
+        log::trace!(
             "start remove repeat candidate, before count: {}",
             self.capture_items_span.len()
         );
@@ -271,7 +271,7 @@ impl Handler {
                 }
             }
         }
-        log::info!("after count: {}", indexes_to_retain.len());
+        log::trace!("after count: {}", indexes_to_retain.len());
         for (index, span) in self.capture_items_span.iter().enumerate() {
             if indexes_to_retain.contains(&index) {
                 res_capture_items_span.push(*span);
@@ -342,14 +342,14 @@ impl Handler {
         if found_target_stct_or_fn {
             log::info!("finding use decl module member...");
             for stct in use_decl_module.get_structs() {
-                log::info!(
+                log::trace!(
                     "per_struct_name = {:?}, target_struct: {}",
                     stct.get_full_name_str(),
                     target_stct_or_fn
                 );
                 if stct.get_full_name_str().contains(&target_stct_or_fn) {
                     log::info!("stct.get_full_name_str() = {:?}", stct.get_full_name_str());
-                    log::info!(
+                    log::trace!(
                         "insert_result<use_decl> = {:?}",
                         env.get_source(&capture_items_loc)
                     );
@@ -365,7 +365,7 @@ impl Handler {
                 );
                 if func.get_name_str().contains(&target_stct_or_fn) {
                     log::info!("func.get_name_str() = {:?}", func.get_name_str());
-                    log::info!(
+                    log::trace!(
                         "insert_result<use_decl> = {:?}",
                         env.get_source(&capture_items_loc)
                     );
@@ -426,7 +426,7 @@ impl Handler {
                     continue;
                 }
                 let capture_ty_src = env.get_source(&capture_ty_loc);
-                log::info!(
+                log::trace!(
                     "process_parameter -- capture_ty_src 11 = {:?}",
                     capture_ty_src
                 );
@@ -494,7 +494,7 @@ impl Handler {
                         continue;
                     }
                     let capture_ty_src = env.get_source(&capture_ty_loc);
-                    log::info!(
+                    log::trace!(
                         "process_parameter -- capture_ty_src 22 = {:?}",
                         capture_ty_src
                     );
@@ -566,7 +566,7 @@ impl Handler {
                     }
                 }
             }
-            log::info!(
+            log::trace!(
                 "capture_ty_start_pos= {:?}, capture_ty_end_pos = {:?}",
                 capture_ty_start_pos,
                 capture_ty_end_pos
@@ -581,7 +581,7 @@ impl Handler {
             );
 
             if self.check_move_model_loc_contains_mouse_pos(env, &capture_ty_loc) {
-                log::info!(
+                log::trace!(
                     "process_return_type -- capture_ty_src = {:?}",
                     env.get_source(&capture_ty_loc)
                 );
@@ -597,7 +597,7 @@ impl Handler {
                     {
                         if self.check_move_model_loc_contains_mouse_pos(env, &specifier.resource.0)
                         {
-                            log::info!(
+                            log::trace!(
                                 "process_specifier -- specifier.resource = {:?}",
                                 env.get_source(&specifier.resource.0)
                             );
@@ -610,11 +610,11 @@ impl Handler {
             }
 
             if let Some(requires) = require_vec {
-                log::info!("requires = {:?}", requires);
+                log::trace!("requires = {:?}", requires);
                 for strct_id in requires {
                     let strct_env = target_fun.module_env.get_struct(strct_id);
                     let strct_str = strct_env.get_name().display(env.symbol_pool()).to_string();
-                    log::info!("process_type -->> strct_str = {:?}", strct_str);
+                    log::trace!("process_type -->> strct_str = {:?}", strct_str);
                     let capture_ty_src = if let Ok(cap_str) = env.get_source(&capture_ty_loc) {
                         cap_str
                     } else {
@@ -677,7 +677,7 @@ impl Handler {
 
         let target_fn = target_module.get_function(target_fun_id);
         let target_fn_spec = target_fn.get_spec();
-        log::info!("target_fun's spec = {}", env.display(&*target_fn_spec));
+        log::trace!("target_fun's spec = {}", env.display(&*target_fn_spec));
         self.get_mouse_loc(env, &spec_fn_span_loc);
         for cond in target_fn_spec.conditions.clone() {
             for exp in cond.all_exps() {
@@ -687,7 +687,7 @@ impl Handler {
     }
 
     fn process_struct(&mut self, env: &GlobalEnv) -> Option<()> {
-        log::info!(">> process_struct for goto definition");
+        log::info!("process_struct for goto definition");
 
         let target_module = env.get_module(self.target_module_id);
         let target_struct = target_module
@@ -711,7 +711,7 @@ impl Handler {
                 capture_field_start + codespan::ByteOffset(offset_epos as i64),
             ),
         );
-        log::info!(
+        log::trace!(
             "atomic_field_source = {:?}",
             env.get_source(&atomic_field_loc)
         );
@@ -725,7 +725,7 @@ impl Handler {
                     && atomic_field_loc.span().end() <= variant_loc.span().end()
                 {
                     let variant_str = env.get_source(&variant_loc);
-                    log::info!("variant_str = {:?}", variant_str);
+                    log::trace!("variant_str = {:?}", variant_str);
                     for field_env in target_struct.get_fields_of_variant(enum_field) {
                         field_env_vec.push(field_env);
                     }
@@ -750,7 +750,7 @@ impl Handler {
                 }
             }
         }
-        log::info!("<< process_struct for goto definition");
+        log::trace!("<< process_struct for goto definition");
         Some(())
     }
 
@@ -799,7 +799,7 @@ impl Handler {
 
         let target_stct = target_module.get_struct(target_stct_id);
         let target_stct_spec = target_stct.get_spec();
-        log::info!("target_stct's spec = {}", env.display(&*target_stct_spec));
+        log::trace!("target_stct's spec = {}", env.display(&*target_stct_spec));
         self.get_mouse_loc(env, &spec_stct_span_loc);
         for cond in target_stct_spec.conditions.clone() {
             for exp in cond.all_exps() {
@@ -845,7 +845,7 @@ impl Handler {
                     {
                         return true;
                     }
-                    log::info!(
+                    log::trace!(
                         "target: exp.visit localvar_symbol = {}",
                         localvar_symbol.display(env.symbol_pool())
                     );
@@ -991,7 +991,7 @@ impl Handler {
     fn process_call(&mut self, env: &GlobalEnv, expdata: &move_model::ast::ExpData) {
         if let Call(node_id, MoveFunction(mid, fid), _) = expdata {
             let this_call_loc = env.get_node_loc(*node_id);
-            log::info!(
+            log::trace!(
                 "<MoveFunction> exp.visit this_call_loc = {:?}",
                 env.get_location(&this_call_loc)
             );
@@ -1047,7 +1047,7 @@ impl Handler {
 
         if let Call(node_id, Pack(mid, sid, _), _) = expdata {
             let this_call_loc = env.get_node_loc(*node_id);
-            log::info!(
+            log::trace!(
                 "<Pack> exp.visit this_call_loc = {:?}",
                 env.get_location(&this_call_loc)
             );
@@ -1091,15 +1091,15 @@ impl Handler {
                 return;
             }
             let this_call_loc = env.get_node_loc(*node_id);
-            log::info!(
+            log::trace!(
                 "<builtin> exp.visit this_call_loc = {:?}",
                 env.get_location(&this_call_loc)
             );
-            log::info!(
+            log::trace!(
                 "<builtin> exp.visit this_call = {:?}",
                 env.get_source(&this_call_loc)
             );
-            log::info!("<builtin> exp.visit expdata = {:?}", expdata);
+            log::trace!("<builtin> exp.visit expdata = {:?}", expdata);
             if this_call_loc.span().start() < self.mouse_span.end()
                 && self.mouse_span.end() < this_call_loc.span().end()
             {
@@ -1156,7 +1156,7 @@ impl Handler {
 
                 let pattern_module = env.get_module(q_id.module_id);
                 let pattern_struct = pattern_module.get_struct(q_id.id);
-                log::info!("pattern_struct = {:?}", pattern_struct.get_full_name_str());
+                log::trace!("pattern_struct = {:?}", pattern_struct.get_full_name_str());
                 let pattern_struct_loc = pattern_struct.get_loc();
                 self.insert_result(env, &pattern_struct_loc, &this_call_loc);
             }
@@ -1229,7 +1229,7 @@ impl Handler {
                         }
                         let generic_struct_ty_str =
                             generic_ty.get_name().display(env.symbol_pool()).to_string();
-                        log::info!("generic_struct_ty_str = {:?}", generic_struct_ty_str);
+                        log::trace!("generic_struct_ty_str = {:?}", generic_struct_ty_str);
                         if let Some(index) = capture_ty_src.find(generic_struct_ty_str.as_str()) {
                             let capture_generic_ty_str_len = generic_struct_ty_str.len();
                             let capture_generic_ty_start = (*capture_items_loc).span().start()
@@ -1245,7 +1245,7 @@ impl Handler {
                                     capture_generic_ty_end,
                                 ),
                             );
-                            log::info!(
+                            log::trace!(
                                 "capture_generic_ty_str = {:?}",
                                 env.get_source(&capture_generic_ty_loc)
                             );
@@ -1274,7 +1274,7 @@ impl Handler {
                     .get_name()
                     .display(env.symbol_pool())
                     .to_string();
-                log::info!("process_type -->> struct_ty_str = {:?}", struct_ty_str);
+                log::trace!("process_type -->> struct_ty_str = {:?}", struct_ty_str);
                 if capture_ty_src.contains(&struct_ty_str) {
                     self.insert_result(env, &type_struct.get_loc(), capture_items_loc);
                     return true;

--- a/src/movefmt.rs
+++ b/src/movefmt.rs
@@ -47,9 +47,7 @@ pub fn on_movefmt_request(
     let parameters = serde_json::from_value::<DocumentFormattingParams>(request.params.clone())
         .expect("could not deserialize Reference request");
     let fpath = parameters.text_document.uri.to_file_path().unwrap();
-    eprintln!("fpath1 = {:?}", fpath);
-    // let fpath = path_concat(std::env::current_dir().unwrap().as_path(), fpath.as_path());
-    // eprintln!("fpath2 = {:?}", fpath);
+
     let project = match context.projects.get_project(&fpath) {
         Some(x) => x,
         None => {
@@ -61,7 +59,7 @@ pub fn on_movefmt_request(
             };
         }
     };
-    eprintln!(
+    log::info!(
         "current_modifing_filepath = {:?}",
         project.current_modifing_filepath
     );
@@ -76,10 +74,13 @@ pub fn on_movefmt_request(
     movefmt_cfg.set().max_width(fmt_cfg.max_width as usize);
     movefmt_cfg.set().indent_size(fmt_cfg.indent_size as usize);
     let content_format =
-        movefmt::core::fmt::format_entry(content_origin.clone(), movefmt_cfg).unwrap();
+        movefmt::core::fmt::format_entry(content_origin.clone(), movefmt_cfg);
+    
+    if content_format.is_err() {
+        return Response::new_err(request.id.clone(), -1, "format failed".to_string());
+    }
 
-    eprintln!("content_format = {}", content_format);
-
+    let content_format = content_format.unwrap();
     let result_line =
         if content_format.clone().lines().count() >= content_origin.clone().lines().count() {
             content_format.clone().lines().count()

--- a/src/movefmt.rs
+++ b/src/movefmt.rs
@@ -30,115 +30,9 @@ pub fn on_movefmt_request(
     request: &Request,
     fmt_cfg: &FmtConfig,
 ) -> lsp_server::Response {
-    log::info!(
-        "on_movefmt_request request = {:?}, fmt_cfg = {:?}",
-        request,
-        fmt_cfg
-    );
-    if !fmt_cfg.enable {
-        log::info!("movefmt disenabled.");
-        return Response {
-            id: "".to_string().into(),
-            result: Some(serde_json::json!({"msg": "movefmt disenabled."})),
-            error: None,
-        };
-    }
-
-    let parameters = serde_json::from_value::<DocumentFormattingParams>(request.params.clone())
-        .expect("could not deserialize Reference request");
-    let fpath = parameters.text_document.uri.to_file_path().unwrap();
-
-    let project = match context.projects.get_project(&fpath) {
-        Some(x) => x,
-        None => {
-            log::error!("project not found:{:?}", fpath.as_path());
-            return Response {
-                id: "".to_string().into(),
-                result: Some(serde_json::json!({"msg": "No available project"})),
-                error: None,
-            };
-        }
-    };
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
-
-    // let content_origin = if project.current_modifing_filepath == fpath {
-    //     project.current_modifing_file_content.clone()
-    // } else {
-    //    std::fs::read_to_string(&fpath).unwrap()
-    // };
-    let content_origin = std::fs::read_to_string(&fpath).unwrap();
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
-    let mut movefmt_cfg = commentfmt::Config::default();
-    movefmt_cfg.set().max_width(fmt_cfg.max_width as usize);
-    movefmt_cfg.set().indent_size(fmt_cfg.indent_size as usize);
-    let content_format =
-        movefmt::core::fmt::format_entry(content_origin.clone(), movefmt_cfg);
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
-    if content_format.is_err() {
-        let r = Response::new_err(request.id.clone(), -1, "format failed".to_string());
-        context
-            .connection
-            .sender
-            .send(Message::Response(r.clone()))
-            .unwrap();
-        return r;
-    }
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
-    let content_format = content_format.unwrap();
-    log::info!("format result: {}", content_format);
-
-    let mut text_edits = vec![];
-
-
-    let before_line = content_origin.clone().lines().count();
-    let after_line = content_format.clone().lines().count();
-
-    text_edits.push(TextEdit {
-        range: lsp_types::Range {
-            start: Position {
-                line: 0,
-                character: 0,
-            },
-            end: Position {
-                line: after_line as u32,
-                character: 0,
-            },
-        },
-        new_text: content_format.clone(),
-    });
-
-    if before_line > after_line {
-        text_edits.push(TextEdit {
-            range: lsp_types::Range {
-                start: Position {
-                    line: (after_line + 1) as u32,
-                    character: 0,
-                },
-                end: Position {
-                    line: before_line as u32,
-                    character: 0,
-                },
-            },
-            new_text: "".to_string(),
-        });
-    }
-   
-
     let r: Response = Response::new_ok(
         request.id.clone(),
-         serde_json::to_value(Some(text_edits)).unwrap()
+        serde_json::to_value(Some(Vec::<TextEdit>::new())).unwrap(),
     );
 
     context
@@ -147,4 +41,120 @@ pub fn on_movefmt_request(
         .send(Message::Response(r.clone()))
         .unwrap();
     r
+
+    // log::info!(
+    //     "on_movefmt_request request = {:?}, fmt_cfg = {:?}",
+    //     request,
+    //     fmt_cfg
+    // );
+    // if !fmt_cfg.enable {
+    //     log::info!("movefmt disenabled.");
+    //     return Response {
+    //         id: "".to_string().into(),
+    //         result: Some(serde_json::json!({"msg": "movefmt disenabled."})),
+    //         error: None,
+    //     };
+    // }
+
+    // let parameters = serde_json::from_value::<DocumentFormattingParams>(request.params.clone())
+    //     .expect("could not deserialize Reference request");
+    // let fpath = parameters.text_document.uri.to_file_path().unwrap();
+
+    // let project = match context.projects.get_project(&fpath) {
+    //     Some(x) => x,
+    //     None => {
+    //         log::error!("project not found:{:?}", fpath.as_path());
+    //         return Response {
+    //             id: "".to_string().into(),
+    //             result: Some(serde_json::json!({"msg": "No available project"})),
+    //             error: None,
+    //         };
+    //     }
+    // };
+    // log::info!(
+    //     "current_modifing_filepath = {:?}",
+    //     project.current_modifing_filepath
+    // );
+
+    // // let content_origin = if project.current_modifing_filepath == fpath {
+    // //     project.current_modifing_file_content.clone()
+    // // } else {
+    // //    std::fs::read_to_string(&fpath).unwrap()
+    // // };
+    // let content_origin = std::fs::read_to_string(&fpath).unwrap();
+    // log::info!(
+    //     "current_modifing_filepath = {:?}",
+    //     project.current_modifing_filepath
+    // );
+    // let mut movefmt_cfg = commentfmt::Config::default();
+    // movefmt_cfg.set().max_width(fmt_cfg.max_width as usize);
+    // movefmt_cfg.set().indent_size(fmt_cfg.indent_size as usize);
+    // let content_format =
+    //     movefmt::core::fmt::format_entry(content_origin.clone(), movefmt_cfg);
+    // log::info!(
+    //     "current_modifing_filepath = {:?}",
+    //     project.current_modifing_filepath
+    // );
+    // if content_format.is_err() {
+    //     let r = Response::new_err(request.id.clone(), -1, "format failed".to_string());
+    //     context
+    //         .connection
+    //         .sender
+    //         .send(Message::Response(r.clone()))
+    //         .unwrap();
+    //     return r;
+    // }
+    // log::info!(
+    //     "current_modifing_filepath = {:?}",
+    //     project.current_modifing_filepath
+    // );
+    // let content_format = content_format.unwrap();
+    // log::info!("format result: {}", content_format);
+
+    // let mut text_edits = vec![];
+
+    // let before_line = content_origin.clone().lines().count();
+    // let after_line = content_format.clone().lines().count();
+
+    // text_edits.push(TextEdit {
+    //     range: lsp_types::Range {
+    //         start: Position {
+    //             line: 0,
+    //             character: 0,
+    //         },
+    //         end: Position {
+    //             line: after_line as u32,
+    //             character: 0,
+    //         },
+    //     },
+    //     new_text: content_format.clone(),
+    // });
+
+    // if before_line > after_line {
+    //     text_edits.push(TextEdit {
+    //         range: lsp_types::Range {
+    //             start: Position {
+    //                 line: (after_line + 1) as u32,
+    //                 character: 0,
+    //             },
+    //             end: Position {
+    //                 line: before_line as u32,
+    //                 character: 0,
+    //             },
+    //         },
+    //         new_text: "".to_string(),
+    //     });
+    // }
+
+    // let r: Response = Response::new_ok(
+    //     request.id.clone(),
+    //      serde_json::to_value(Some(text_edits)).unwrap()
+    // );
+
+    // context
+    //     .connection
+    //     .sender
+    //     .send(Message::Response(r.clone()))
+    //     .unwrap();
+    // r
 }

--- a/src/movefmt.rs
+++ b/src/movefmt.rs
@@ -64,44 +64,94 @@ pub fn on_movefmt_request(
         project.current_modifing_filepath
     );
 
-    let content_origin = if project.current_modifing_filepath == fpath {
-        project.current_modifing_file_content.clone()
-    } else {
-        std::fs::read_to_string(&fpath).unwrap()
-    };
-    // let content_origin = std::fs::read_to_string(&fpath).unwrap();
+    // let content_origin = if project.current_modifing_filepath == fpath {
+    //     project.current_modifing_file_content.clone()
+    // } else {
+    //    std::fs::read_to_string(&fpath).unwrap()
+    // };
+    let content_origin = std::fs::read_to_string(&fpath).unwrap();
+    log::info!(
+        "current_modifing_filepath = {:?}",
+        project.current_modifing_filepath
+    );
     let mut movefmt_cfg = commentfmt::Config::default();
+    log::info!(
+        "current_modifing_filepath = {:?}",
+        project.current_modifing_filepath
+    );
     movefmt_cfg.set().max_width(fmt_cfg.max_width as usize);
+    log::info!(
+        "current_modifing_filepath = {:?}",
+        project.current_modifing_filepath
+    );
     movefmt_cfg.set().indent_size(fmt_cfg.indent_size as usize);
+    log::info!(
+        "current_modifing_filepath = {:?}",
+        project.current_modifing_filepath
+    );
     let content_format =
         movefmt::core::fmt::format_entry(content_origin.clone(), movefmt_cfg);
-    
+    log::info!(
+        "current_modifing_filepath = {:?}",
+        project.current_modifing_filepath
+    );
     if content_format.is_err() {
-        return Response::new_err(request.id.clone(), -1, "format failed".to_string());
+        let r = Response::new_err(request.id.clone(), -1, "format failed".to_string());
+        context
+            .connection
+            .sender
+            .send(Message::Response(r.clone()))
+            .unwrap();
+        return r;
     }
-
+    log::info!(
+        "current_modifing_filepath = {:?}",
+        project.current_modifing_filepath
+    );
     let content_format = content_format.unwrap();
-    let result_line =
-        if content_format.clone().lines().count() >= content_origin.clone().lines().count() {
-            content_format.clone().lines().count()
-        } else {
-            content_origin.clone().lines().count()
-        };
+    log::info!("format result: {}", content_format);
 
-    let result = Some(vec![TextEdit {
+    let mut text_edits = vec![];
+
+
+    let before_line = content_origin.clone().lines().count();
+    let after_line = content_format.clone().lines().count();
+
+    text_edits.push(TextEdit {
         range: lsp_types::Range {
             start: Position {
                 line: 0,
                 character: 0,
             },
             end: Position {
-                line: result_line as u32,
+                line: after_line as u32,
                 character: 0,
             },
         },
         new_text: content_format.clone(),
-    }]);
-    let r: Response = Response::new_ok(request.id.clone(), serde_json::to_value(result).unwrap());
+    });
+
+    if before_line > after_line {
+        text_edits.push(TextEdit {
+            range: lsp_types::Range {
+                start: Position {
+                    line: (after_line + 1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: before_line as u32,
+                    character: 0,
+                },
+            },
+            new_text: "".to_string(),
+        });
+    }
+   
+
+    let r: Response = Response::new_ok(
+        request.id.clone(),
+         serde_json::to_value(Some(text_edits)).unwrap()
+    );
 
     context
         .connection

--- a/src/movefmt.rs
+++ b/src/movefmt.rs
@@ -75,20 +75,8 @@ pub fn on_movefmt_request(
         project.current_modifing_filepath
     );
     let mut movefmt_cfg = commentfmt::Config::default();
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
     movefmt_cfg.set().max_width(fmt_cfg.max_width as usize);
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
     movefmt_cfg.set().indent_size(fmt_cfg.indent_size as usize);
-    log::info!(
-        "current_modifing_filepath = {:?}",
-        project.current_modifing_filepath
-    );
     let content_format =
         movefmt::core::fmt::format_entry(content_origin.clone(), movefmt_cfg);
     log::info!(

--- a/src/project_manager.rs
+++ b/src/project_manager.rs
@@ -173,7 +173,7 @@ impl Project {
             .report_diag(&mut error_writer, Severity::Error);
         new_project.err_diags = String::from_utf8_lossy(&error_writer.into_inner()).to_string();
         if new_project.err_diags.len() > 0 {
-            log::error!(
+            log::trace!(
                 "\n*******************************************\nerr_diags = \n{}",
                 new_project.err_diags
             );

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -79,7 +79,7 @@ pub fn on_document_symbol_request(context: &Context, request: &Request) -> lsp_s
         Some(x) => x,
         None => {
             log::error!(
-                "coule not found valid project from file path, fpath = {:?}",
+                "coule not found valid project from file path for symbol in outline, fpath = {:?}",
                 fpath.as_path()
             );
             return lsp_server::Response {


### PR DESCRIPTION
This PR includes the following features and improvements:  

1. **Autocomplete**: Added support for autocompleting functions and other elements from `std` and `aptos-framework`. [#25]  
2. **Formatting**: Fixed issues where the `fmt` functionality caused save delays, leading to saving an outdated version of the file. Also resolved an issue where asynchronous formatting introduced extra characters. [#28]  
3. **Diagnostics**: Problems panel now correctly displays all diagnostic messages instead of only one. [#27]  
4. **Performance Optimization**: Significantly improved the plugin's response speed for save, formatting, and autocomplete operations. [#26]  
5. **Plugin Configuration Changes**:  
   - Decoupled built-in formatting from the LSP protocol. The current formatting functionality now depends on the `"aptos-move-analyzer.movefmt.enable"` option instead of the `format on save` setting. [#23]  
   - `LspPath` now takes effect correctly, ensuring that VSCode runs the specified executable in the designated directory. [#24]