### PR TITLE
Optimize speed and try to avoid to truncate source code (#36)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "aptos-move-analyzer"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bisection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos-move-analyzer"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["BitsLab/MoveBit"]
 description = "A language server for Move"
 repository = "https://github.com/movebit/move"

--- a/editors/CHANGELOG.md
+++ b/editors/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelogs:
 
+## 2025/4/30 v1.0.5
+- add warning between `aptos-moveanalyzer::format enable` and `vscode::format on save`.[(#issue33)](https://github.com/movebit/aptos-move-analyzer/issues/35)
+- try avoiding to truncating source code.[(#issue33)](https://github.com/movebit/aptos-move-analyzer/issues/32)
+- optimize speed on InlayHInts.  [(#issue32)](https://github.com/movebit/aptos-move-analyzer/issues/32)
+- optimize speed on foramt. [(#issue31)](https://github.com/movebit/aptos-move-analyzer/issues/31)
+
+
+
 ## 2024/7/8 v1.0.0
 - supported `receiver style call`
 - `find reference` supported generic types in function header

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -5,7 +5,7 @@
 	"publisher": "MoveBit",
 	"icon": "images/move.png",
 	"license": "Apache-2.0",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"preview": false,
 	"homepage": "https://github.com/movebit/aptos-move-analyzer",
 	"repository": {

--- a/editors/code/src/configuration.ts
+++ b/editors/code/src/configuration.ts
@@ -41,7 +41,7 @@ function isValidUrl(url: string): boolean {
  * extension's `package.json`, under the key `"contributes.configuration.properties"`.
  */
 class Configuration {
-    private readonly configuration: vscode.WorkspaceConfiguration;
+    public readonly configuration: vscode.WorkspaceConfiguration;
 
     constructor() {
         this.configuration = vscode.workspace.getConfiguration('aptos-move-analyzer');

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -11,9 +11,9 @@ import { sync as commandExistsSync } from 'command-exists';
 import { IndentAction } from 'vscode';
 // import { info } from 'console';
 
-// function sleep(ms: number): Promise<void> {
-//     return new Promise(resolve => setTimeout(resolve, ms));
-// }
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 /** Information passed along to each VS Code command defined by this extension. */
 export class Context {
@@ -21,6 +21,9 @@ export class Context {
     private lastChangeTime: number;
     private client: lc.LanguageClient | undefined;
     private didchange: boolean;
+
+    private didInlayHintsTimer: NodeJS.Timeout | null;
+    private lastInlayHintsTime: number;
     private constructor(
         private readonly extensionContext: Readonly<vscode.ExtensionContext>,
         readonly configuration: Readonly<Configuration>,
@@ -29,6 +32,8 @@ export class Context {
         this.client = client;
         this.didChangeTimer = null;
         this.lastChangeTime = 0;
+        this.didInlayHintsTimer = null;
+        this.lastInlayHintsTime = 0;
         this.didchange = false;
     }
 
@@ -183,6 +188,34 @@ export class Context {
             return next(data);
         };
 
+        // This middleware is designed to debounce frontend requests for InlayHints 
+        // in order to improve the efficiency of the extension. Currently, InlayHints 
+        // may suffer from low performance, which can lead to truncation of the source code.
+        client.middleware.provideInlayHints = (
+            document: vscode.TextDocument, 
+            viewPort: vscode.Range, 
+            token: vscode.CancellationToken, 
+            next: lc.ProvideInlayHintsSignature
+        ) => {
+            const currentTime = Date.now();
+            if (currentTime - this.lastInlayHintsTime < 300) {
+                this.lastChangeTime = currentTime;
+                if (this.didInlayHintsTimer) {
+                    clearTimeout(this.didInlayHintsTimer);  // clear the previous timer
+                    this.didInlayHintsTimer = null;
+                }
+                this.didInlayHintsTimer = setTimeout(() => {
+                    next(document, viewPort, token);
+                    this.didchange = true;
+                    this.didChangeTimer = null;  
+                }, 300);
+                return next(document, viewPort, token);
+            }
+            // sleep(2000);
+            this.lastChangeTime = currentTime;
+            return next(document, viewPort, token);
+        }
+
         log.info('Starting client...');
         client.start();
         this.client = client;
@@ -201,7 +234,3 @@ export class Context {
         return this.client;
     }
 } // Context
-
-function sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -24,6 +24,7 @@ export type LspStatus =
 let currentStatus: LspStatus = "stopped";
 // let extensionStatus: vscode.StatusBarItem;
 let analyzerLspPath: string | undefined;
+let currentConfig = new Configuration();
 
 export async function activate(
   extensionContext: Readonly<vscode.ExtensionContext>,
@@ -72,6 +73,17 @@ export async function activate(
     const client = context.getClient();
     if (client !== undefined) {
       const new_configuration = new Configuration();
+      
+      // false -> true
+      if (!currentConfig.configuration.get<boolean>('movefmt.enable') 
+        && new_configuration.configuration.get<boolean>('movefmt.enable')
+        && vscode.workspace.getConfiguration('editor').get<boolean>('formatOnSave')
+      ) {
+        vscode.window.showWarningMessage("movefmt::enable is different from format-on-save. \
+          It might be necessary to disable the format-on-save.");
+      }
+      currentConfig = new_configuration;
+
       log.info(`new_configuration: ${new_configuration.toString()}`);
       void client.sendRequest('move/lsp/client/inlay_hints/config', new_configuration.inlay_hints_config());
       void client.sendRequest('move/lsp/movefmt/config', new_configuration.movefmt_config());
@@ -80,6 +92,9 @@ export async function activate(
   reload_cfg();
   vscode.workspace.onDidChangeConfiguration(() => {
     log.info('reload_cfg ...  ');
+
+
+
     reload_cfg();
   });
 }

--- a/editors/package-lock.json
+++ b/editors/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "editors",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/bin/aptos-move-analyzer.rs
+++ b/src/bin/aptos-move-analyzer.rs
@@ -3,7 +3,7 @@
 
 use aptos_move_analyzer::{
     completion,
-    context::{Context, Debounce, FileDiags},
+    context::{Context, FileDiags},
     goto_definition, hover,
     inlay_hints::{self, *},
     move_generate_spec_file::on_generate_spec_file,
@@ -20,14 +20,12 @@ use log::{Level, Metadata, Record};
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::{
     notification::Notification as _, request::Request as _, CompletionOptions,
-    DidSaveTextDocumentParams, HoverProviderCapability, OneOf, SaveOptions,
+    HoverProviderCapability, OneOf, SaveOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     WorkDoneProgressOptions,
 };
 use move_command_line_common::files::FileHash;
-use move_compiler::diag;
-use move_core_types::effects::Op;
-use std::{collections::HashMap, path::PathBuf, time::Duration};
+use std::{collections::HashMap, path::PathBuf};
 use url::Url;
 
 struct AnalyzerConfig {
@@ -136,7 +134,7 @@ fn main() {
         ..Default::default()
     })
     .expect("could not serialize server capabilities");
-
+    
     context
         .connection
         .initialize_finish(
@@ -664,6 +662,9 @@ fn format_on_did_save(
     movefmt_cfg
         .set()
         .indent_size(analyzer_cfg.movefmt_config.indent_size as usize);
+    movefmt_cfg
+        .set()
+        .emit_mode(commentfmt::EmitMode::Overwrite);
 
     match movefmt::core::fmt::format_entry(file_content.clone(), movefmt_cfg) {
         Ok(result) => {

--- a/src/movefmt.rs
+++ b/src/movefmt.rs
@@ -28,7 +28,7 @@ impl Default for FmtConfig {
 pub fn on_movefmt_request(
     context: &Context,
     request: &Request,
-    fmt_cfg: &FmtConfig,
+    _fmt_cfg: &FmtConfig,
 ) -> lsp_server::Response {
     let r: Response = Response::new_ok(
         request.id.clone(),

--- a/tests/aptos-aave-v3/aave-core/.gitignore
+++ b/tests/aptos-aave-v3/aave-core/.gitignore
@@ -1,0 +1,2 @@
+chainlink-data-feeds/*
+chainlink-platform/*

--- a/tests/aptos-aave-v3/aave-core/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/Move.toml
@@ -1,0 +1,20 @@
+[package]
+name = "AavePool"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_pool = '_'
+
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AaveAcl = { local = "./aave-acl" }
+AaveConfig = { local = "./aave-config" }
+AaveMath = { local = "./aave-math" }
+AaveOracle = { local = "aave-oracle" }
+AaveRate = { local = "./aave-rate" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-acl/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-acl/Move.toml
@@ -1,0 +1,16 @@
+[package]
+name = "AaveAcl"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_acl = '_'
+
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AaveConfig = { local = "../aave-config" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-acl/doc/acl_manage.md
+++ b/tests/aptos-aave-v3/aave-core/aave-acl/doc/acl_manage.md
@@ -1,0 +1,889 @@
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage"></a>
+
+# Module `0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9::acl_manage`
+
+@title ACLManager
+@author Aave
+@notice Access Control List Manager. Main registry of system roles and permissions.
+
+Roles are referred to by their <code><a href="">vector</a>&lt;u8&gt;</code> identifier. These should be exposed
+in the external API and be unique. The best way to achieve this is by
+using <code><b>const</b></code> hash digests:
+```
+const MY_ROLE = b"MY_ROLE";
+```
+Roles can be used to represent a set of permissions. To restrict access to a
+function call, use {has_role}:
+```
+public fun foo() {
+assert!(has_role(MY_ROLE, error_code::ENOT_MANAGEMENT));
+...
+}
+```
+Roles can be granted and revoked dynamically via the {grant_role} and
+{revoke_role} functions. Each role has an associated admin role, and only
+accounts that have a role's admin role can call {grant_role} and {revoke_role}.
+
+By default, the admin role for all roles is <code><a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_DEFAULT_ADMIN_ROLE">DEFAULT_ADMIN_ROLE</a></code>, which means
+that only accounts with this role will be able to grant or revoke other
+roles. More complex role relationships can be created by using
+{set_role_admin}.
+
+WARNING: The <code><a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_DEFAULT_ADMIN_ROLE">DEFAULT_ADMIN_ROLE</a></code> is also its own admin: it has permission to
+grant and revoke this role. Extra precautions should be taken to secure
+accounts that have been granted it.
+
+
+-  [Struct `RoleAdminChanged`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleAdminChanged)
+-  [Struct `RoleGranted`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleGranted)
+-  [Struct `RoleRevoked`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleRevoked)
+-  [Struct `RoleData`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleData)
+-  [Resource `Roles`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_Roles)
+-  [Constants](#@Constants_0)
+-  [Function `grant_default_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_grant_default_admin_role)
+-  [Function `default_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_default_admin_role)
+-  [Function `get_role_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_role_admin)
+-  [Function `set_role_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_set_role_admin)
+-  [Function `has_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_has_role)
+-  [Function `grant_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_grant_role)
+-  [Function `renounce_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_renounce_role)
+-  [Function `revoke_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_revoke_role)
+-  [Function `add_pool_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_pool_admin)
+-  [Function `remove_pool_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_pool_admin)
+-  [Function `is_pool_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_pool_admin)
+-  [Function `add_emergency_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_emergency_admin)
+-  [Function `remove_emergency_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_emergency_admin)
+-  [Function `is_emergency_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_emergency_admin)
+-  [Function `add_risk_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_risk_admin)
+-  [Function `remove_risk_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_risk_admin)
+-  [Function `is_risk_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_risk_admin)
+-  [Function `add_flash_borrower`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_flash_borrower)
+-  [Function `remove_flash_borrower`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_flash_borrower)
+-  [Function `is_flash_borrower`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_flash_borrower)
+-  [Function `add_bridge`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_bridge)
+-  [Function `remove_bridge`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_bridge)
+-  [Function `is_bridge`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_bridge)
+-  [Function `add_asset_listing_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_asset_listing_admin)
+-  [Function `remove_asset_listing_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_asset_listing_admin)
+-  [Function `is_asset_listing_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_asset_listing_admin)
+-  [Function `add_funds_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_funds_admin)
+-  [Function `remove_funds_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_funds_admin)
+-  [Function `is_funds_admin`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_funds_admin)
+-  [Function `add_emission_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_emission_admin_role)
+-  [Function `remove_emission_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_emission_admin_role)
+-  [Function `is_emission_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_emission_admin_role)
+-  [Function `add_admin_controlled_ecosystem_reserve_funds_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_admin_controlled_ecosystem_reserve_funds_admin_role)
+-  [Function `remove_admin_controlled_ecosystem_reserve_funds_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_admin_controlled_ecosystem_reserve_funds_admin_role)
+-  [Function `is_admin_controlled_ecosystem_reserve_funds_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_admin_controlled_ecosystem_reserve_funds_admin_role)
+-  [Function `add_rewards_controller_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_rewards_controller_admin_role)
+-  [Function `remove_rewards_controller_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_rewards_controller_admin_role)
+-  [Function `is_rewards_controller_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_rewards_controller_admin_role)
+-  [Function `get_pool_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_pool_admin_role)
+-  [Function `get_emergency_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_emergency_admin_role)
+-  [Function `get_risk_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_risk_admin_role)
+-  [Function `get_flash_borrower_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_flash_borrower_role)
+-  [Function `get_bridge_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_bridge_role)
+-  [Function `get_asset_listing_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_asset_listing_admin_role)
+-  [Function `get_funds_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_funds_admin_role)
+-  [Function `get_emission_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_emission_admin_role)
+-  [Function `get_admin_controlled_ecosystem_reserve_funds_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_admin_controlled_ecosystem_reserve_funds_admin_role)
+-  [Function `get_rewards_controller_admin_role`](#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_rewards_controller_admin_role)
+
+
+<pre><code><b>use</b> <a href="">0x1::event</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::smart_table</a>;
+<b>use</b> <a href="">0x1::string</a>;
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleAdminChanged"></a>
+
+## Struct `RoleAdminChanged`
+
+@dev Emitted when <code>newAdminRole</code> is set as ```role```'s admin role, replacing <code>previousAdminRole</code>
+
+<code><a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_DEFAULT_ADMIN_ROLE">DEFAULT_ADMIN_ROLE</a></code> is the starting admin for all roles, despite
+{RoleAdminChanged} not being emitted signaling this.
+
+
+<pre><code>#[<a href="">event</a>]
+<b>struct</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleAdminChanged">RoleAdminChanged</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleGranted"></a>
+
+## Struct `RoleGranted`
+
+@dev Emitted when <code><a href="">account</a></code> is granted <code>role</code>.
+
+<code>sender</code> is the account that originated the contract call, an admin role
+
+
+<pre><code>#[<a href="">event</a>]
+<b>struct</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleGranted">RoleGranted</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleRevoked"></a>
+
+## Struct `RoleRevoked`
+
+@dev Emitted when <code><a href="">account</a></code> is revoked <code>role</code>.
+
+<code>sender</code> is the account that originated the contract call:
+- if using <code>revoke_role</code>, it is the admin role bearer
+- if using <code>renounce_role</code>, it is the role bearer (i.e. <code><a href="">account</a></code>)
+
+
+<pre><code>#[<a href="">event</a>]
+<b>struct</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleRevoked">RoleRevoked</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleData"></a>
+
+## Struct `RoleData`
+
+
+
+<pre><code><b>struct</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RoleData">RoleData</a> <b>has</b> store
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_Roles"></a>
+
+## Resource `Roles`
+
+
+
+<pre><code><b>struct</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_Roles">Roles</a> <b>has</b> key
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN_ROLE">ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [65, 68, 77, 73, 78, 95, 67, 79, 78, 84, 82, 79, 76, 76, 69, 68, 95, 69, 67, 79, 83, 89, 83, 84, 69, 77, 95, 82, 69, 83, 69, 82, 86, 69, 95, 70, 85, 78, 68, 83, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_ASSET_LISTING_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_ASSET_LISTING_ADMIN_ROLE">ASSET_LISTING_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [65, 83, 83, 69, 84, 95, 76, 73, 83, 84, 73, 78, 71, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_BRIDGE_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_BRIDGE_ROLE">BRIDGE_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [66, 82, 73, 68, 71, 69];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_DEFAULT_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_DEFAULT_ADMIN_ROLE">DEFAULT_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [68, 69, 70, 65, 85, 76, 84, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EMERGENCY_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EMERGENCY_ADMIN_ROLE">EMERGENCY_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [69, 77, 69, 82, 71, 69, 78, 67, 89, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EMISSION_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EMISSION_ADMIN_ROLE">EMISSION_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [69, 77, 73, 83, 83, 73, 79, 78, 95, 65, 68, 77, 73, 78, 95, 82, 79, 76, 69];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_ENOT_MANAGEMENT"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_ENOT_MANAGEMENT">ENOT_MANAGEMENT</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EROLE_CAN_ONLY_RENOUNCE_SELF"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EROLE_CAN_ONLY_RENOUNCE_SELF">EROLE_CAN_ONLY_RENOUNCE_SELF</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EROLE_NOT_ADMIN"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EROLE_NOT_ADMIN">EROLE_NOT_ADMIN</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EROLE_NOT_EXISTS"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_EROLE_NOT_EXISTS">EROLE_NOT_EXISTS</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_FLASH_BORROWER_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_FLASH_BORROWER_ROLE">FLASH_BORROWER_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [70, 76, 65, 83, 72, 95, 66, 79, 82, 82, 79, 87, 69, 82];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_FUNDS_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_FUNDS_ADMIN_ROLE">FUNDS_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [70, 85, 78, 68, 83, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_POOL_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_POOL_ADMIN_ROLE">POOL_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [80, 79, 79, 76, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_REWARDS_CONTROLLER_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_REWARDS_CONTROLLER_ADMIN_ROLE">REWARDS_CONTROLLER_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [82, 69, 87, 65, 82, 68, 83, 95, 67, 79, 78, 84, 82, 79, 76, 76, 69, 82, 95, 65, 68, 77, 73, 78, 95, 82, 79, 76, 69];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RISK_ADMIN_ROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_RISK_ADMIN_ROLE">RISK_ADMIN_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [82, 73, 83, 75, 95, 65, 68, 77, 73, 78];
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_grant_default_admin_role"></a>
+
+## Function `grant_default_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_grant_default_admin_role">grant_default_admin_role</a>(admin: &<a href="">signer</a>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_default_admin_role"></a>
+
+## Function `default_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_default_admin_role">default_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_role_admin"></a>
+
+## Function `get_role_admin`
+
+@dev Returns the admin role that controls <code>role</code>.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_role_admin">get_role_admin</a>(role: <a href="_String">string::String</a>): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_set_role_admin"></a>
+
+## Function `set_role_admin`
+
+@dev Sets <code>adminRole</code> as ```role```'s admin role.
+Emits a {RoleAdminChanged} event.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_set_role_admin">set_role_admin</a>(admin: &<a href="">signer</a>, role: <a href="_String">string::String</a>, admin_role: <a href="_String">string::String</a>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_has_role"></a>
+
+## Function `has_role`
+
+@dev Returns <code><b>true</b></code> if <code><a href="">account</a></code> has been granted <code>role</code>.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_has_role">has_role</a>(role: <a href="_String">string::String</a>, user: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_grant_role"></a>
+
+## Function `grant_role`
+
+@dev Grants <code>role</code> to <code><a href="">account</a></code>.
+
+If <code><a href="">account</a></code> had not been already granted <code>role</code>, emits a {RoleGranted}
+event.
+
+Requirements:
+
+- the caller must have ```role```'s admin role.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_grant_role">grant_role</a>(admin: &<a href="">signer</a>, role: <a href="_String">string::String</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_renounce_role"></a>
+
+## Function `renounce_role`
+
+@dev Revokes <code>role</code> from the calling account.
+Roles are often managed via {grant_role} and {revoke_role}: this function's
+purpose is to provide a mechanism for accounts to lose their privileges
+if they are compromised (such as when a trusted device is misplaced).
+
+If the calling account had been granted <code>role</code>, emits a {role_revoked}
+event.
+
+Requirements:
+
+- the caller must be <code><a href="">account</a></code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_renounce_role">renounce_role</a>(admin: &<a href="">signer</a>, role: <a href="_String">string::String</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_revoke_role"></a>
+
+## Function `revoke_role`
+
+@dev Revokes <code>role</code> from <code><a href="">account</a></code>.
+
+If <code><a href="">account</a></code> had been granted <code>role</code>, emits a {RoleRevoked} event.
+
+Requirements:
+
+- the caller must have ```role```'s admin role.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_revoke_role">revoke_role</a>(admin: &<a href="">signer</a>, role: <a href="_String">string::String</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_pool_admin"></a>
+
+## Function `add_pool_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_pool_admin">add_pool_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_pool_admin"></a>
+
+## Function `remove_pool_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_pool_admin">remove_pool_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_pool_admin"></a>
+
+## Function `is_pool_admin`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_pool_admin">is_pool_admin</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_emergency_admin"></a>
+
+## Function `add_emergency_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_emergency_admin">add_emergency_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_emergency_admin"></a>
+
+## Function `remove_emergency_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_emergency_admin">remove_emergency_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_emergency_admin"></a>
+
+## Function `is_emergency_admin`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_emergency_admin">is_emergency_admin</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_risk_admin"></a>
+
+## Function `add_risk_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_risk_admin">add_risk_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_risk_admin"></a>
+
+## Function `remove_risk_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_risk_admin">remove_risk_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_risk_admin"></a>
+
+## Function `is_risk_admin`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_risk_admin">is_risk_admin</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_flash_borrower"></a>
+
+## Function `add_flash_borrower`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_flash_borrower">add_flash_borrower</a>(admin: &<a href="">signer</a>, borrower: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_flash_borrower"></a>
+
+## Function `remove_flash_borrower`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_flash_borrower">remove_flash_borrower</a>(admin: &<a href="">signer</a>, borrower: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_flash_borrower"></a>
+
+## Function `is_flash_borrower`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_flash_borrower">is_flash_borrower</a>(borrower: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_bridge"></a>
+
+## Function `add_bridge`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_bridge">add_bridge</a>(admin: &<a href="">signer</a>, bridge: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_bridge"></a>
+
+## Function `remove_bridge`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_bridge">remove_bridge</a>(admin: &<a href="">signer</a>, bridge: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_bridge"></a>
+
+## Function `is_bridge`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_bridge">is_bridge</a>(bridge: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_asset_listing_admin"></a>
+
+## Function `add_asset_listing_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_asset_listing_admin">add_asset_listing_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_asset_listing_admin"></a>
+
+## Function `remove_asset_listing_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_asset_listing_admin">remove_asset_listing_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_asset_listing_admin"></a>
+
+## Function `is_asset_listing_admin`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_asset_listing_admin">is_asset_listing_admin</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_funds_admin"></a>
+
+## Function `add_funds_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_funds_admin">add_funds_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_funds_admin"></a>
+
+## Function `remove_funds_admin`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_funds_admin">remove_funds_admin</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_funds_admin"></a>
+
+## Function `is_funds_admin`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_funds_admin">is_funds_admin</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_emission_admin_role"></a>
+
+## Function `add_emission_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_emission_admin_role">add_emission_admin_role</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_emission_admin_role"></a>
+
+## Function `remove_emission_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_emission_admin_role">remove_emission_admin_role</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_emission_admin_role"></a>
+
+## Function `is_emission_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_emission_admin_role">is_emission_admin_role</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_admin_controlled_ecosystem_reserve_funds_admin_role"></a>
+
+## Function `add_admin_controlled_ecosystem_reserve_funds_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_admin_controlled_ecosystem_reserve_funds_admin_role">add_admin_controlled_ecosystem_reserve_funds_admin_role</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_admin_controlled_ecosystem_reserve_funds_admin_role"></a>
+
+## Function `remove_admin_controlled_ecosystem_reserve_funds_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_admin_controlled_ecosystem_reserve_funds_admin_role">remove_admin_controlled_ecosystem_reserve_funds_admin_role</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_admin_controlled_ecosystem_reserve_funds_admin_role"></a>
+
+## Function `is_admin_controlled_ecosystem_reserve_funds_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_admin_controlled_ecosystem_reserve_funds_admin_role">is_admin_controlled_ecosystem_reserve_funds_admin_role</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_rewards_controller_admin_role"></a>
+
+## Function `add_rewards_controller_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_add_rewards_controller_admin_role">add_rewards_controller_admin_role</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_rewards_controller_admin_role"></a>
+
+## Function `remove_rewards_controller_admin_role`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_remove_rewards_controller_admin_role">remove_rewards_controller_admin_role</a>(admin: &<a href="">signer</a>, user: <b>address</b>)
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_rewards_controller_admin_role"></a>
+
+## Function `is_rewards_controller_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_is_rewards_controller_admin_role">is_rewards_controller_admin_role</a>(admin: <b>address</b>): bool
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_pool_admin_role"></a>
+
+## Function `get_pool_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_pool_admin_role">get_pool_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_emergency_admin_role"></a>
+
+## Function `get_emergency_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_emergency_admin_role">get_emergency_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_risk_admin_role"></a>
+
+## Function `get_risk_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_risk_admin_role">get_risk_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_flash_borrower_role"></a>
+
+## Function `get_flash_borrower_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_flash_borrower_role">get_flash_borrower_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_bridge_role"></a>
+
+## Function `get_bridge_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_bridge_role">get_bridge_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_asset_listing_admin_role"></a>
+
+## Function `get_asset_listing_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_asset_listing_admin_role">get_asset_listing_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_funds_admin_role"></a>
+
+## Function `get_funds_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_funds_admin_role">get_funds_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_emission_admin_role"></a>
+
+## Function `get_emission_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_emission_admin_role">get_emission_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_admin_controlled_ecosystem_reserve_funds_admin_role"></a>
+
+## Function `get_admin_controlled_ecosystem_reserve_funds_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_admin_controlled_ecosystem_reserve_funds_admin_role">get_admin_controlled_ecosystem_reserve_funds_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>
+
+
+
+<a id="0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_rewards_controller_admin_role"></a>
+
+## Function `get_rewards_controller_admin_role`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage_get_rewards_controller_admin_role">get_rewards_controller_admin_role</a>(): <a href="_String">string::String</a>
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-acl/sources/acl_manage.move
+++ b/tests/aptos-aave-v3/aave-core/aave-acl/sources/acl_manage.move
@@ -1,0 +1,512 @@
+/// @title ACLManager
+/// @author Aave
+/// @notice Access Control List Manager. Main registry of system roles and permissions.
+///
+/// Roles are referred to by their `vector<u8>` identifier. These should be exposed
+/// in the external API and be unique. The best way to achieve this is by
+/// using `const` hash digests:
+/// ```
+/// const MY_ROLE = b"MY_ROLE";
+/// ```
+/// Roles can be used to represent a set of permissions. To restrict access to a
+/// function call, use {has_role}:
+/// ```
+/// public fun foo() {
+///     assert!(has_role(MY_ROLE, error_code::ENOT_MANAGEMENT));
+///     ...
+/// }
+/// ```
+/// Roles can be granted and revoked dynamically via the {grant_role} and
+/// {revoke_role} functions. Each role has an associated admin role, and only
+/// accounts that have a role's admin role can call {grant_role} and {revoke_role}.
+///
+/// By default, the admin role for all roles is `DEFAULT_ADMIN_ROLE`, which means
+/// that only accounts with this role will be able to grant or revoke other
+/// roles. More complex role relationships can be created by using
+/// {set_role_admin}.
+///
+/// WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
+/// grant and revoke this role. Extra precautions should be taken to secure
+/// accounts that have been granted it.
+module aave_acl::acl_manage {
+    use std::signer;
+    use std::string::{Self, String};
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::event;
+
+    use aave_config::error_config;
+
+    const DEFAULT_ADMIN_ROLE: vector<u8> = b"";
+    const POOL_ADMIN_ROLE: vector<u8> = b"POOL_ADMIN";
+    const EMERGENCY_ADMIN_ROLE: vector<u8> = b"EMERGENCY_ADMIN";
+    const RISK_ADMIN_ROLE: vector<u8> = b"RISK_ADMIN";
+    const FLASH_BORROWER_ROLE: vector<u8> = b"FLASH_BORROWER";
+    const BRIDGE_ROLE: vector<u8> = b"BRIDGE";
+    const ASSET_LISTING_ADMIN_ROLE: vector<u8> = b"ASSET_LISTING_ADMIN";
+    const FUNDS_ADMIN_ROLE: vector<u8> = b"FUNDS_ADMIN";
+    const EMISSION_ADMIN_ROLE: vector<u8> = b"EMISSION_ADMIN_ROLE";
+    const ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN_ROLE: vector<u8> = b"ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN";
+    const REWARDS_CONTROLLER_ADMIN_ROLE: vector<u8> = b"REWARDS_CONTROLLER_ADMIN_ROLE";
+
+    #[event]
+    /// @dev Emitted when `new_admin_role` is set as ``role``'s admin role, replacing `previous_admin_role`
+    ///
+    /// `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
+    /// {RoleAdminChanged} not being emitted signaling this.
+    struct RoleAdminChanged has store, drop {
+        role: String,
+        previous_admin_role: String,
+        new_admin_role: String
+    }
+
+    #[event]
+    /// @dev Emitted when `account` is granted `role`.
+    ///
+    /// `sender` is the account that originated the contract call, an admin role
+    struct RoleGranted has store, drop {
+        role: String,
+        account: address,
+        sender: address
+    }
+
+    #[event]
+    /// @dev Emitted when `account` is revoked `role`.
+    ///
+    /// `sender` is the account that originated the contract call:
+    ///   - if using `revoke_role`, it is the admin role bearer
+    ///   - if using `renounce_role`, it is the role bearer (i.e. `account`)
+    struct RoleRevoked has store, drop {
+        role: String,
+        account: address,
+        sender: address
+    }
+
+    struct RoleData has store {
+        members: SmartTable<address, bool>,
+        admin_role: String
+    }
+
+    struct Roles has key {
+        acl_instance: SmartTable<String, RoleData>
+    }
+
+    #[test_only]
+    public fun test_init_module(admin: &signer) acquires Roles {
+        init_module(admin);
+        grant_default_admin_role(admin);
+    }
+
+    fun init_module(admin: &signer) {
+        let admin_address = signer::address_of(admin);
+        check_super_admin(admin_address);
+        move_to(
+            admin,
+            Roles {
+                acl_instance: smart_table::new<String, RoleData>()
+            }
+        );
+    }
+
+    public entry fun grant_default_admin_role(admin: &signer) acquires Roles {
+        let admin_address = signer::address_of(admin);
+        check_super_admin(admin_address);
+        grant_role_internal(admin, default_admin_role(), admin_address);
+    }
+
+    fun check_super_admin(admin: address) {
+        assert!(admin == @aave_acl, error_config::get_enot_acl_owner());
+    }
+
+    fun only_role(role: String, user: address) acquires Roles {
+        assert!(has_role(role, user), error_config::get_erole_missmatch());
+    }
+
+    #[view]
+    public fun default_admin_role(): String {
+        string::utf8(DEFAULT_ADMIN_ROLE)
+    }
+
+    #[view]
+    /// @dev Returns the admin role that controls `role`.
+    public fun get_role_admin(role: String): String acquires Roles {
+        let roles = borrow_global<Roles>(@aave_acl);
+        if (!smart_table::contains(&roles.acl_instance, role)) {
+            return string::utf8(b"")
+        };
+
+        smart_table::borrow(&roles.acl_instance, role).admin_role
+    }
+
+    /// @dev Sets `admin_role` as ``role``'s admin role.
+    /// Emits a {RoleAdminChanged} event.
+    public entry fun set_role_admin(
+        admin: &signer, role: String, admin_role: String
+    ) acquires Roles {
+        only_role(default_admin_role(), signer::address_of(admin));
+
+        let previous_admin_role = get_role_admin(role);
+        let roles = borrow_global_mut<Roles>(@aave_acl);
+
+        if (!smart_table::contains(&mut roles.acl_instance, role)) {
+            let members = smart_table::new<address, bool>();
+            let role_data = RoleData { members, admin_role };
+            smart_table::add(&mut roles.acl_instance, role, role_data);
+        } else {
+            let role_data = smart_table::borrow_mut(&mut roles.acl_instance, role);
+            role_data.admin_role = admin_role;
+        };
+
+        event::emit(
+            RoleAdminChanged { role, previous_admin_role, new_admin_role: admin_role }
+        );
+    }
+
+    #[view]
+    /// @dev Returns `true` if `user` has been granted `role`.
+    /// @param role The role identifier
+    /// @param user The account to check
+    public fun has_role(role: String, user: address): bool acquires Roles {
+        let role_res = borrow_global<Roles>(@aave_acl);
+        if (!smart_table::contains(&role_res.acl_instance, role)) {
+            return false
+        };
+        let role_data = smart_table::borrow(&role_res.acl_instance, role);
+        if (!smart_table::contains(&role_data.members, user)) {
+            return false
+        };
+
+        *smart_table::borrow(&role_data.members, user)
+    }
+
+    /// @dev Grants `role` to `account`.
+    ///
+    /// If `account` had not been already granted `role`, emits a {RoleGranted}
+    /// event.
+    ///
+    /// Requirements:
+    ///
+    /// - the caller must have ``role``'s admin role.
+    public entry fun grant_role(
+        admin: &signer, role: String, user: address
+    ) acquires Roles {
+        let admin_address = signer::address_of(admin);
+        only_role(get_role_admin(role), admin_address);
+        grant_role_internal(admin, role, user);
+    }
+
+    fun grant_role_internal(admin: &signer, role: String, user: address) acquires Roles {
+        if (!has_role(role, user)) {
+            let role_res = borrow_global_mut<Roles>(@aave_acl);
+            if (!smart_table::contains(&role_res.acl_instance, role)) {
+                let members = smart_table::new<address, bool>();
+                smart_table::add(&mut members, user, true);
+                let role_data = RoleData { members, admin_role: string::utf8(b"") };
+                smart_table::add(&mut role_res.acl_instance, role, role_data);
+            } else {
+                let role_data = smart_table::borrow_mut(&mut role_res.acl_instance, role);
+                smart_table::upsert(&mut role_data.members, user, true);
+            };
+
+            event::emit(
+                RoleGranted { role, account: user, sender: signer::address_of(admin) }
+            );
+        }
+    }
+
+    /// @dev Revokes `role` from the calling account.
+    /// Roles are often managed via {grant_role} and {revoke_role}: this function's
+    /// purpose is to provide a mechanism for accounts to lose their privileges
+    /// if they are compromised (such as when a trusted device is misplaced).
+    ///
+    /// If the calling account had been granted `role`, emits a {role_revoked}
+    /// event.
+    ///
+    /// Requirements:
+    ///
+    /// - the caller must be `account`.
+    public entry fun renounce_role(
+        admin: &signer, role: String, user: address
+    ) acquires Roles {
+        assert!(
+            signer::address_of(admin) == user,
+            error_config::get_erole_can_only_renounce_self()
+        );
+        revoke_role_internal(admin, role, user);
+    }
+
+    /// @dev Revokes `role` from `account`.
+    ///
+    /// If `account` had been granted `role`, emits a {RoleRevoked} event.
+    ///
+    /// Requirements:
+    ///
+    /// - the caller must have ``role``'s admin role.
+    ///
+    public entry fun revoke_role(
+        admin: &signer, role: String, user: address
+    ) acquires Roles {
+        let admin_address = signer::address_of(admin);
+        only_role(get_role_admin(role), admin_address);
+        revoke_role_internal(admin, role, user);
+    }
+
+    fun revoke_role_internal(admin: &signer, role: String, user: address) acquires Roles {
+        if (has_role(role, user)) {
+            let role_res = borrow_global_mut<Roles>(@aave_acl);
+            let role_data = smart_table::borrow_mut(&mut role_res.acl_instance, role);
+            smart_table::upsert(&mut role_data.members, user, false);
+
+            event::emit(
+                RoleRevoked { role, account: user, sender: signer::address_of(admin) }
+            );
+        }
+    }
+
+    public entry fun add_pool_admin(admin: &signer, user: address) acquires Roles {
+        grant_role(admin, get_pool_admin_role(), user);
+    }
+
+    public entry fun remove_pool_admin(admin: &signer, user: address) acquires Roles {
+        revoke_role(admin, get_pool_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_pool_admin(admin: address): bool acquires Roles {
+        has_role(get_pool_admin_role(), admin)
+    }
+
+    public entry fun add_emergency_admin(admin: &signer, user: address) acquires Roles {
+        grant_role(admin, get_emergency_admin_role(), user);
+    }
+
+    public entry fun remove_emergency_admin(admin: &signer, user: address) acquires Roles {
+        revoke_role(admin, get_emergency_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_emergency_admin(admin: address): bool acquires Roles {
+        has_role(get_emergency_admin_role(), admin)
+    }
+
+    public entry fun add_risk_admin(admin: &signer, user: address) acquires Roles {
+        grant_role(admin, get_risk_admin_role(), user);
+    }
+
+    public entry fun remove_risk_admin(admin: &signer, user: address) acquires Roles {
+        revoke_role(admin, get_risk_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_risk_admin(admin: address): bool acquires Roles {
+        has_role(get_risk_admin_role(), admin)
+    }
+
+    public entry fun add_flash_borrower(admin: &signer, borrower: address) acquires Roles {
+        grant_role(admin, get_flash_borrower_role(), borrower);
+    }
+
+    public entry fun remove_flash_borrower(
+        admin: &signer, borrower: address
+    ) acquires Roles {
+        revoke_role(admin, get_flash_borrower_role(), borrower);
+    }
+
+    #[view]
+    public fun is_flash_borrower(borrower: address): bool acquires Roles {
+        has_role(get_flash_borrower_role(), borrower)
+    }
+
+    public entry fun add_bridge(admin: &signer, bridge: address) acquires Roles {
+        grant_role(admin, get_bridge_role(), bridge);
+    }
+
+    public entry fun remove_bridge(admin: &signer, bridge: address) acquires Roles {
+        revoke_role(admin, get_bridge_role(), bridge);
+    }
+
+    #[view]
+    public fun is_bridge(bridge: address): bool acquires Roles {
+        has_role(get_bridge_role(), bridge)
+    }
+
+    public entry fun add_asset_listing_admin(admin: &signer, user: address) acquires Roles {
+        grant_role(admin, get_asset_listing_admin_role(), user);
+    }
+
+    public entry fun remove_asset_listing_admin(
+        admin: &signer, user: address
+    ) acquires Roles {
+        revoke_role(admin, get_asset_listing_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_asset_listing_admin(admin: address): bool acquires Roles {
+        has_role(get_asset_listing_admin_role(), admin)
+    }
+
+    public entry fun add_funds_admin(admin: &signer, user: address) acquires Roles {
+        grant_role(admin, get_funds_admin_role(), user);
+    }
+
+    public entry fun remove_funds_admin(admin: &signer, user: address) acquires Roles {
+        revoke_role(admin, get_funds_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_funds_admin(admin: address): bool acquires Roles {
+        has_role(get_funds_admin_role(), admin)
+    }
+
+    public entry fun add_emission_admin(admin: &signer, user: address) acquires Roles {
+        grant_role(admin, get_emission_admin_role(), user);
+    }
+
+    public entry fun remove_emission_admin(admin: &signer, user: address) acquires Roles {
+        revoke_role(admin, get_emission_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_emission_admin(admin: address): bool acquires Roles {
+        has_role(get_emission_admin_role(), admin)
+    }
+
+    public entry fun add_admin_controlled_ecosystem_reserve_funds_admin(
+        admin: &signer, user: address
+    ) acquires Roles {
+        grant_role(
+            admin, get_admin_controlled_ecosystem_reserve_funds_admin_role(), user
+        );
+    }
+
+    public entry fun remove_admin_controlled_ecosystem_reserve_funds_admin(
+        admin: &signer, user: address
+    ) acquires Roles {
+        revoke_role(
+            admin, get_admin_controlled_ecosystem_reserve_funds_admin_role(), user
+        );
+    }
+
+    #[view]
+    public fun is_admin_controlled_ecosystem_reserve_funds_admin(
+        admin: address
+    ): bool acquires Roles {
+        has_role(get_admin_controlled_ecosystem_reserve_funds_admin_role(), admin)
+    }
+
+    public entry fun add_rewards_controller_admin(
+        admin: &signer, user: address
+    ) acquires Roles {
+        grant_role(admin, get_rewards_controller_admin_role(), user);
+    }
+
+    public entry fun remove_rewards_controller_admin(
+        admin: &signer, user: address
+    ) acquires Roles {
+        revoke_role(admin, get_rewards_controller_admin_role(), user);
+    }
+
+    #[view]
+    public fun is_rewards_controller_admin(admin: address): bool acquires Roles {
+        has_role(get_rewards_controller_admin_role(), admin)
+    }
+
+    #[view]
+    public fun get_pool_admin_role(): String {
+        string::utf8(POOL_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_emergency_admin_role(): String {
+        string::utf8(EMERGENCY_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_risk_admin_role(): String {
+        string::utf8(RISK_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_flash_borrower_role(): String {
+        string::utf8(FLASH_BORROWER_ROLE)
+    }
+
+    #[view]
+    public fun get_bridge_role(): String {
+        string::utf8(BRIDGE_ROLE)
+    }
+
+    #[view]
+    public fun get_asset_listing_admin_role(): String {
+        string::utf8(ASSET_LISTING_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_funds_admin_role(): String {
+        string::utf8(FUNDS_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_emission_admin_role(): String {
+        string::utf8(EMISSION_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_admin_controlled_ecosystem_reserve_funds_admin_role(): String {
+        string::utf8(ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN_ROLE)
+    }
+
+    #[view]
+    public fun get_rewards_controller_admin_role(): String {
+        string::utf8(REWARDS_CONTROLLER_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_pool_admin_role_for_testing(): String {
+        string::utf8(POOL_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_emergency_admin_role_for_testing(): String {
+        string::utf8(EMERGENCY_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_risk_admin_role_for_testing(): String {
+        string::utf8(RISK_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_flash_borrower_role_for_testing(): String {
+        string::utf8(FLASH_BORROWER_ROLE)
+    }
+
+    #[test_only]
+    public fun get_bridge_role_for_testing(): String {
+        string::utf8(BRIDGE_ROLE)
+    }
+
+    #[test_only]
+    public fun get_asset_listing_admin_role_for_testing(): String {
+        string::utf8(ASSET_LISTING_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_funds_admin_role_for_testing(): String {
+        string::utf8(FUNDS_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_emissions_admin_role_for_testing(): String {
+        string::utf8(EMISSION_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_admin_controlled_ecosystem_reserve_funds_admin_role_for_testing(): String {
+        string::utf8(ADMIN_CONTROLLED_ECOSYSTEM_RESERVE_FUNDS_ADMIN_ROLE)
+    }
+
+    #[test_only]
+    public fun get_rewards_controller_admin_role_for_testing(): String {
+        string::utf8(REWARDS_CONTROLLER_ADMIN_ROLE)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-acl/tests/acl_manage_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-acl/tests/acl_manage_tests.move
@@ -1,0 +1,530 @@
+#[test_only]
+module aave_acl::acl_manage_tests {
+    use std::signer;
+    use std::string::utf8;
+
+    use aave_acl::acl_manage::{
+        add_admin_controlled_ecosystem_reserve_funds_admin,
+        add_asset_listing_admin,
+        add_bridge,
+        add_emergency_admin,
+        add_emission_admin,
+        add_flash_borrower,
+        add_funds_admin,
+        add_pool_admin,
+        add_rewards_controller_admin,
+        add_risk_admin,
+        get_admin_controlled_ecosystem_reserve_funds_admin_role,
+        get_admin_controlled_ecosystem_reserve_funds_admin_role_for_testing,
+        get_asset_listing_admin_role,
+        get_asset_listing_admin_role_for_testing,
+        get_bridge_role,
+        get_bridge_role_for_testing,
+        get_emergency_admin_role,
+        get_emergency_admin_role_for_testing,
+        get_emission_admin_role,
+        get_emissions_admin_role_for_testing,
+        get_flash_borrower_role,
+        get_flash_borrower_role_for_testing,
+        get_funds_admin_role,
+        get_funds_admin_role_for_testing,
+        get_pool_admin_role,
+        get_pool_admin_role_for_testing,
+        get_rewards_controller_admin_role,
+        get_rewards_controller_admin_role_for_testing,
+        get_risk_admin_role,
+        get_risk_admin_role_for_testing,
+        grant_role,
+        has_role,
+        is_admin_controlled_ecosystem_reserve_funds_admin,
+        is_asset_listing_admin,
+        is_bridge,
+        is_emergency_admin,
+        is_emission_admin,
+        is_flash_borrower,
+        is_funds_admin,
+        is_pool_admin,
+        is_rewards_controller_admin,
+        is_risk_admin,
+        remove_admin_controlled_ecosystem_reserve_funds_admin,
+        remove_asset_listing_admin,
+        remove_bridge,
+        remove_emergency_admin,
+        remove_emission_admin,
+        remove_flash_borrower,
+        remove_funds_admin,
+        remove_pool_admin,
+        remove_rewards_controller_admin,
+        remove_risk_admin,
+        revoke_role,
+        set_role_admin,
+        test_init_module
+    };
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    // ========== TEST: BASIC GETTERS ============
+    #[test]
+    fun test_asset_listing_admin_role() {
+        assert!(
+            get_asset_listing_admin_role()
+                == get_asset_listing_admin_role_for_testing(),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_bridge_role() {
+        assert!(get_bridge_role() == get_bridge_role_for_testing(), TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_flash_borrower_role() {
+        assert!(
+            get_flash_borrower_role() == get_flash_borrower_role_for_testing(),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_risk_admin_role() {
+        assert!(get_risk_admin_role() == get_risk_admin_role_for_testing(), TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_emergency_admin_role() {
+        assert!(
+            get_emergency_admin_role() == get_emergency_admin_role_for_testing(),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_pool_admin_role() {
+        assert!(get_pool_admin_role() == get_pool_admin_role_for_testing(), TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_funds_admin_role() {
+        assert!(
+            get_funds_admin_role() == get_funds_admin_role_for_testing(), TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_emission_admin_role() {
+        assert!(
+            get_emission_admin_role() == get_emissions_admin_role_for_testing(),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_admin_controlled_ecosystem_reserve_funds_admin_role() {
+        assert!(
+            get_admin_controlled_ecosystem_reserve_funds_admin_role()
+                == get_admin_controlled_ecosystem_reserve_funds_admin_role_for_testing(),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_rewards_controller_admin_role() {
+        assert!(
+            get_rewards_controller_admin_role()
+                == get_rewards_controller_admin_role_for_testing(),
+            TEST_SUCCESS
+        );
+    }
+
+    // ========== TEST: TEST OWNER HOLDERS ============
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_asset_listing_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_asset_listing_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_asset_listing_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_bridge(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin, get_bridge_role_for_testing(), signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_bridge(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_flash_borrower(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_flash_borrower_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_flash_borrower(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_risk_admin(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_risk_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_risk_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_emergency_admin(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_emergency_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_emergency_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_pool_admin(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_pool_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_pool_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_funds_admin(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_funds_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_funds_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_emission_admin(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_emissions_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_emission_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_admin_controlled_ecosystem_reserve_funds_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_admin_controlled_ecosystem_reserve_funds_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(
+            is_admin_controlled_ecosystem_reserve_funds_admin(
+                signer::address_of(test_addr)
+            ),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_is_rewards_controller_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_rewards_controller_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(
+            is_rewards_controller_admin(signer::address_of(test_addr)),
+            TEST_SUCCESS
+        );
+    }
+
+    // ========== TEST: GRANT ROLE + HAS ROLE ============
+    #[test(super_admin = @aave_acl, test_addr = @0x01, other_addr = @0x02)]
+    fun test_has_role(
+        super_admin: &signer, test_addr: &signer, other_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_pool_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has no longer the role assigned
+        assert!(
+            !has_role(
+                get_pool_admin_role_for_testing(), signer::address_of(other_addr)
+            ),
+            TEST_SUCCESS
+        );
+    }
+
+    // ========== TEST: REVOKE + HAS ROLE ============
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_revoke_role(super_admin: &signer, test_addr: &signer) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        grant_role(
+            super_admin,
+            get_pool_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(is_pool_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+
+        let role_admin = utf8(b"role_admin");
+        // set role admin
+        set_role_admin(super_admin, get_pool_admin_role_for_testing(), role_admin);
+        // add the asset listing role to some address
+        grant_role(super_admin, role_admin, signer::address_of(test_addr));
+
+        // now remove the role
+        revoke_role(
+            test_addr,
+            get_pool_admin_role_for_testing(),
+            signer::address_of(test_addr)
+        );
+        // check the address has no longer the role assigned
+        assert!(
+            !has_role(get_pool_admin_role_for_testing(), signer::address_of(test_addr)),
+            TEST_SUCCESS
+        );
+    }
+
+    // ============== SPECIAL FUNCTIONS ============ //
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_pool_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_pool_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_pool_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_pool_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_pool_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_asset_listing_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_asset_listing_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_asset_listing_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_asset_listing_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_asset_listing_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_bridge_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_bridge(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_bridge(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_bridge(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_bridge(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_emergency_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_emergency_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_emergency_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_emergency_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_emergency_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_flash_borrower_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_flash_borrower(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_flash_borrower(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_flash_borrower(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_flash_borrower(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_risk_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_risk_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_risk_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_risk_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_risk_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_funds_admin(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_funds_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_funds_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_funds_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_funds_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_emission_admin_role(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_emission_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(is_emission_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+        // remove pool admin
+        remove_emission_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(!is_emission_admin(signer::address_of(test_addr)), TEST_SUCCESS);
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_admin_controlled_ecosystem_reserve_funds_admin_role(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_admin_controlled_ecosystem_reserve_funds_admin(
+            super_admin, signer::address_of(test_addr)
+        );
+        // check the address has the role assigned
+        assert!(
+            is_admin_controlled_ecosystem_reserve_funds_admin(
+                signer::address_of(test_addr)
+            ),
+            TEST_SUCCESS
+        );
+        // remove pool admin
+        remove_admin_controlled_ecosystem_reserve_funds_admin(
+            super_admin, signer::address_of(test_addr)
+        );
+        // check the address has no longer the role assigned
+        assert!(
+            !is_admin_controlled_ecosystem_reserve_funds_admin(
+                signer::address_of(test_addr)
+            ),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(super_admin = @aave_acl, test_addr = @0x01)]
+    fun test_add_remove_rewards_controller_admin_role(
+        super_admin: &signer, test_addr: &signer
+    ) {
+        // init the module
+        test_init_module(super_admin);
+        // add the asset listing role to some address
+        add_rewards_controller_admin(super_admin, signer::address_of(test_addr));
+        // check the address has the role assigned
+        assert!(
+            is_rewards_controller_admin(signer::address_of(test_addr)),
+            TEST_SUCCESS
+        );
+        // remove pool admin
+        remove_rewards_controller_admin(super_admin, signer::address_of(test_addr));
+        // check the address has no longer the role assigned
+        assert!(
+            !is_rewards_controller_admin(signer::address_of(test_addr)),
+            TEST_SUCCESS
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-config/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "AaveConfig"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_config = '_'
+
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-config/doc/error_config.md
+++ b/tests/aptos-aave-v3/aave-core/aave-config/doc/error_config.md
@@ -1,0 +1,1977 @@
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error"></a>
+
+# Module `0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::error`
+
+@title Errors library
+@author Aave
+@notice Defines the error messages emitted by the different contracts of the Aave protocol
+
+
+-  [Constants](#@Constants_0)
+-  [Function `get_ecaller_not_pool_admin`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_admin)
+-  [Function `get_ecaller_not_emergency_admin`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_emergency_admin)
+-  [Function `get_ecaller_not_pool_or_emergency_admin`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_or_emergency_admin)
+-  [Function `get_ecaller_not_risk_or_pool_admin`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_risk_or_pool_admin)
+-  [Function `get_ecaller_not_asset_listing_or_pool_admin`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_asset_listing_or_pool_admin)
+-  [Function `get_ecaller_not_bridge`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_bridge)
+-  [Function `get_eaddresses_provider_not_registered`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaddresses_provider_not_registered)
+-  [Function `get_einvalid_addresses_provider_id`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_addresses_provider_id)
+-  [Function `get_enot_contract`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_enot_contract)
+-  [Function `get_ecaller_not_pool_configurator`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_configurator)
+-  [Function `get_ecaller_not_atoken`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_atoken)
+-  [Function `get_einvalid_addresses_provider`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_addresses_provider)
+-  [Function `get_einvalid_flashloan_executor_return`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_flashloan_executor_return)
+-  [Function `get_ereserve_already_added`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_already_added)
+-  [Function `get_ereserves_storage_count_mismatch`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserves_storage_count_mismatch)
+-  [Function `get_eno_more_reserves_allowed`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_more_reserves_allowed)
+-  [Function `get_eemode_category_reserved`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eemode_category_reserved)
+-  [Function `get_einvalid_emode_category_assignment`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category_assignment)
+-  [Function `get_ereserve_liquidity_not_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_liquidity_not_zero)
+-  [Function `get_eflashloan_premium_invalid`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eflashloan_premium_invalid)
+-  [Function `get_einvalid_reserve_params`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_params)
+-  [Function `get_einvalid_emode_category_params`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category_params)
+-  [Function `get_ebridge_protocol_fee_invalid`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ebridge_protocol_fee_invalid)
+-  [Function `get_ecaller_must_be_pool`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_must_be_pool)
+-  [Function `get_einvalid_mint_amount`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_mint_amount)
+-  [Function `get_einvalid_burn_amount`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_burn_amount)
+-  [Function `get_einvalid_amount`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_amount)
+-  [Function `get_ereserve_inactive`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_inactive)
+-  [Function `get_ereserve_frozen`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_frozen)
+-  [Function `get_ereserve_paused`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_paused)
+-  [Function `get_eborrowing_not_enabled`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eborrowing_not_enabled)
+-  [Function `get_enot_enough_available_user_balance`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_enot_enough_available_user_balance)
+-  [Function `get_einvalid_interest_rate_mode_selected`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_interest_rate_mode_selected)
+-  [Function `get_ecollateral_balance_is_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_balance_is_zero)
+-  [Function `get_ehealth_factor_lower_than_liquidation_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ehealth_factor_lower_than_liquidation_threshold)
+-  [Function `get_ecollateral_cannot_cover_new_borrow`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_cannot_cover_new_borrow)
+-  [Function `get_ecollateral_same_as_borrowing_currency`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_same_as_borrowing_currency)
+-  [Function `get_eno_debt_of_selected_type`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_debt_of_selected_type)
+-  [Function `get_eno_explicit_amount_to_repay_on_behalf`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_explicit_amount_to_repay_on_behalf)
+-  [Function `get_eno_outstanding_variable_debt`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_outstanding_variable_debt)
+-  [Function `get_eunderlying_balance_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_balance_zero)
+-  [Function `get_einterest_rate_rebalance_conditions_not_met`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einterest_rate_rebalance_conditions_not_met)
+-  [Function `get_ehealth_factor_not_below_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ehealth_factor_not_below_threshold)
+-  [Function `get_ecollateral_cannot_be_liquidated`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_cannot_be_liquidated)
+-  [Function `get_especified_currency_not_borrowed_by_user`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_especified_currency_not_borrowed_by_user)
+-  [Function `get_einconsistent_flashloan_params`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_flashloan_params)
+-  [Function `get_eborrow_cap_exceeded`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eborrow_cap_exceeded)
+-  [Function `get_esupply_cap_exceeded`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esupply_cap_exceeded)
+-  [Function `get_eunbacked_mint_cap_exceeded`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunbacked_mint_cap_exceeded)
+-  [Function `get_edebt_ceiling_exceeded`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_edebt_ceiling_exceeded)
+-  [Function `get_eunderlying_claimable_rights_not_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_claimable_rights_not_zero)
+-  [Function `get_evariable_debt_supply_not_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_evariable_debt_supply_not_zero)
+-  [Function `get_eltv_validation_failed`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eltv_validation_failed)
+-  [Function `get_einconsistent_emode_category`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_emode_category)
+-  [Function `get_eprice_oracle_sentinel_check_failed`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eprice_oracle_sentinel_check_failed)
+-  [Function `get_easset_not_borrowable_in_isolation`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_easset_not_borrowable_in_isolation)
+-  [Function `get_ereserve_already_initialized`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_already_initialized)
+-  [Function `get_euser_in_isolation_mode_or_ltv_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_euser_in_isolation_mode_or_ltv_zero)
+-  [Function `get_einvalid_ltv`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_ltv)
+-  [Function `get_einvalid_liq_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liq_threshold)
+-  [Function `get_einvalid_liq_bonus`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liq_bonus)
+-  [Function `get_einvalid_decimals`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_decimals)
+-  [Function `get_einvalid_reserve_factor`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_factor)
+-  [Function `get_einvalid_borrow_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_borrow_cap)
+-  [Function `get_einvalid_supply_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_supply_cap)
+-  [Function `get_einvalid_liquidation_protocol_fee`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liquidation_protocol_fee)
+-  [Function `get_einvalid_emode_category`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category)
+-  [Function `get_einvalid_unbacked_mint_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_unbacked_mint_cap)
+-  [Function `get_einvalid_debt_ceiling`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_debt_ceiling)
+-  [Function `get_einvalid_reserve_index`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_index)
+-  [Function `get_eacl_admin_cannot_be_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eacl_admin_cannot_be_zero)
+-  [Function `get_einconsistent_params_length`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_params_length)
+-  [Function `get_ezero_address_not_valid`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ezero_address_not_valid)
+-  [Function `get_einvalid_expiration`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_expiration)
+-  [Function `get_einvalid_signature`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_signature)
+-  [Function `get_eoperation_not_supported`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eoperation_not_supported)
+-  [Function `get_edebt_ceiling_not_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_edebt_ceiling_not_zero)
+-  [Function `get_easset_not_listed`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_easset_not_listed)
+-  [Function `get_einvalid_optimal_usage_ratio`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_optimal_usage_ratio)
+-  [Function `get_eunderlying_cannot_be_rescued`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_cannot_be_rescued)
+-  [Function `get_eaddresses_provider_already_added`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaddresses_provider_already_added)
+-  [Function `get_epool_addresses_do_not_match`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_epool_addresses_do_not_match)
+-  [Function `get_esiloed_borrowing_violation`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esiloed_borrowing_violation)
+-  [Function `get_ereserve_debt_not_zero`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_debt_not_zero)
+-  [Function `get_eflashloan_disabled`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eflashloan_disabled)
+-  [Function `get_euser_not_listed`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_euser_not_listed)
+-  [Function `get_esigner_and_on_behalf_of_no_same`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esigner_and_on_behalf_of_no_same)
+-  [Function `get_eaccount_does_not_exist`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaccount_does_not_exist)
+-  [Function `get_flashloan_payer_not_receiver`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_flashloan_payer_not_receiver)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EACCOUNT_DOES_NOT_EXIST"></a>
+
+Account does not exist
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>: u64 = 95;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EACL_ADMIN_CANNOT_BE_ZERO"></a>
+
+ACL admin cannot be set to the zero address
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EACL_ADMIN_CANNOT_BE_ZERO">EACL_ADMIN_CANNOT_BE_ZERO</a>: u64 = 75;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EADDRESSES_PROVIDER_ALREADY_ADDED"></a>
+
+Reserve has already been added to reserve list
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EADDRESSES_PROVIDER_ALREADY_ADDED">EADDRESSES_PROVIDER_ALREADY_ADDED</a>: u64 = 86;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EADDRESSES_PROVIDER_NOT_REGISTERED"></a>
+
+Pool addresses provider is not registered
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EADDRESSES_PROVIDER_NOT_REGISTERED">EADDRESSES_PROVIDER_NOT_REGISTERED</a>: u64 = 7;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EASSET_NOT_BORROWABLE_IN_ISOLATION"></a>
+
+Asset is not borrowable in isolation mode
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EASSET_NOT_BORROWABLE_IN_ISOLATION">EASSET_NOT_BORROWABLE_IN_ISOLATION</a>: u64 = 60;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EASSET_NOT_LISTED"></a>
+
+Asset is not listed
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EASSET_NOT_LISTED">EASSET_NOT_LISTED</a>: u64 = 82;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EBORROWING_NOT_ENABLED"></a>
+
+Borrowing is not enabled
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EBORROWING_NOT_ENABLED">EBORROWING_NOT_ENABLED</a>: u64 = 30;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EBORROW_CAP_EXCEEDED"></a>
+
+Borrow cap is exceeded
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EBORROW_CAP_EXCEEDED">EBORROW_CAP_EXCEEDED</a>: u64 = 50;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EBRIDGE_PROTOCOL_FEE_INVALID"></a>
+
+Invalid bridge protocol fee
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EBRIDGE_PROTOCOL_FEE_INVALID">EBRIDGE_PROTOCOL_FEE_INVALID</a>: u64 = 22;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_MUST_BE_POOL"></a>
+
+The caller of this function must be a pool
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_MUST_BE_POOL">ECALLER_MUST_BE_POOL</a>: u64 = 23;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN"></a>
+
+The caller of the function is not an asset listing or pool admin
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN">ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN</a>: u64 = 5;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_ATOKEN"></a>
+
+The caller of the function is not an AToken
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_ATOKEN">ECALLER_NOT_ATOKEN</a>: u64 = 11;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_BRIDGE"></a>
+
+The caller of the function is not a bridge
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_BRIDGE">ECALLER_NOT_BRIDGE</a>: u64 = 6;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_EMERGENCY_ADMIN"></a>
+
+The caller of the function is not an emergency admin
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_EMERGENCY_ADMIN">ECALLER_NOT_EMERGENCY_ADMIN</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_POOL_ADMIN"></a>
+
+The caller of the function is not a pool admin
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_POOL_ADMIN">ECALLER_NOT_POOL_ADMIN</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_POOL_CONFIGURATOR"></a>
+
+The caller of the function is not the pool configurator
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_POOL_CONFIGURATOR">ECALLER_NOT_POOL_CONFIGURATOR</a>: u64 = 10;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN"></a>
+
+The caller of the function is not a pool or emergency admin
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN">ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_RISK_OR_POOL_ADMIN"></a>
+
+The caller of the function is not a risk or pool admin
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECALLER_NOT_RISK_OR_POOL_ADMIN">ECALLER_NOT_RISK_OR_POOL_ADMIN</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_BALANCE_IS_ZERO"></a>
+
+The collateral balance is 0
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_BALANCE_IS_ZERO">ECOLLATERAL_BALANCE_IS_ZERO</a>: u64 = 34;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_CANNOT_BE_LIQUIDATED"></a>
+
+The collateral chosen cannot be liquidated
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_CANNOT_BE_LIQUIDATED">ECOLLATERAL_CANNOT_BE_LIQUIDATED</a>: u64 = 46;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_CANNOT_COVER_NEW_BORROW"></a>
+
+There is not enough collateral to cover a new borrow
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_CANNOT_COVER_NEW_BORROW">ECOLLATERAL_CANNOT_COVER_NEW_BORROW</a>: u64 = 36;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_SAME_AS_BORROWING_CURRENCY"></a>
+
+Collateral is (mostly) the same currency that is being borrowed
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ECOLLATERAL_SAME_AS_BORROWING_CURRENCY">ECOLLATERAL_SAME_AS_BORROWING_CURRENCY</a>: u64 = 37;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EDEBT_CEILING_EXCEEDED"></a>
+
+Debt ceiling is exceeded
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EDEBT_CEILING_EXCEEDED">EDEBT_CEILING_EXCEEDED</a>: u64 = 53;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EDEBT_CEILING_NOT_ZERO"></a>
+
+Debt ceiling is not zero
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EDEBT_CEILING_NOT_ZERO">EDEBT_CEILING_NOT_ZERO</a>: u64 = 81;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EEMODE_CATEGORY_RESERVED"></a>
+
+Zero eMode category is reserved for volatile heterogeneous assets
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EEMODE_CATEGORY_RESERVED">EEMODE_CATEGORY_RESERVED</a>: u64 = 16;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EFLASHLOAN_DISABLED"></a>
+
+FlashLoaning for this asset is disabled
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EFLASHLOAN_DISABLED">EFLASHLOAN_DISABLED</a>: u64 = 91;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EFLASHLOAN_PAYER_NOT_RECEIVER"></a>
+
+Flashloan payer is different from the flashloan receiver
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EFLASHLOAN_PAYER_NOT_RECEIVER">EFLASHLOAN_PAYER_NOT_RECEIVER</a>: u64 = 95;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EFLASHLOAN_PREMIUM_INVALID"></a>
+
+Invalid flashloan premium
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EFLASHLOAN_PREMIUM_INVALID">EFLASHLOAN_PREMIUM_INVALID</a>: u64 = 19;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD"></a>
+
+Health factor is lesser than the liquidation threshold
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD">EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD</a>: u64 = 35;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EHEALTH_FACTOR_NOT_BELOW_THRESHOLD"></a>
+
+Health factor is not below the threshold
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EHEALTH_FACTOR_NOT_BELOW_THRESHOLD">EHEALTH_FACTOR_NOT_BELOW_THRESHOLD</a>: u64 = 45;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINCONSISTENT_EMODE_CATEGORY"></a>
+
+Inconsistent eMode category
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINCONSISTENT_EMODE_CATEGORY">EINCONSISTENT_EMODE_CATEGORY</a>: u64 = 58;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINCONSISTENT_FLASHLOAN_PARAMS"></a>
+
+Inconsistent flashloan parameters
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINCONSISTENT_FLASHLOAN_PARAMS">EINCONSISTENT_FLASHLOAN_PARAMS</a>: u64 = 49;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINCONSISTENT_PARAMS_LENGTH"></a>
+
+Array parameters that should be equal length are not
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINCONSISTENT_PARAMS_LENGTH">EINCONSISTENT_PARAMS_LENGTH</a>: u64 = 76;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET"></a>
+
+Interest rate rebalance conditions were not met
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET">EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET</a>: u64 = 44;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_ADDRESSES_PROVIDER"></a>
+
+The address of the pool addresses provider is invalid
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_ADDRESSES_PROVIDER">EINVALID_ADDRESSES_PROVIDER</a>: u64 = 12;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_ADDRESSES_PROVIDER_ID"></a>
+
+Invalid id for the pool addresses provider
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_ADDRESSES_PROVIDER_ID">EINVALID_ADDRESSES_PROVIDER_ID</a>: u64 = 8;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_AMOUNT"></a>
+
+Amount must be greater than 0
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_AMOUNT">EINVALID_AMOUNT</a>: u64 = 26;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_BORROW_CAP"></a>
+
+Invalid borrow cap for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_BORROW_CAP">EINVALID_BORROW_CAP</a>: u64 = 68;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_BURN_AMOUNT"></a>
+
+Invalid amount to burn
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_BURN_AMOUNT">EINVALID_BURN_AMOUNT</a>: u64 = 25;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_DEBT_CEILING"></a>
+
+Invalid debt ceiling for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_DEBT_CEILING">EINVALID_DEBT_CEILING</a>: u64 = 73;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_DECIMALS"></a>
+
+Invalid decimals parameter of the underlying asset of the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_DECIMALS">EINVALID_DECIMALS</a>: u64 = 66;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EMODE_CATEGORY"></a>
+
+Invalid eMode category for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EMODE_CATEGORY">EINVALID_EMODE_CATEGORY</a>: u64 = 71;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EMODE_CATEGORY_ASSIGNMENT"></a>
+
+Invalid eMode category assignment to asset
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EMODE_CATEGORY_ASSIGNMENT">EINVALID_EMODE_CATEGORY_ASSIGNMENT</a>: u64 = 17;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EMODE_CATEGORY_PARAMS"></a>
+
+Invalid risk parameters for the eMode category
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EMODE_CATEGORY_PARAMS">EINVALID_EMODE_CATEGORY_PARAMS</a>: u64 = 21;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EXPIRATION"></a>
+
+Invalid expiration
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_EXPIRATION">EINVALID_EXPIRATION</a>: u64 = 78;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_FLASHLOAN_EXECUTOR_RETURN"></a>
+
+Invalid return value of the flashloan executor function
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_FLASHLOAN_EXECUTOR_RETURN">EINVALID_FLASHLOAN_EXECUTOR_RETURN</a>: u64 = 13;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_INTEREST_RATE_MODE_SELECTED"></a>
+
+Invalid interest rate mode selected
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_INTEREST_RATE_MODE_SELECTED">EINVALID_INTEREST_RATE_MODE_SELECTED</a>: u64 = 33;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LIQUIDATION_PROTOCOL_FEE"></a>
+
+Invalid liquidation protocol fee for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LIQUIDATION_PROTOCOL_FEE">EINVALID_LIQUIDATION_PROTOCOL_FEE</a>: u64 = 70;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LIQ_BONUS"></a>
+
+Invalid liquidity bonus parameter for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LIQ_BONUS">EINVALID_LIQ_BONUS</a>: u64 = 65;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LIQ_THRESHOLD"></a>
+
+Invalid liquidity threshold parameter for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LIQ_THRESHOLD">EINVALID_LIQ_THRESHOLD</a>: u64 = 64;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LTV"></a>
+
+Invalid ltv parameter for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_LTV">EINVALID_LTV</a>: u64 = 63;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_MINT_AMOUNT"></a>
+
+Invalid amount to mint
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_MINT_AMOUNT">EINVALID_MINT_AMOUNT</a>: u64 = 24;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_OPTIMAL_USAGE_RATIO"></a>
+
+Invalid optimal usage ratio
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_OPTIMAL_USAGE_RATIO">EINVALID_OPTIMAL_USAGE_RATIO</a>: u64 = 83;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_RESERVE_FACTOR"></a>
+
+Invalid reserve factor parameter for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_RESERVE_FACTOR">EINVALID_RESERVE_FACTOR</a>: u64 = 67;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_RESERVE_INDEX"></a>
+
+Invalid reserve index
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_RESERVE_INDEX">EINVALID_RESERVE_INDEX</a>: u64 = 74;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_RESERVE_PARAMS"></a>
+
+Invalid risk parameters for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_RESERVE_PARAMS">EINVALID_RESERVE_PARAMS</a>: u64 = 20;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_SIGNATURE"></a>
+
+Invalid signature
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>: u64 = 79;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_SUPPLY_CAP"></a>
+
+Invalid supply cap for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_SUPPLY_CAP">EINVALID_SUPPLY_CAP</a>: u64 = 69;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_UNBACKED_MINT_CAP"></a>
+
+Invalid unbacked mint cap for the reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EINVALID_UNBACKED_MINT_CAP">EINVALID_UNBACKED_MINT_CAP</a>: u64 = 72;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ELTV_VALIDATION_FAILED"></a>
+
+Ltv validation failed
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ELTV_VALIDATION_FAILED">ELTV_VALIDATION_FAILED</a>: u64 = 57;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENOT_CONTRACT"></a>
+
+Address is not a contract
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENOT_CONTRACT">ENOT_CONTRACT</a>: u64 = 9;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENOT_ENOUGH_AVAILABLE_USER_BALANCE"></a>
+
+User cannot withdraw more than the available balance
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENOT_ENOUGH_AVAILABLE_USER_BALANCE">ENOT_ENOUGH_AVAILABLE_USER_BALANCE</a>: u64 = 32;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_DEBT_OF_SELECTED_TYPE"></a>
+
+For repayment of a specific type of debt, the user needs to have debt that type
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_DEBT_OF_SELECTED_TYPE">ENO_DEBT_OF_SELECTED_TYPE</a>: u64 = 39;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF"></a>
+
+To repay on behalf of a user an explicit amount to repay is needed
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF">ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF</a>: u64 = 40;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_MORE_RESERVES_ALLOWED"></a>
+
+Maximum amount of reserves in the pool reached
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_MORE_RESERVES_ALLOWED">ENO_MORE_RESERVES_ALLOWED</a>: u64 = 15;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_OUTSTANDING_VARIABLE_DEBT"></a>
+
+User does not have outstanding variable rate debt on this reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ENO_OUTSTANDING_VARIABLE_DEBT">ENO_OUTSTANDING_VARIABLE_DEBT</a>: u64 = 42;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EOPERATION_NOT_SUPPORTED"></a>
+
+Operation not supported
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EOPERATION_NOT_SUPPORTED">EOPERATION_NOT_SUPPORTED</a>: u64 = 80;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EPOOL_ADDRESSES_DO_NOT_MATCH"></a>
+
+The token implementation pool address and the pool address provided by the initializing pool do not match
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EPOOL_ADDRESSES_DO_NOT_MATCH">EPOOL_ADDRESSES_DO_NOT_MATCH</a>: u64 = 87;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EPRICE_ORACLE_SENTINEL_CHECK_FAILED"></a>
+
+Price oracle sentinel validation failed
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EPRICE_ORACLE_SENTINEL_CHECK_FAILED">EPRICE_ORACLE_SENTINEL_CHECK_FAILED</a>: u64 = 59;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVES_STORAGE_COUNT_MISMATCH"></a>
+
+Mismatch of reserves count in storage
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVES_STORAGE_COUNT_MISMATCH">ERESERVES_STORAGE_COUNT_MISMATCH</a>: u64 = 93;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_ALREADY_ADDED"></a>
+
+Reserve has already been added to reserve list
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_ALREADY_ADDED">ERESERVE_ALREADY_ADDED</a>: u64 = 14;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_ALREADY_INITIALIZED"></a>
+
+Reserve has already been initialized
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_ALREADY_INITIALIZED">ERESERVE_ALREADY_INITIALIZED</a>: u64 = 61;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_DEBT_NOT_ZERO"></a>
+
+the total debt of the reserve needs to be 0
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_DEBT_NOT_ZERO">ERESERVE_DEBT_NOT_ZERO</a>: u64 = 90;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_FROZEN"></a>
+
+Action cannot be performed because the reserve is frozen
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_FROZEN">ERESERVE_FROZEN</a>: u64 = 28;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_INACTIVE"></a>
+
+Action requires an active reserve
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_INACTIVE">ERESERVE_INACTIVE</a>: u64 = 27;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_LIQUIDITY_NOT_ZERO"></a>
+
+The liquidity of the reserve needs to be 0
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_LIQUIDITY_NOT_ZERO">ERESERVE_LIQUIDITY_NOT_ZERO</a>: u64 = 18;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_PAUSED"></a>
+
+Action cannot be performed because the reserve is paused
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ERESERVE_PAUSED">ERESERVE_PAUSED</a>: u64 = 29;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESIGNER_AND_ON_BEHALF_OF_NO_SAME"></a>
+
+The person who signed must be consistent with on_behalf_of
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESIGNER_AND_ON_BEHALF_OF_NO_SAME">ESIGNER_AND_ON_BEHALF_OF_NO_SAME</a>: u64 = 94;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESILOED_BORROWING_VIOLATION"></a>
+
+User is trying to borrow multiple assets including a siloed one
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESILOED_BORROWING_VIOLATION">ESILOED_BORROWING_VIOLATION</a>: u64 = 89;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER"></a>
+
+User did not borrow the specified currency
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER">ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER</a>: u64 = 47;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESUPPLY_CAP_EXCEEDED"></a>
+
+Supply cap is exceeded
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_ESUPPLY_CAP_EXCEEDED">ESUPPLY_CAP_EXCEEDED</a>: u64 = 51;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNBACKED_MINT_CAP_EXCEEDED"></a>
+
+Unbacked mint cap is exceeded
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNBACKED_MINT_CAP_EXCEEDED">EUNBACKED_MINT_CAP_EXCEEDED</a>: u64 = 52;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNDERLYING_BALANCE_ZERO"></a>
+
+The underlying balance needs to be greater than 0
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNDERLYING_BALANCE_ZERO">EUNDERLYING_BALANCE_ZERO</a>: u64 = 43;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNDERLYING_CANNOT_BE_RESCUED"></a>
+
+The underlying asset cannot be rescued
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNDERLYING_CANNOT_BE_RESCUED">EUNDERLYING_CANNOT_BE_RESCUED</a>: u64 = 85;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO"></a>
+
+Claimable rights over underlying not zero (aToken supply or accruedToTreasury)
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO">EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO</a>: u64 = 54;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO"></a>
+
+User is in isolation mode or ltv is zero
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO">EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO</a>: u64 = 62;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUSER_NOT_LISTED"></a>
+
+User is not listed
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EUSER_NOT_LISTED">EUSER_NOT_LISTED</a>: u64 = 92;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EVARIABLE_DEBT_SUPPLY_NOT_ZERO"></a>
+
+Variable debt supply is not zero
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EVARIABLE_DEBT_SUPPLY_NOT_ZERO">EVARIABLE_DEBT_SUPPLY_NOT_ZERO</a>: u64 = 56;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EZERO_ADDRESS_NOT_VALID"></a>
+
+Zero address not valid
+
+
+<pre><code><b>const</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_EZERO_ADDRESS_NOT_VALID">EZERO_ADDRESS_NOT_VALID</a>: u64 = 77;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_admin"></a>
+
+## Function `get_ecaller_not_pool_admin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_admin">get_ecaller_not_pool_admin</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_emergency_admin"></a>
+
+## Function `get_ecaller_not_emergency_admin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_emergency_admin">get_ecaller_not_emergency_admin</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_or_emergency_admin"></a>
+
+## Function `get_ecaller_not_pool_or_emergency_admin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_or_emergency_admin">get_ecaller_not_pool_or_emergency_admin</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_risk_or_pool_admin"></a>
+
+## Function `get_ecaller_not_risk_or_pool_admin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_risk_or_pool_admin">get_ecaller_not_risk_or_pool_admin</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_asset_listing_or_pool_admin"></a>
+
+## Function `get_ecaller_not_asset_listing_or_pool_admin`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_asset_listing_or_pool_admin">get_ecaller_not_asset_listing_or_pool_admin</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_bridge"></a>
+
+## Function `get_ecaller_not_bridge`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_bridge">get_ecaller_not_bridge</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaddresses_provider_not_registered"></a>
+
+## Function `get_eaddresses_provider_not_registered`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaddresses_provider_not_registered">get_eaddresses_provider_not_registered</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_addresses_provider_id"></a>
+
+## Function `get_einvalid_addresses_provider_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_addresses_provider_id">get_einvalid_addresses_provider_id</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_enot_contract"></a>
+
+## Function `get_enot_contract`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_enot_contract">get_enot_contract</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_configurator"></a>
+
+## Function `get_ecaller_not_pool_configurator`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_pool_configurator">get_ecaller_not_pool_configurator</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_atoken"></a>
+
+## Function `get_ecaller_not_atoken`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_not_atoken">get_ecaller_not_atoken</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_addresses_provider"></a>
+
+## Function `get_einvalid_addresses_provider`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_addresses_provider">get_einvalid_addresses_provider</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_flashloan_executor_return"></a>
+
+## Function `get_einvalid_flashloan_executor_return`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_flashloan_executor_return">get_einvalid_flashloan_executor_return</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_already_added"></a>
+
+## Function `get_ereserve_already_added`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_already_added">get_ereserve_already_added</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserves_storage_count_mismatch"></a>
+
+## Function `get_ereserves_storage_count_mismatch`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserves_storage_count_mismatch">get_ereserves_storage_count_mismatch</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_more_reserves_allowed"></a>
+
+## Function `get_eno_more_reserves_allowed`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_more_reserves_allowed">get_eno_more_reserves_allowed</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eemode_category_reserved"></a>
+
+## Function `get_eemode_category_reserved`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eemode_category_reserved">get_eemode_category_reserved</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category_assignment"></a>
+
+## Function `get_einvalid_emode_category_assignment`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category_assignment">get_einvalid_emode_category_assignment</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_liquidity_not_zero"></a>
+
+## Function `get_ereserve_liquidity_not_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_liquidity_not_zero">get_ereserve_liquidity_not_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eflashloan_premium_invalid"></a>
+
+## Function `get_eflashloan_premium_invalid`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eflashloan_premium_invalid">get_eflashloan_premium_invalid</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_params"></a>
+
+## Function `get_einvalid_reserve_params`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_params">get_einvalid_reserve_params</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category_params"></a>
+
+## Function `get_einvalid_emode_category_params`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category_params">get_einvalid_emode_category_params</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ebridge_protocol_fee_invalid"></a>
+
+## Function `get_ebridge_protocol_fee_invalid`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ebridge_protocol_fee_invalid">get_ebridge_protocol_fee_invalid</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_must_be_pool"></a>
+
+## Function `get_ecaller_must_be_pool`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecaller_must_be_pool">get_ecaller_must_be_pool</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_mint_amount"></a>
+
+## Function `get_einvalid_mint_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_mint_amount">get_einvalid_mint_amount</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_burn_amount"></a>
+
+## Function `get_einvalid_burn_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_burn_amount">get_einvalid_burn_amount</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_amount"></a>
+
+## Function `get_einvalid_amount`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_amount">get_einvalid_amount</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_inactive"></a>
+
+## Function `get_ereserve_inactive`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_inactive">get_ereserve_inactive</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_frozen"></a>
+
+## Function `get_ereserve_frozen`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_frozen">get_ereserve_frozen</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_paused"></a>
+
+## Function `get_ereserve_paused`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_paused">get_ereserve_paused</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eborrowing_not_enabled"></a>
+
+## Function `get_eborrowing_not_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eborrowing_not_enabled">get_eborrowing_not_enabled</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_enot_enough_available_user_balance"></a>
+
+## Function `get_enot_enough_available_user_balance`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_enot_enough_available_user_balance">get_enot_enough_available_user_balance</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_interest_rate_mode_selected"></a>
+
+## Function `get_einvalid_interest_rate_mode_selected`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_interest_rate_mode_selected">get_einvalid_interest_rate_mode_selected</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_balance_is_zero"></a>
+
+## Function `get_ecollateral_balance_is_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_balance_is_zero">get_ecollateral_balance_is_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ehealth_factor_lower_than_liquidation_threshold"></a>
+
+## Function `get_ehealth_factor_lower_than_liquidation_threshold`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ehealth_factor_lower_than_liquidation_threshold">get_ehealth_factor_lower_than_liquidation_threshold</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_cannot_cover_new_borrow"></a>
+
+## Function `get_ecollateral_cannot_cover_new_borrow`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_cannot_cover_new_borrow">get_ecollateral_cannot_cover_new_borrow</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_same_as_borrowing_currency"></a>
+
+## Function `get_ecollateral_same_as_borrowing_currency`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_same_as_borrowing_currency">get_ecollateral_same_as_borrowing_currency</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_debt_of_selected_type"></a>
+
+## Function `get_eno_debt_of_selected_type`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_debt_of_selected_type">get_eno_debt_of_selected_type</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_explicit_amount_to_repay_on_behalf"></a>
+
+## Function `get_eno_explicit_amount_to_repay_on_behalf`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_explicit_amount_to_repay_on_behalf">get_eno_explicit_amount_to_repay_on_behalf</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_outstanding_variable_debt"></a>
+
+## Function `get_eno_outstanding_variable_debt`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eno_outstanding_variable_debt">get_eno_outstanding_variable_debt</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_balance_zero"></a>
+
+## Function `get_eunderlying_balance_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_balance_zero">get_eunderlying_balance_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einterest_rate_rebalance_conditions_not_met"></a>
+
+## Function `get_einterest_rate_rebalance_conditions_not_met`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einterest_rate_rebalance_conditions_not_met">get_einterest_rate_rebalance_conditions_not_met</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ehealth_factor_not_below_threshold"></a>
+
+## Function `get_ehealth_factor_not_below_threshold`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ehealth_factor_not_below_threshold">get_ehealth_factor_not_below_threshold</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_cannot_be_liquidated"></a>
+
+## Function `get_ecollateral_cannot_be_liquidated`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ecollateral_cannot_be_liquidated">get_ecollateral_cannot_be_liquidated</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_especified_currency_not_borrowed_by_user"></a>
+
+## Function `get_especified_currency_not_borrowed_by_user`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_especified_currency_not_borrowed_by_user">get_especified_currency_not_borrowed_by_user</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_flashloan_params"></a>
+
+## Function `get_einconsistent_flashloan_params`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_flashloan_params">get_einconsistent_flashloan_params</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eborrow_cap_exceeded"></a>
+
+## Function `get_eborrow_cap_exceeded`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eborrow_cap_exceeded">get_eborrow_cap_exceeded</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esupply_cap_exceeded"></a>
+
+## Function `get_esupply_cap_exceeded`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esupply_cap_exceeded">get_esupply_cap_exceeded</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunbacked_mint_cap_exceeded"></a>
+
+## Function `get_eunbacked_mint_cap_exceeded`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunbacked_mint_cap_exceeded">get_eunbacked_mint_cap_exceeded</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_edebt_ceiling_exceeded"></a>
+
+## Function `get_edebt_ceiling_exceeded`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_edebt_ceiling_exceeded">get_edebt_ceiling_exceeded</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_claimable_rights_not_zero"></a>
+
+## Function `get_eunderlying_claimable_rights_not_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_claimable_rights_not_zero">get_eunderlying_claimable_rights_not_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_evariable_debt_supply_not_zero"></a>
+
+## Function `get_evariable_debt_supply_not_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_evariable_debt_supply_not_zero">get_evariable_debt_supply_not_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eltv_validation_failed"></a>
+
+## Function `get_eltv_validation_failed`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eltv_validation_failed">get_eltv_validation_failed</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_emode_category"></a>
+
+## Function `get_einconsistent_emode_category`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_emode_category">get_einconsistent_emode_category</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eprice_oracle_sentinel_check_failed"></a>
+
+## Function `get_eprice_oracle_sentinel_check_failed`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eprice_oracle_sentinel_check_failed">get_eprice_oracle_sentinel_check_failed</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_easset_not_borrowable_in_isolation"></a>
+
+## Function `get_easset_not_borrowable_in_isolation`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_easset_not_borrowable_in_isolation">get_easset_not_borrowable_in_isolation</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_already_initialized"></a>
+
+## Function `get_ereserve_already_initialized`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_already_initialized">get_ereserve_already_initialized</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_euser_in_isolation_mode_or_ltv_zero"></a>
+
+## Function `get_euser_in_isolation_mode_or_ltv_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_euser_in_isolation_mode_or_ltv_zero">get_euser_in_isolation_mode_or_ltv_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_ltv"></a>
+
+## Function `get_einvalid_ltv`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_ltv">get_einvalid_ltv</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liq_threshold"></a>
+
+## Function `get_einvalid_liq_threshold`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liq_threshold">get_einvalid_liq_threshold</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liq_bonus"></a>
+
+## Function `get_einvalid_liq_bonus`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liq_bonus">get_einvalid_liq_bonus</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_decimals"></a>
+
+## Function `get_einvalid_decimals`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_decimals">get_einvalid_decimals</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_factor"></a>
+
+## Function `get_einvalid_reserve_factor`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_factor">get_einvalid_reserve_factor</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_borrow_cap"></a>
+
+## Function `get_einvalid_borrow_cap`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_borrow_cap">get_einvalid_borrow_cap</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_supply_cap"></a>
+
+## Function `get_einvalid_supply_cap`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_supply_cap">get_einvalid_supply_cap</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liquidation_protocol_fee"></a>
+
+## Function `get_einvalid_liquidation_protocol_fee`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_liquidation_protocol_fee">get_einvalid_liquidation_protocol_fee</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category"></a>
+
+## Function `get_einvalid_emode_category`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_emode_category">get_einvalid_emode_category</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_unbacked_mint_cap"></a>
+
+## Function `get_einvalid_unbacked_mint_cap`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_unbacked_mint_cap">get_einvalid_unbacked_mint_cap</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_debt_ceiling"></a>
+
+## Function `get_einvalid_debt_ceiling`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_debt_ceiling">get_einvalid_debt_ceiling</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_index"></a>
+
+## Function `get_einvalid_reserve_index`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_reserve_index">get_einvalid_reserve_index</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eacl_admin_cannot_be_zero"></a>
+
+## Function `get_eacl_admin_cannot_be_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eacl_admin_cannot_be_zero">get_eacl_admin_cannot_be_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_params_length"></a>
+
+## Function `get_einconsistent_params_length`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einconsistent_params_length">get_einconsistent_params_length</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ezero_address_not_valid"></a>
+
+## Function `get_ezero_address_not_valid`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ezero_address_not_valid">get_ezero_address_not_valid</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_expiration"></a>
+
+## Function `get_einvalid_expiration`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_expiration">get_einvalid_expiration</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_signature"></a>
+
+## Function `get_einvalid_signature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_signature">get_einvalid_signature</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eoperation_not_supported"></a>
+
+## Function `get_eoperation_not_supported`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eoperation_not_supported">get_eoperation_not_supported</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_edebt_ceiling_not_zero"></a>
+
+## Function `get_edebt_ceiling_not_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_edebt_ceiling_not_zero">get_edebt_ceiling_not_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_easset_not_listed"></a>
+
+## Function `get_easset_not_listed`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_easset_not_listed">get_easset_not_listed</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_optimal_usage_ratio"></a>
+
+## Function `get_einvalid_optimal_usage_ratio`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_einvalid_optimal_usage_ratio">get_einvalid_optimal_usage_ratio</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_cannot_be_rescued"></a>
+
+## Function `get_eunderlying_cannot_be_rescued`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eunderlying_cannot_be_rescued">get_eunderlying_cannot_be_rescued</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaddresses_provider_already_added"></a>
+
+## Function `get_eaddresses_provider_already_added`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaddresses_provider_already_added">get_eaddresses_provider_already_added</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_epool_addresses_do_not_match"></a>
+
+## Function `get_epool_addresses_do_not_match`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_epool_addresses_do_not_match">get_epool_addresses_do_not_match</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esiloed_borrowing_violation"></a>
+
+## Function `get_esiloed_borrowing_violation`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esiloed_borrowing_violation">get_esiloed_borrowing_violation</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_debt_not_zero"></a>
+
+## Function `get_ereserve_debt_not_zero`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_ereserve_debt_not_zero">get_ereserve_debt_not_zero</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eflashloan_disabled"></a>
+
+## Function `get_eflashloan_disabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eflashloan_disabled">get_eflashloan_disabled</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_euser_not_listed"></a>
+
+## Function `get_euser_not_listed`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_euser_not_listed">get_euser_not_listed</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esigner_and_on_behalf_of_no_same"></a>
+
+## Function `get_esigner_and_on_behalf_of_no_same`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_esigner_and_on_behalf_of_no_same">get_esigner_and_on_behalf_of_no_same</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaccount_does_not_exist"></a>
+
+## Function `get_eaccount_does_not_exist`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_eaccount_does_not_exist">get_eaccount_does_not_exist</a>(): u64
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_flashloan_payer_not_receiver"></a>
+
+## Function `get_flashloan_payer_not_receiver`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error_get_flashloan_payer_not_receiver">get_flashloan_payer_not_receiver</a>(): u64
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-config/doc/helper.md
+++ b/tests/aptos-aave-v3/aave-core/aave-config/doc/helper.md
@@ -1,0 +1,23 @@
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_helper"></a>
+
+# Module `0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::helper`
+
+
+
+-  [Function `bitwise_negation`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_helper_bitwise_negation)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_helper_bitwise_negation"></a>
+
+## Function `bitwise_negation`
+
+Get the result of bitwise negation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="helper.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_helper_bitwise_negation">bitwise_negation</a>(m: u256): u256
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-config/doc/reserve_config.md
+++ b/tests/aptos-aave-v3/aave-core/aave-config/doc/reserve_config.md
@@ -1,0 +1,1109 @@
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve"></a>
+
+# Module `0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::reserve`
+
+@title ReserveConfiguration module
+@author Aave
+@notice Implements the bitmap logic to handle the reserve configuration
+
+
+-  [Resource `ReserveConfigurationMap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap)
+-  [Constants](#@Constants_0)
+-  [Function `init`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_init)
+-  [Function `set_ltv`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_ltv)
+-  [Function `get_ltv`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_ltv)
+-  [Function `set_liquidation_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_threshold)
+-  [Function `get_liquidation_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_threshold)
+-  [Function `set_liquidation_bonus`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_bonus)
+-  [Function `get_liquidation_bonus`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_bonus)
+-  [Function `set_decimals`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_decimals)
+-  [Function `get_decimals`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_decimals)
+-  [Function `set_active`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_active)
+-  [Function `get_active`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_active)
+-  [Function `set_frozen`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_frozen)
+-  [Function `get_frozen`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_frozen)
+-  [Function `set_paused`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_paused)
+-  [Function `get_paused`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_paused)
+-  [Function `set_borrowable_in_isolation`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrowable_in_isolation)
+-  [Function `get_borrowable_in_isolation`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrowable_in_isolation)
+-  [Function `set_siloed_borrowing`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_siloed_borrowing)
+-  [Function `get_siloed_borrowing`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_siloed_borrowing)
+-  [Function `set_borrowing_enabled`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrowing_enabled)
+-  [Function `get_borrowing_enabled`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrowing_enabled)
+-  [Function `set_reserve_factor`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_reserve_factor)
+-  [Function `get_reserve_factor`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_reserve_factor)
+-  [Function `set_borrow_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrow_cap)
+-  [Function `get_borrow_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrow_cap)
+-  [Function `set_supply_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_supply_cap)
+-  [Function `get_supply_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_supply_cap)
+-  [Function `set_debt_ceiling`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_debt_ceiling)
+-  [Function `get_debt_ceiling`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_debt_ceiling)
+-  [Function `set_liquidation_protocol_fee`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_protocol_fee)
+-  [Function `get_liquidation_protocol_fee`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_protocol_fee)
+-  [Function `set_unbacked_mint_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_unbacked_mint_cap)
+-  [Function `get_unbacked_mint_cap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_unbacked_mint_cap)
+-  [Function `set_emode_category`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_emode_category)
+-  [Function `get_emode_category`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_emode_category)
+-  [Function `set_flash_loan_enabled`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_flash_loan_enabled)
+-  [Function `get_flash_loan_enabled`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_flash_loan_enabled)
+-  [Function `get_flags`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_flags)
+-  [Function `get_params`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_params)
+-  [Function `get_caps`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_caps)
+-  [Function `get_debt_ceiling_decimals`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_debt_ceiling_decimals)
+-  [Function `get_max_reserves_count`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_max_reserves_count)
+
+
+<pre><code><b>use</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error">0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::error</a>;
+<b>use</b> <a href="helper.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_helper">0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::helper</a>;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap"></a>
+
+## Resource `ReserveConfigurationMap`
+
+
+
+<pre><code><b>struct</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">ReserveConfigurationMap</a> <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ACTIVE_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ACTIVE_MASK">ACTIVE_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457511950319091711999;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWABLE_IN_ISOLATION_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWABLE_IN_ISOLATION_MASK">BORROWABLE_IN_ISOLATION_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039455278164903915945983;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWABLE_IN_ISOLATION_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWABLE_IN_ISOLATION_START_BIT_POSITION">BORROWABLE_IN_ISOLATION_START_BIT_POSITION</a>: u256 = 61;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWING_ENABLED_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWING_ENABLED_START_BIT_POSITION">BORROWING_ENABLED_START_BIT_POSITION</a>: u256 = 58;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWING_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROWING_MASK">BORROWING_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457295777536977928191;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROW_CAP_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROW_CAP_MASK">BORROW_CAP_MASK</a>: u256 = 115792089237316195423570985008687907853269901588890828691141347134601036824575;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROW_CAP_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_BORROW_CAP_START_BIT_POSITION">BORROW_CAP_START_BIT_POSITION</a>: u256 = 80;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DEBT_CEILING_DECIMALS"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DEBT_CEILING_DECIMALS">DEBT_CEILING_DECIMALS</a>: u256 = 2;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DEBT_CEILING_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DEBT_CEILING_MASK">DEBT_CEILING_MASK</a>: u256 = 108555083659990515227827083269813533489170840026057959730454019326871953473535;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DEBT_CEILING_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DEBT_CEILING_START_BIT_POSITION">DEBT_CEILING_START_BIT_POSITION</a>: u256 = 212;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DECIMALS_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_DECIMALS_MASK">DECIMALS_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457512231794068422655;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_EMODE_CATEGORY_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_EMODE_CATEGORY_MASK">EMODE_CATEGORY_MASK</a>: u256 = 115792089237316195423570889601861022891927484329094684320502060868636724166655;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_EMODE_CATEGORY_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_EMODE_CATEGORY_START_BIT_POSITION">EMODE_CATEGORY_START_BIT_POSITION</a>: u256 = 168;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_FLASHLOAN_ENABLED_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_FLASHLOAN_ENABLED_MASK">FLASHLOAN_ENABLED_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039448360635876274864127;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_FLASHLOAN_ENABLED_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_FLASHLOAN_ENABLED_START_BIT_POSITION">FLASHLOAN_ENABLED_START_BIT_POSITION</a>: u256 = 63;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_FROZEN_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_FROZEN_MASK">FROZEN_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457439892725053784063;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_IS_ACTIVE_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_IS_ACTIVE_START_BIT_POSITION">IS_ACTIVE_START_BIT_POSITION</a>: u256 = 56;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_IS_FROZEN_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_IS_FROZEN_START_BIT_POSITION">IS_FROZEN_START_BIT_POSITION</a>: u256 = 57;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_IS_PAUSED_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_IS_PAUSED_START_BIT_POSITION">IS_PAUSED_START_BIT_POSITION</a>: u256 = 60;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_BONUS_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_BONUS_MASK">LIQUIDATION_BONUS_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457583726442447896575;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_BONUS_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_BONUS_START_BIT_POSITION">LIQUIDATION_BONUS_START_BIT_POSITION</a>: u256 = 32;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_PROTOCOL_FEE_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_PROTOCOL_FEE_MASK">LIQUIDATION_PROTOCOL_FEE_MASK</a>: u256 = 115792089237316195423570984634549197687329661445021480007966928956539929624575;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_PROTOCOL_FEE_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_PROTOCOL_FEE_START_BIT_POSITION">LIQUIDATION_PROTOCOL_FEE_START_BIT_POSITION</a>: u256 = 152;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_THRESHOLD_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_THRESHOLD_MASK">LIQUIDATION_THRESHOLD_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457584007908834738175;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_THRESHOLD_START_BIT_POSITION"></a>
+
+@dev For the LTV, the start bit is 0 (up to 15), hence no bitshifting is needed
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LIQUIDATION_THRESHOLD_START_BIT_POSITION">LIQUIDATION_THRESHOLD_START_BIT_POSITION</a>: u256 = 16;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LTV_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_LTV_MASK">LTV_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129574400;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_RESERVES_COUNT"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_RESERVES_COUNT">MAX_RESERVES_COUNT</a>: u16 = 128;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_BORROW_CAP"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_BORROW_CAP">MAX_VALID_BORROW_CAP</a>: u256 = 68719476735;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_DEBT_CEILING"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_DEBT_CEILING">MAX_VALID_DEBT_CEILING</a>: u256 = 1099511627775;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_DECIMALS"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_DECIMALS">MAX_VALID_DECIMALS</a>: u256 = 255;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_EMODE_CATEGORY"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_EMODE_CATEGORY">MAX_VALID_EMODE_CATEGORY</a>: u256 = 255;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LIQUIDATION_BONUS"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LIQUIDATION_BONUS">MAX_VALID_LIQUIDATION_BONUS</a>: u256 = 65535;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LIQUIDATION_PROTOCOL_FEE"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LIQUIDATION_PROTOCOL_FEE">MAX_VALID_LIQUIDATION_PROTOCOL_FEE</a>: u256 = 65535;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LIQUIDATION_THRESHOLD"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LIQUIDATION_THRESHOLD">MAX_VALID_LIQUIDATION_THRESHOLD</a>: u256 = 65535;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LTV"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_LTV">MAX_VALID_LTV</a>: u256 = 65535;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_RESERVE_FACTOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_RESERVE_FACTOR">MAX_VALID_RESERVE_FACTOR</a>: u256 = 65535;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_SUPPLY_CAP"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_SUPPLY_CAP">MAX_VALID_SUPPLY_CAP</a>: u256 = 68719476735;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_UNBACKED_MINT_CAP"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_MAX_VALID_UNBACKED_MINT_CAP">MAX_VALID_UNBACKED_MINT_CAP</a>: u256 = 68719476735;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_PAUSED_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_PAUSED_MASK">PAUSED_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039456431086408522792959;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_RESERVE_DECIMALS_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_RESERVE_DECIMALS_START_BIT_POSITION">RESERVE_DECIMALS_START_BIT_POSITION</a>: u256 = 48;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_RESERVE_FACTOR_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_RESERVE_FACTOR_MASK">RESERVE_FACTOR_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640562830550211137357664485375;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_RESERVE_FACTOR_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_RESERVE_FACTOR_START_BIT_POSITION">RESERVE_FACTOR_START_BIT_POSITION</a>: u256 = 64;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SILOED_BORROWING_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SILOED_BORROWING_MASK">SILOED_BORROWING_MASK</a>: u256 = 115792089237316195423570985008687907853269984665640564039452972321894702252031;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SILOED_BORROWING_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SILOED_BORROWING_START_BIT_POSITION">SILOED_BORROWING_START_BIT_POSITION</a>: u256 = 62;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SUPPLY_CAP_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SUPPLY_CAP_MASK">SUPPLY_CAP_MASK</a>: u256 = 115792089237316195423570985008682198862499243902866067452821842515308866174975;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SUPPLY_CAP_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_SUPPLY_CAP_START_BIT_POSITION">SUPPLY_CAP_START_BIT_POSITION</a>: u256 = 116;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_UNBACKED_MINT_CAP_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_UNBACKED_MINT_CAP_MASK">UNBACKED_MINT_CAP_MASK</a>: u256 = 115792089237309613405341795965490592094593402660309829990319025859654871678975;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_UNBACKED_MINT_CAP_START_BIT_POSITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_UNBACKED_MINT_CAP_START_BIT_POSITION">UNBACKED_MINT_CAP_START_BIT_POSITION</a>: u256 = 176;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_init"></a>
+
+## Function `init`
+
+@notice init the reserve configuration
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_init">init</a>(): <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_ltv"></a>
+
+## Function `set_ltv`
+
+@notice Sets the Loan to Value of the reserve
+@param self The reserve configuration
+@param ltv The new ltv
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_ltv">set_ltv</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, ltv: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_ltv"></a>
+
+## Function `get_ltv`
+
+@notice Gets the Loan to Value of the reserve
+@param self The reserve configuration
+@return The loan to value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_ltv">get_ltv</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_threshold"></a>
+
+## Function `set_liquidation_threshold`
+
+@notice Sets the liquidation threshold of the reserve
+@param self The reserve configuration
+@param liquidation_threshold The new liquidation threshold
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_threshold">set_liquidation_threshold</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, liquidation_threshold: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_threshold"></a>
+
+## Function `get_liquidation_threshold`
+
+@notice Gets the liquidation threshold of the reserve
+@param self The reserve configuration
+@return The liquidation threshold
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_threshold">get_liquidation_threshold</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_bonus"></a>
+
+## Function `set_liquidation_bonus`
+
+@notice Sets the liquidation bonus of the reserve
+@param self The reserve configuration
+@param liquidation_bonus The new liquidation bonus
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_bonus">set_liquidation_bonus</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, liquidation_bonus: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_bonus"></a>
+
+## Function `get_liquidation_bonus`
+
+@notice Gets the liquidation bonus of the reserve
+@param self The reserve configuration
+@return The liquidation bonus
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_bonus">get_liquidation_bonus</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_decimals"></a>
+
+## Function `set_decimals`
+
+@notice Sets the decimals of the underlying asset of the reserve
+@param self The reserve configuration
+@param decimals The decimals
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_decimals">set_decimals</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, decimals: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_decimals"></a>
+
+## Function `get_decimals`
+
+@notice Gets the decimals of the underlying asset of the reserve
+@param self The reserve configuration
+@return The decimals
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_decimals">get_decimals</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_active"></a>
+
+## Function `set_active`
+
+@notice Sets the active state of the reserve
+@param self The reserve configuration
+@param active The new active state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_active">set_active</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, active: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_active"></a>
+
+## Function `get_active`
+
+@notice Gets the active state of the reserve
+@param self The reserve configuration
+@return The active state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_active">get_active</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_frozen"></a>
+
+## Function `set_frozen`
+
+@notice Sets the frozen state of the reserve
+@param self The reserve configuration
+@param frozen The new frozen state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_frozen">set_frozen</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, frozen: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_frozen"></a>
+
+## Function `get_frozen`
+
+@notice Gets the frozen state of the reserve
+@param self The reserve configuration
+@return The frozen state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_frozen">get_frozen</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_paused"></a>
+
+## Function `set_paused`
+
+@notice Sets the paused state of the reserve
+@param self The reserve configuration
+@param paused The new paused state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_paused">set_paused</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, paused: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_paused"></a>
+
+## Function `get_paused`
+
+@notice Gets the paused state of the reserve
+@param self The reserve configuration
+@return The paused state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_paused">get_paused</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrowable_in_isolation"></a>
+
+## Function `set_borrowable_in_isolation`
+
+@notice Sets the borrowing in isolation state of the reserve
+@dev When this flag is set to true, the asset will be borrowable against isolated collaterals and the borrowed
+amount will be accumulated in the isolated collateral's total debt exposure.
+@dev Only assets of the same family (eg USD stablecoins) should be borrowable in isolation mode to keep
+consistency in the debt ceiling calculations.
+@param self The reserve configuration
+@param borrowable The new borrowing in isolation state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrowable_in_isolation">set_borrowable_in_isolation</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, borrowable: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrowable_in_isolation"></a>
+
+## Function `get_borrowable_in_isolation`
+
+@notice Gets the borrowable in isolation flag for the reserve.
+@dev If the returned flag is true, the asset is borrowable against isolated collateral. Assets borrowed with
+isolated collateral is accounted for in the isolated collateral's total debt exposure.
+@dev Only assets of the same family (eg USD stablecoins) should be borrowable in isolation mode to keep
+consistency in the debt ceiling calculations.
+@param self The reserve configuration
+@return The borrowable in isolation flag
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrowable_in_isolation">get_borrowable_in_isolation</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_siloed_borrowing"></a>
+
+## Function `set_siloed_borrowing`
+
+@notice Sets the siloed borrowing flag for the reserve.
+@dev When this flag is set to true, users borrowing this asset will not be allowed to borrow any other asset.
+@param self The reserve configuration
+@param siloed_borrowing True if the asset is siloed
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_siloed_borrowing">set_siloed_borrowing</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, siloed_borrowing: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_siloed_borrowing"></a>
+
+## Function `get_siloed_borrowing`
+
+@notice Gets the siloed borrowing flag for the reserve.
+@dev When this flag is set to true, users borrowing this asset will not be allowed to borrow any other asset.
+@param self The reserve configuration
+@return The siloed borrowing flag
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_siloed_borrowing">get_siloed_borrowing</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrowing_enabled"></a>
+
+## Function `set_borrowing_enabled`
+
+@notice Enables or disables borrowing on the reserve
+@param self The reserve configuration
+@param borrowing_enabled True if the borrowing needs to be enabled, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrowing_enabled">set_borrowing_enabled</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, borrowing_enabled: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrowing_enabled"></a>
+
+## Function `get_borrowing_enabled`
+
+@notice Gets the borrowing state of the reserve
+@param self The reserve configuration
+@return The borrowing state
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrowing_enabled">get_borrowing_enabled</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_reserve_factor"></a>
+
+## Function `set_reserve_factor`
+
+@notice Sets the reserve factor of the reserve
+@param self The reserve configuration
+@param reserve_factor The reserve factor
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_reserve_factor">set_reserve_factor</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, reserve_factor: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_reserve_factor"></a>
+
+## Function `get_reserve_factor`
+
+@notice Gets the reserve factor of the reserve
+@param self The reserve configuration
+@return The reserve factor
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_reserve_factor">get_reserve_factor</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrow_cap"></a>
+
+## Function `set_borrow_cap`
+
+@notice Sets the borrow cap of the reserve
+@param self The reserve configuration
+@param borrow_cap The borrow cap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_borrow_cap">set_borrow_cap</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, borrow_cap: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrow_cap"></a>
+
+## Function `get_borrow_cap`
+
+@notice Gets the borrow cap of the reserve
+@param self The reserve configuration
+@return The borrow cap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_borrow_cap">get_borrow_cap</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_supply_cap"></a>
+
+## Function `set_supply_cap`
+
+@notice Sets the supply cap of the reserve
+@param self The reserve configuration
+@param supply_cap The supply cap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_supply_cap">set_supply_cap</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, supply_cap: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_supply_cap"></a>
+
+## Function `get_supply_cap`
+
+@notice Gets the supply cap of the reserve
+@param self The reserve configuration
+@return The supply cap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_supply_cap">get_supply_cap</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_debt_ceiling"></a>
+
+## Function `set_debt_ceiling`
+
+@notice Sets the debt ceiling in isolation mode for the asset
+@param self The reserve configuration
+@param debt_ceiling The maximum debt ceiling for the asset
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_debt_ceiling">set_debt_ceiling</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, debt_ceiling: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_debt_ceiling"></a>
+
+## Function `get_debt_ceiling`
+
+@notice Gets the debt ceiling for the asset if the asset is in isolation mode
+@param self The reserve configuration
+@return The debt ceiling (0 = isolation mode disabled)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_debt_ceiling">get_debt_ceiling</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_protocol_fee"></a>
+
+## Function `set_liquidation_protocol_fee`
+
+@notice Sets the liquidation protocol fee of the reserve
+@param self The reserve configuration
+@param liquidation_protocol_fee The liquidation protocol fee
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_liquidation_protocol_fee">set_liquidation_protocol_fee</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, liquidation_protocol_fee: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_protocol_fee"></a>
+
+## Function `get_liquidation_protocol_fee`
+
+@dev Gets the liquidation protocol fee
+@param self The reserve configuration
+@return The liquidation protocol fee
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_liquidation_protocol_fee">get_liquidation_protocol_fee</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_unbacked_mint_cap"></a>
+
+## Function `set_unbacked_mint_cap`
+
+@notice Sets the unbacked mint cap of the reserve
+@param self The reserve configuration
+@param unbacked_mint_cap The unbacked mint cap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_unbacked_mint_cap">set_unbacked_mint_cap</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, unbacked_mint_cap: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_unbacked_mint_cap"></a>
+
+## Function `get_unbacked_mint_cap`
+
+@dev Gets the unbacked mint cap of the reserve
+@param self The reserve configuration
+@return The unbacked mint cap
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_unbacked_mint_cap">get_unbacked_mint_cap</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_emode_category"></a>
+
+## Function `set_emode_category`
+
+@notice Sets the eMode asset category
+@param self The reserve configuration
+@param emode_category The asset category when the user selects the eMode
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_emode_category">set_emode_category</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, emode_category: u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_emode_category"></a>
+
+## Function `get_emode_category`
+
+@dev Gets the eMode asset category
+@param self The reserve configuration
+@return The eMode category for the asset
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_emode_category">get_emode_category</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_flash_loan_enabled"></a>
+
+## Function `set_flash_loan_enabled`
+
+@notice Sets the flashloanable flag for the reserve
+@param self The reserve configuration
+@param flash_loan_enabled True if the asset is flashloanable, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_set_flash_loan_enabled">set_flash_loan_enabled</a>(self: &<b>mut</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>, flash_loan_enabled: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_flash_loan_enabled"></a>
+
+## Function `get_flash_loan_enabled`
+
+@notice Gets the flashloanable flag for the reserve
+@param self The reserve configuration
+@return The flashloanable flag
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_flash_loan_enabled">get_flash_loan_enabled</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_flags"></a>
+
+## Function `get_flags`
+
+@notice Gets the configuration flags of the reserve
+@param self The reserve configuration
+@return The state flag representing active
+@return The state flag representing frozen
+@return The state flag representing borrowing enabled
+@return The state flag representing paused
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_flags">get_flags</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): (bool, bool, bool, bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_params"></a>
+
+## Function `get_params`
+
+@notice Gets the configuration parameters of the reserve from storage
+@param self The reserve configuration
+@return The state param representing ltv
+@return The state param representing liquidation threshold
+@return The state param representing liquidation bonus
+@return The state param representing reserve decimals
+@return The state param representing reserve factor
+@return The state param representing eMode category
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_params">get_params</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): (u256, u256, u256, u256, u256, u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_caps"></a>
+
+## Function `get_caps`
+
+@notice Gets the caps parameters of the reserve from storage
+@param self The reserve configuration
+@return The state param representing borrow cap
+@return The state param representing supply cap.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_caps">get_caps</a>(self: &<a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_ReserveConfigurationMap">reserve::ReserveConfigurationMap</a>): (u256, u256)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_debt_ceiling_decimals"></a>
+
+## Function `get_debt_ceiling_decimals`
+
+@notice Gets the debt ceiling decimals
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_debt_ceiling_decimals">get_debt_ceiling_decimals</a>(): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_max_reserves_count"></a>
+
+## Function `get_max_reserves_count`
+
+@notice Gets the maximum number of reserves
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve_get_max_reserves_count">get_max_reserves_count</a>(): u16
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-config/doc/user_config.md
+++ b/tests/aptos-aave-v3/aave-core/aave-config/doc/user_config.md
@@ -1,0 +1,374 @@
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user"></a>
+
+# Module `0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::user`
+
+@title UserConfiguration library
+@author Aave
+@notice Implements the bitmap logic to handle the user configuration
+
+
+-  [Resource `UserConfigurationMap`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap)
+-  [Constants](#@Constants_0)
+-  [Function `init`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_init)
+-  [Function `get_interest_rate_mode_none`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_interest_rate_mode_none)
+-  [Function `get_interest_rate_mode_variable`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_interest_rate_mode_variable)
+-  [Function `get_borrowing_mask`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_borrowing_mask)
+-  [Function `get_collateral_mask`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_collateral_mask)
+-  [Function `get_minimum_health_factor_liquidation_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_minimum_health_factor_liquidation_threshold)
+-  [Function `get_health_factor_liquidation_threshold`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_health_factor_liquidation_threshold)
+-  [Function `get_isolated_collateral_supplier_role`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_isolated_collateral_supplier_role)
+-  [Function `set_borrowing`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_set_borrowing)
+-  [Function `set_using_as_collateral`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_set_using_as_collateral)
+-  [Function `is_using_as_collateral_or_borrowing`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_or_borrowing)
+-  [Function `is_borrowing`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing)
+-  [Function `is_using_as_collateral`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral)
+-  [Function `is_using_as_collateral_one`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_one)
+-  [Function `is_using_as_collateral_any`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_any)
+-  [Function `is_borrowing_one`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing_one)
+-  [Function `is_borrowing_any`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing_any)
+-  [Function `is_empty`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_empty)
+-  [Function `get_first_asset_id_by_mask`](#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_first_asset_id_by_mask)
+
+
+<pre><code><b>use</b> <a href="error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error">0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::error</a>;
+<b>use</b> <a href="helper.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_helper">0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::helper</a>;
+<b>use</b> <a href="reserve_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_reserve">0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::reserve</a>;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap"></a>
+
+## Resource `UserConfigurationMap`
+
+
+
+<pre><code><b>struct</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">UserConfigurationMap</a> <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_BORROWING_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_BORROWING_MASK">BORROWING_MASK</a>: u256 = 38597363079105398474523661669562635951089994888546854679819194669304376546645;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_COLLATERAL_MASK"></a>
+
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_COLLATERAL_MASK">COLLATERAL_MASK</a>: u256 = 77194726158210796949047323339125271902179989777093709359638389338608753093290;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_HEALTH_FACTOR_LIQUIDATION_THRESHOLD"></a>
+
+@dev Minimum health factor to consider a user position healthy
+A value of 1e18 results in 1
+1 * 10 ** 18
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_HEALTH_FACTOR_LIQUIDATION_THRESHOLD">HEALTH_FACTOR_LIQUIDATION_THRESHOLD</a>: u256 = 1000000000000000000;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_INTEREST_RATE_MODE_NONE"></a>
+
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_INTEREST_RATE_MODE_NONE">INTEREST_RATE_MODE_NONE</a>: u8 = 0;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_INTEREST_RATE_MODE_VARIABLE"></a>
+
+1 = Stable Rate, 2 = Variable Rate, Since the Stable Rate service has been removed, only the Variable Rate service is retained.
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_INTEREST_RATE_MODE_VARIABLE">INTEREST_RATE_MODE_VARIABLE</a>: u8 = 2;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_ISOLATED_COLLATERAL_SUPPLIER_ROLE"></a>
+
+@dev Role identifier for the role allowed to supply isolated reserves as collateral
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_ISOLATED_COLLATERAL_SUPPLIER_ROLE">ISOLATED_COLLATERAL_SUPPLIER_ROLE</a>: <a href="">vector</a>&lt;u8&gt; = [73, 83, 79, 76, 65, 84, 69, 68, 95, 67, 79, 76, 76, 65, 84, 69, 82, 65, 76, 95, 83, 85, 80, 80, 76, 73, 69, 82];
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_MINIMUM_HEALTH_FACTOR_LIQUIDATION_THRESHOLD"></a>
+
+Minimum health factor allowed under any circumstance
+A value of 0.95e18 results in 0.95
+0.95 * 10 ** 18
+
+
+<pre><code><b>const</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_MINIMUM_HEALTH_FACTOR_LIQUIDATION_THRESHOLD">MINIMUM_HEALTH_FACTOR_LIQUIDATION_THRESHOLD</a>: u256 = 950000000000000000;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_init"></a>
+
+## Function `init`
+
+@notice Initializes the user configuration map
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_init">init</a>(): <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_interest_rate_mode_none"></a>
+
+## Function `get_interest_rate_mode_none`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_interest_rate_mode_none">get_interest_rate_mode_none</a>(): u8
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_interest_rate_mode_variable"></a>
+
+## Function `get_interest_rate_mode_variable`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_interest_rate_mode_variable">get_interest_rate_mode_variable</a>(): u8
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_borrowing_mask"></a>
+
+## Function `get_borrowing_mask`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_borrowing_mask">get_borrowing_mask</a>(): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_collateral_mask"></a>
+
+## Function `get_collateral_mask`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_collateral_mask">get_collateral_mask</a>(): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_minimum_health_factor_liquidation_threshold"></a>
+
+## Function `get_minimum_health_factor_liquidation_threshold`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_minimum_health_factor_liquidation_threshold">get_minimum_health_factor_liquidation_threshold</a>(): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_health_factor_liquidation_threshold"></a>
+
+## Function `get_health_factor_liquidation_threshold`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_health_factor_liquidation_threshold">get_health_factor_liquidation_threshold</a>(): u256
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_isolated_collateral_supplier_role"></a>
+
+## Function `get_isolated_collateral_supplier_role`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_isolated_collateral_supplier_role">get_isolated_collateral_supplier_role</a>(): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_set_borrowing"></a>
+
+## Function `set_borrowing`
+
+@notice Sets if the user is borrowing the reserve identified by reserve_index
+@param self The configuration object
+@param reserve_index The index of the reserve in the bitmap
+@param borrowing True if the user is borrowing the reserve, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_set_borrowing">set_borrowing</a>(self: &<b>mut</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>, reserve_index: u256, borrowing: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_set_using_as_collateral"></a>
+
+## Function `set_using_as_collateral`
+
+@notice Sets if the user is using as collateral the reserve identified by reserve_index
+@param self The configuration object
+@param reserve_index The index of the reserve in the bitmap
+@param using_as_collateral True if the user is using the reserve as collateral, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_set_using_as_collateral">set_using_as_collateral</a>(self: &<b>mut</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>, reserve_index: u256, using_as_collateral: bool)
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_or_borrowing"></a>
+
+## Function `is_using_as_collateral_or_borrowing`
+
+@notice Returns if a user has been using the reserve for borrowing or as collateral
+@param self The configuration object
+@param reserve_index The index of the reserve in the bitmap
+@return True if the user has been using a reserve for borrowing or as collateral, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_or_borrowing">is_using_as_collateral_or_borrowing</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>, reserve_index: u256): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing"></a>
+
+## Function `is_borrowing`
+
+@notice Validate a user has been using the reserve for borrowing
+@param self The configuration object
+@param reserve_index The index of the reserve in the bitmap
+@return True if the user has been using a reserve for borrowing, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing">is_borrowing</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>, reserve_index: u256): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral"></a>
+
+## Function `is_using_as_collateral`
+
+@notice Validate a user has been using the reserve as collateral
+@param self The configuration object
+@param reserve_index The index of the reserve in the bitmap
+@return True if the user has been using a reserve as collateral, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral">is_using_as_collateral</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>, reserve_index: u256): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_one"></a>
+
+## Function `is_using_as_collateral_one`
+
+@notice Checks if a user has been supplying only one reserve as collateral
+@dev this uses a simple trick - if a number is a power of two (only one bit set) then n & (n - 1) == 0
+@param self The configuration object
+@return True if the user has been supplying as collateral one reserve, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_one">is_using_as_collateral_one</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_any"></a>
+
+## Function `is_using_as_collateral_any`
+
+@notice Checks if a user has been supplying any reserve as collateral
+@param self The configuration object
+@return True if the user has been supplying as collateral any reserve, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_using_as_collateral_any">is_using_as_collateral_any</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing_one"></a>
+
+## Function `is_borrowing_one`
+
+@notice Checks if a user has been borrowing only one asset
+@dev this uses a simple trick - if a number is a power of two (only one bit set) then n & (n - 1) == 0
+@param self The configuration object
+@return True if the user has been supplying as collateral one reserve, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing_one">is_borrowing_one</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing_any"></a>
+
+## Function `is_borrowing_any`
+
+@notice Checks if a user has been borrowing from any reserve
+@param self The configuration object
+@return True if the user has been borrowing any reserve, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_borrowing_any">is_borrowing_any</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_empty"></a>
+
+## Function `is_empty`
+
+@notice Checks if a user has not been using any reserve for borrowing or supply
+@param self The configuration object
+@return True if the user has not been borrowing or supplying any reserve, false otherwise
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_is_empty">is_empty</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>): bool
+</code></pre>
+
+
+
+<a id="0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_first_asset_id_by_mask"></a>
+
+## Function `get_first_asset_id_by_mask`
+
+@notice Returns the address of the first asset flagged in the bitmap given the corresponding bitmask
+@param self The configuration object
+@return The index of the first asset flagged in the bitmap once the corresponding mask is applied
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_get_first_asset_id_by_mask">get_first_asset_id_by_mask</a>(self: &<a href="user_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_user_UserConfigurationMap">user::UserConfigurationMap</a>, mask: u256): u256
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-config/sources/error_config.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/sources/error_config.move
@@ -1,0 +1,702 @@
+/// @title Errors library
+/// @author Aave
+/// @notice Defines the error messages emitted by the different contracts of the Aave protocol
+module aave_config::error_config {
+    /// The caller of the function is not a pool admin
+    const ECALLER_NOT_POOL_ADMIN: u64 = 1;
+    /// The caller of the function is not an emergency admin
+    const ECALLER_NOT_EMERGENCY_ADMIN: u64 = 2;
+    /// The caller of the function is not a pool or emergency admin
+    const ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN: u64 = 3;
+    /// The caller of the function is not a risk or pool admin
+    const ECALLER_NOT_RISK_OR_POOL_ADMIN: u64 = 4;
+    /// The caller of the function is not an asset listing or pool admin
+    const ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN: u64 = 5;
+    /// The caller of the function is not a bridge
+    const ECALLER_NOT_BRIDGE: u64 = 6;
+    /// Pool addresses provider is not registered
+    const EADDRESSES_PROVIDER_NOT_REGISTERED: u64 = 7;
+    /// Invalid id for the pool addresses provider
+    const EINVALID_ADDRESSES_PROVIDER_ID: u64 = 8;
+    /// Address is not a contract
+    const ENOT_CONTRACT: u64 = 9;
+    /// The caller of the function is not the pool configurator
+    const ECALLER_NOT_POOL_CONFIGURATOR: u64 = 10;
+    /// The caller of the function is not an AToken
+    const ECALLER_NOT_ATOKEN: u64 = 11;
+    /// The address of the pool addresses provider is invalid
+    const EINVALID_ADDRESSES_PROVIDER: u64 = 12;
+    /// Invalid return value of the flashloan executor function
+    const EINVALID_FLASHLOAN_EXECUTOR_RETURN: u64 = 13;
+    /// Reserve has already been added to reserve list
+    const ERESERVE_ALREADY_ADDED: u64 = 14;
+    /// Maximum amount of reserves in the pool reached
+    const ENO_MORE_RESERVES_ALLOWED: u64 = 15;
+    /// Zero eMode category is reserved for volatile heterogeneous assets
+    const EEMODE_CATEGORY_RESERVED: u64 = 16;
+    /// Invalid eMode category assignment to asset
+    const EINVALID_EMODE_CATEGORY_ASSIGNMENT: u64 = 17;
+    /// The liquidity of the reserve needs to be 0
+    const ERESERVE_LIQUIDITY_NOT_ZERO: u64 = 18;
+    /// Invalid flashloan premium
+    const EFLASHLOAN_PREMIUM_INVALID: u64 = 19;
+    /// Invalid risk parameters for the reserve
+    const EINVALID_RESERVE_PARAMS: u64 = 20;
+    /// Invalid risk parameters for the eMode category
+    const EINVALID_EMODE_CATEGORY_PARAMS: u64 = 21;
+    /// Invalid bridge protocol fee
+    const EBRIDGE_PROTOCOL_FEE_INVALID: u64 = 22;
+    /// The caller of this function must be a pool
+    const ECALLER_MUST_BE_POOL: u64 = 23;
+    /// Invalid amount to mint
+    const EINVALID_MINT_AMOUNT: u64 = 24;
+    /// Invalid amount to burn
+    const EINVALID_BURN_AMOUNT: u64 = 25;
+    /// Amount must be greater than 0
+    const EINVALID_AMOUNT: u64 = 26;
+    /// Action requires an active reserve
+    const ERESERVE_INACTIVE: u64 = 27;
+    /// Action cannot be performed because the reserve is frozen
+    const ERESERVE_FROZEN: u64 = 28;
+    /// Action cannot be performed because the reserve is paused
+    const ERESERVE_PAUSED: u64 = 29;
+    /// Borrowing is not enabled
+    const EBORROWING_NOT_ENABLED: u64 = 30;
+    /// User cannot withdraw more than the available balance
+    const ENOT_ENOUGH_AVAILABLE_USER_BALANCE: u64 = 32;
+    /// Invalid interest rate mode selected
+    const EINVALID_INTEREST_RATE_MODE_SELECTED: u64 = 33;
+    /// The collateral balance is 0
+    const ECOLLATERAL_BALANCE_IS_ZERO: u64 = 34;
+    /// Health factor is lesser than the liquidation threshold
+    const EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD: u64 = 35;
+    /// There is not enough collateral to cover a new borrow
+    const ECOLLATERAL_CANNOT_COVER_NEW_BORROW: u64 = 36;
+    /// Collateral is (mostly) the same currency that is being borrowed
+    const ECOLLATERAL_SAME_AS_BORROWING_CURRENCY: u64 = 37;
+    /// For repayment of a specific type of debt, the user needs to have debt that type
+    const ENO_DEBT_OF_SELECTED_TYPE: u64 = 39;
+    /// To repay on behalf of a user an explicit amount to repay is needed
+    const ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF: u64 = 40;
+    /// User does not have outstanding variable rate debt on this reserve
+    const ENO_OUTSTANDING_VARIABLE_DEBT: u64 = 42;
+    /// The underlying balance needs to be greater than 0
+    const EUNDERLYING_BALANCE_ZERO: u64 = 43;
+    /// Interest rate rebalance conditions were not met
+    const EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET: u64 = 44;
+    /// Health factor is not below the threshold
+    const EHEALTH_FACTOR_NOT_BELOW_THRESHOLD: u64 = 45;
+    /// The collateral chosen cannot be liquidated
+    const ECOLLATERAL_CANNOT_BE_LIQUIDATED: u64 = 46;
+    /// User did not borrow the specified currency
+    const ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER: u64 = 47;
+    /// Inconsistent flashloan parameters
+    const EINCONSISTENT_FLASHLOAN_PARAMS: u64 = 49;
+    /// Borrow cap is exceeded
+    const EBORROW_CAP_EXCEEDED: u64 = 50;
+    /// Supply cap is exceeded
+    const ESUPPLY_CAP_EXCEEDED: u64 = 51;
+    /// Unbacked mint cap is exceeded
+    const EUNBACKED_MINT_CAP_EXCEEDED: u64 = 52;
+    /// Debt ceiling is exceeded
+    const EDEBT_CEILING_EXCEEDED: u64 = 53;
+    /// Claimable rights over underlying not zero (aToken supply or accruedToTreasury)
+    const EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO: u64 = 54;
+    /// Variable debt supply is not zero
+    const EVARIABLE_DEBT_SUPPLY_NOT_ZERO: u64 = 56;
+    /// Ltv validation failed
+    const ELTV_VALIDATION_FAILED: u64 = 57;
+    /// Inconsistent eMode category
+    const EINCONSISTENT_EMODE_CATEGORY: u64 = 58;
+    /// Price oracle sentinel validation failed
+    const EPRICE_ORACLE_SENTINEL_CHECK_FAILED: u64 = 59;
+    /// Asset is not borrowable in isolation mode
+    const EASSET_NOT_BORROWABLE_IN_ISOLATION: u64 = 60;
+    /// Reserve has already been initialized
+    const ERESERVE_ALREADY_INITIALIZED: u64 = 61;
+    /// User is in isolation mode or ltv is zero
+    const EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO: u64 = 62;
+    /// Invalid ltv parameter for the reserve
+    const EINVALID_LTV: u64 = 63;
+    /// Invalid liquidity threshold parameter for the reserve
+    const EINVALID_LIQ_THRESHOLD: u64 = 64;
+    /// Invalid liquidity bonus parameter for the reserve
+    const EINVALID_LIQ_BONUS: u64 = 65;
+    /// Invalid decimals parameter of the underlying asset of the reserve
+    const EINVALID_DECIMALS: u64 = 66;
+    /// Invalid reserve factor parameter for the reserve
+    const EINVALID_RESERVE_FACTOR: u64 = 67;
+    /// Invalid borrow cap for the reserve
+    const EINVALID_BORROW_CAP: u64 = 68;
+    /// Invalid supply cap for the reserve
+    const EINVALID_SUPPLY_CAP: u64 = 69;
+    /// Invalid liquidation protocol fee for the reserve
+    const EINVALID_LIQUIDATION_PROTOCOL_FEE: u64 = 70;
+    /// Invalid eMode category for the reserve
+    const EINVALID_EMODE_CATEGORY: u64 = 71;
+    /// Invalid unbacked mint cap for the reserve
+    const EINVALID_UNBACKED_MINT_CAP: u64 = 72;
+    /// Invalid debt ceiling for the reserve
+    const EINVALID_DEBT_CEILING: u64 = 73;
+    /// Invalid reserve index
+    const EINVALID_RESERVE_INDEX: u64 = 74;
+    /// ACL admin cannot be set to the zero address
+    const EACL_ADMIN_CANNOT_BE_ZERO: u64 = 75;
+    /// Array parameters that should be equal length are not
+    const EINCONSISTENT_PARAMS_LENGTH: u64 = 76;
+    /// Zero address not valid
+    const EZERO_ADDRESS_NOT_VALID: u64 = 77;
+    /// Invalid expiration
+    const EINVALID_EXPIRATION: u64 = 78;
+    /// Invalid signature
+    const EINVALID_SIGNATURE: u64 = 79;
+    /// Operation not supported
+    const EOPERATION_NOT_SUPPORTED: u64 = 80;
+    /// Debt ceiling is not zero
+    const EDEBT_CEILING_NOT_ZERO: u64 = 81;
+    /// Asset is not listed
+    const EASSET_NOT_LISTED: u64 = 82;
+    /// Invalid optimal usage ratio
+    const EINVALID_OPTIMAL_USAGE_RATIO: u64 = 83;
+    /// The underlying asset cannot be rescued
+    const EUNDERLYING_CANNOT_BE_RESCUED: u64 = 85;
+    /// Reserve has already been added to reserve list
+    const EADDRESSES_PROVIDER_ALREADY_ADDED: u64 = 86;
+    /// The token implementation pool address and the pool address provided by the initializing pool do not match
+    const EPOOL_ADDRESSES_DO_NOT_MATCH: u64 = 87;
+    /// User is trying to borrow multiple assets including a siloed one
+    const ESILOED_BORROWING_VIOLATION: u64 = 89;
+    /// the total debt of the reserve needs to be 0
+    const ERESERVE_DEBT_NOT_ZERO: u64 = 90;
+    /// FlashLoaning for this asset is disabled
+    const EFLASHLOAN_DISABLED: u64 = 91;
+
+    /// Aptos has introduced a new business logic error code range from 1001 to 2000.
+
+    /// aave_acl module error code range from 1001 to 1100.
+    /// Account is not the acl's owner.
+    const ENOT_ACL_OWNER: u64 = 1001;
+    /// Account is missing role.
+    const EROLE_MISSMATCH: u64 = 1002;
+    /// can only renounce roles for self
+    const EROLE_CAN_ONLY_RENOUNCE_SELF: u64 = 1003;
+
+    /// aave_math module error code range from 1101 to 1200.
+    /// Calculation results in overflow
+    const EOVERFLOW: u64 = 1101;
+    /// Cannot divide by zero
+    const EDIVISION_BY_ZERO: u64 = 1102;
+
+    /// aave_oracle module error code range from 1201 to 1300.
+    /// Account is not the oracle's owner.
+    const ENOT_ORACLE_OWNER: u64 = 1201;
+    const EORACLE_RESOURCE_NOT_FOUND: u64 = 1202;
+
+    /// aave_oracle
+    /// Not an asset listing or a pool admin error
+    const ENOT_ASSET_LISTING_OR_POOL_ADMIN: u64 = 1203;
+    /// base currency not set
+    const EBASE_CURRENCY_NOT_SET: u64 = 1204;
+    /// identical base currency already added
+    const EIDENTICAL_BASE_CURRENCY_ALREADY_ADDED: u64 = 1205;
+    /// missing price feed identifier
+    const EMISSING_PRICE_FEED_IDENTIFIER: u64 = 1206;
+    /// missing price vaa
+    const EMISSING_PRICE_VAA: u64 = 1207;
+    /// not existing price feed identifier
+    const EPRICE_FEED_IDENTIFIER_NOT_EXIST: u64 = 1208;
+
+    /// aave_rate module error code range from 1301 to 1400.
+    /// Account is not the rate's owner.
+    const ENOT_RATE_OWNER: u64 = 1301;
+
+    /// aave_pool module error code range from 1401 to 1500.
+    /// Account is not the pool's owner.
+    const ENOT_POOL_OWNER: u64 = 1401;
+    /// User is not listed
+    const EUSER_NOT_LISTED: u64 = 1402;
+    /// Mismatch of reserves count in storage
+    const ERESERVES_STORAGE_COUNT_MISMATCH: u64 = 1403;
+    /// The person who signed must be consistent with on_behalf_of
+    const ESIGNER_AND_ON_BEHALF_OF_NO_SAME: u64 = 1404;
+    /// Account does not exist
+    const EACCOUNT_DOES_NOT_EXIST: u64 = 1405;
+    /// Flashloan payer is different from the flashloan receiver
+    const EFLASHLOAN_PAYER_NOT_RECEIVER: u64 = 1406;
+    /// Price oracle validation failed
+    const EPRICE_ORACLE_CHECK_FAILED: u64 = 1407;
+    /// reserve list not initialized
+    const ERESERVE_LIST_NOT_INITIALIZED: u64 = 1408;
+
+    /// aave_tokens
+    /// Token already exists
+    const ETOKEN_ALREADY_EXISTS: u64 = 1409;
+    /// Token not exist
+    const ETOKEN_NOT_EXIST: u64 = 1410;
+    /// Resource not exist
+    const ERESOURCE_NOT_EXIST: u64 = 1411;
+    /// Token name already exist
+    const ETOKEN_NAME_ALREADY_EXIST: u64 = 1412;
+    /// Token symbol already exist
+    const ETOKEN_SYMBOL_ALREADY_EXIST: u64 = 1413;
+
+    /// coin migrations
+    /// User has insufficient coins to wrap
+    const EINSUFFICIENT_COINS_TO_WRAP: u64 = 1414;
+    /// User has insufficient fungible assets to unwrap
+    const EINSUFFICIENT_FAS_TO_UNWRAP: u64 = 1415;
+    /// The coin has not been mapped to a fungible asset by Aptos
+    const EUNMAPPED_COIN_TO_FA: u64 = 1416;
+
+    public fun get_ecaller_not_pool_admin(): u64 {
+        ECALLER_NOT_POOL_ADMIN
+    }
+
+    public fun get_ecaller_not_emergency_admin(): u64 {
+        ECALLER_NOT_EMERGENCY_ADMIN
+    }
+
+    public fun get_ecaller_not_pool_or_emergency_admin(): u64 {
+        ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN
+    }
+
+    public fun get_ecaller_not_risk_or_pool_admin(): u64 {
+        ECALLER_NOT_RISK_OR_POOL_ADMIN
+    }
+
+    public fun get_ecaller_not_asset_listing_or_pool_admin(): u64 {
+        ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN
+    }
+
+    public fun get_ecaller_not_bridge(): u64 {
+        ECALLER_NOT_BRIDGE
+    }
+
+    public fun get_eaddresses_provider_not_registered(): u64 {
+        EADDRESSES_PROVIDER_NOT_REGISTERED
+    }
+
+    public fun get_einvalid_addresses_provider_id(): u64 {
+        EINVALID_ADDRESSES_PROVIDER_ID
+    }
+
+    public fun get_enot_contract(): u64 {
+        ENOT_CONTRACT
+    }
+
+    public fun get_ecaller_not_pool_configurator(): u64 {
+        ECALLER_NOT_POOL_CONFIGURATOR
+    }
+
+    public fun get_ecaller_not_atoken(): u64 {
+        ECALLER_NOT_ATOKEN
+    }
+
+    public fun get_einvalid_addresses_provider(): u64 {
+        EINVALID_ADDRESSES_PROVIDER
+    }
+
+    public fun get_einvalid_flashloan_executor_return(): u64 {
+        EINVALID_FLASHLOAN_EXECUTOR_RETURN
+    }
+
+    public fun get_ereserve_already_added(): u64 {
+        ERESERVE_ALREADY_ADDED
+    }
+
+    public fun get_ereserves_storage_count_mismatch(): u64 {
+        ERESERVES_STORAGE_COUNT_MISMATCH
+    }
+
+    public fun get_eno_more_reserves_allowed(): u64 {
+        ENO_MORE_RESERVES_ALLOWED
+    }
+
+    public fun get_eemode_category_reserved(): u64 {
+        EEMODE_CATEGORY_RESERVED
+    }
+
+    public fun get_einvalid_emode_category_assignment(): u64 {
+        EINVALID_EMODE_CATEGORY_ASSIGNMENT
+    }
+
+    public fun get_ereserve_liquidity_not_zero(): u64 {
+        ERESERVE_LIQUIDITY_NOT_ZERO
+    }
+
+    public fun get_eflashloan_premium_invalid(): u64 {
+        EFLASHLOAN_PREMIUM_INVALID
+    }
+
+    public fun get_einvalid_reserve_params(): u64 {
+        EINVALID_RESERVE_PARAMS
+    }
+
+    public fun get_einvalid_emode_category_params(): u64 {
+        EINVALID_EMODE_CATEGORY_PARAMS
+    }
+
+    public fun get_ebridge_protocol_fee_invalid(): u64 {
+        EBRIDGE_PROTOCOL_FEE_INVALID
+    }
+
+    public fun get_ecaller_must_be_pool(): u64 {
+        ECALLER_MUST_BE_POOL
+    }
+
+    public fun get_einvalid_mint_amount(): u64 {
+        EINVALID_MINT_AMOUNT
+    }
+
+    public fun get_einvalid_burn_amount(): u64 {
+        EINVALID_BURN_AMOUNT
+    }
+
+    public fun get_einvalid_amount(): u64 {
+        EINVALID_AMOUNT
+    }
+
+    public fun get_ereserve_inactive(): u64 {
+        ERESERVE_INACTIVE
+    }
+
+    public fun get_ereserve_frozen(): u64 {
+        ERESERVE_FROZEN
+    }
+
+    public fun get_ereserve_paused(): u64 {
+        ERESERVE_PAUSED
+    }
+
+    public fun get_eborrowing_not_enabled(): u64 {
+        EBORROWING_NOT_ENABLED
+    }
+
+    public fun get_enot_enough_available_user_balance(): u64 {
+        ENOT_ENOUGH_AVAILABLE_USER_BALANCE
+    }
+
+    public fun get_einvalid_interest_rate_mode_selected(): u64 {
+        EINVALID_INTEREST_RATE_MODE_SELECTED
+    }
+
+    public fun get_ecollateral_balance_is_zero(): u64 {
+        ECOLLATERAL_BALANCE_IS_ZERO
+    }
+
+    public fun get_ehealth_factor_lower_than_liquidation_threshold(): u64 {
+        EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD
+    }
+
+    public fun get_ecollateral_cannot_cover_new_borrow(): u64 {
+        ECOLLATERAL_CANNOT_COVER_NEW_BORROW
+    }
+
+    public fun get_ecollateral_same_as_borrowing_currency(): u64 {
+        ECOLLATERAL_SAME_AS_BORROWING_CURRENCY
+    }
+
+    public fun get_eno_debt_of_selected_type(): u64 {
+        ENO_DEBT_OF_SELECTED_TYPE
+    }
+
+    public fun get_eno_explicit_amount_to_repay_on_behalf(): u64 {
+        ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF
+    }
+
+    public fun get_eno_outstanding_variable_debt(): u64 {
+        ENO_OUTSTANDING_VARIABLE_DEBT
+    }
+
+    public fun get_eunderlying_balance_zero(): u64 {
+        EUNDERLYING_BALANCE_ZERO
+    }
+
+    public fun get_einterest_rate_rebalance_conditions_not_met(): u64 {
+        EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET
+    }
+
+    public fun get_ehealth_factor_not_below_threshold(): u64 {
+        EHEALTH_FACTOR_NOT_BELOW_THRESHOLD
+    }
+
+    public fun get_ecollateral_cannot_be_liquidated(): u64 {
+        ECOLLATERAL_CANNOT_BE_LIQUIDATED
+    }
+
+    public fun get_especified_currency_not_borrowed_by_user(): u64 {
+        ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER
+    }
+
+    public fun get_einconsistent_flashloan_params(): u64 {
+        EINCONSISTENT_FLASHLOAN_PARAMS
+    }
+
+    public fun get_eborrow_cap_exceeded(): u64 {
+        EBORROW_CAP_EXCEEDED
+    }
+
+    public fun get_esupply_cap_exceeded(): u64 {
+        ESUPPLY_CAP_EXCEEDED
+    }
+
+    public fun get_eunbacked_mint_cap_exceeded(): u64 {
+        EUNBACKED_MINT_CAP_EXCEEDED
+    }
+
+    public fun get_edebt_ceiling_exceeded(): u64 {
+        EDEBT_CEILING_EXCEEDED
+    }
+
+    public fun get_eunderlying_claimable_rights_not_zero(): u64 {
+        EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO
+    }
+
+    public fun get_evariable_debt_supply_not_zero(): u64 {
+        EVARIABLE_DEBT_SUPPLY_NOT_ZERO
+    }
+
+    public fun get_eltv_validation_failed(): u64 {
+        ELTV_VALIDATION_FAILED
+    }
+
+    public fun get_einconsistent_emode_category(): u64 {
+        EINCONSISTENT_EMODE_CATEGORY
+    }
+
+    public fun get_easset_not_borrowable_in_isolation(): u64 {
+        EASSET_NOT_BORROWABLE_IN_ISOLATION
+    }
+
+    public fun get_ereserve_already_initialized(): u64 {
+        ERESERVE_ALREADY_INITIALIZED
+    }
+
+    public fun get_euser_in_isolation_mode_or_ltv_zero(): u64 {
+        EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO
+    }
+
+    public fun get_einvalid_ltv(): u64 {
+        EINVALID_LTV
+    }
+
+    public fun get_einvalid_liq_threshold(): u64 {
+        EINVALID_LIQ_THRESHOLD
+    }
+
+    public fun get_einvalid_liq_bonus(): u64 {
+        EINVALID_LIQ_BONUS
+    }
+
+    public fun get_einvalid_decimals(): u64 {
+        EINVALID_DECIMALS
+    }
+
+    public fun get_einvalid_reserve_factor(): u64 {
+        EINVALID_RESERVE_FACTOR
+    }
+
+    public fun get_einvalid_borrow_cap(): u64 {
+        EINVALID_BORROW_CAP
+    }
+
+    public fun get_einvalid_supply_cap(): u64 {
+        EINVALID_SUPPLY_CAP
+    }
+
+    public fun get_einvalid_liquidation_protocol_fee(): u64 {
+        EINVALID_LIQUIDATION_PROTOCOL_FEE
+    }
+
+    public fun get_einvalid_emode_category(): u64 {
+        EINVALID_EMODE_CATEGORY
+    }
+
+    public fun get_einvalid_unbacked_mint_cap(): u64 {
+        EINVALID_UNBACKED_MINT_CAP
+    }
+
+    public fun get_einvalid_debt_ceiling(): u64 {
+        EINVALID_DEBT_CEILING
+    }
+
+    public fun get_einvalid_reserve_index(): u64 {
+        EINVALID_RESERVE_INDEX
+    }
+
+    public fun get_eacl_admin_cannot_be_zero(): u64 {
+        EACL_ADMIN_CANNOT_BE_ZERO
+    }
+
+    public fun get_einconsistent_params_length(): u64 {
+        EINCONSISTENT_PARAMS_LENGTH
+    }
+
+    public fun get_ezero_address_not_valid(): u64 {
+        EZERO_ADDRESS_NOT_VALID
+    }
+
+    public fun get_einvalid_expiration(): u64 {
+        EINVALID_EXPIRATION
+    }
+
+    public fun get_einvalid_signature(): u64 {
+        EINVALID_SIGNATURE
+    }
+
+    public fun get_eoperation_not_supported(): u64 {
+        EOPERATION_NOT_SUPPORTED
+    }
+
+    public fun get_edebt_ceiling_not_zero(): u64 {
+        EDEBT_CEILING_NOT_ZERO
+    }
+
+    public fun get_easset_not_listed(): u64 {
+        EASSET_NOT_LISTED
+    }
+
+    public fun get_einvalid_optimal_usage_ratio(): u64 {
+        EINVALID_OPTIMAL_USAGE_RATIO
+    }
+
+    public fun get_eunderlying_cannot_be_rescued(): u64 {
+        EUNDERLYING_CANNOT_BE_RESCUED
+    }
+
+    public fun get_eaddresses_provider_already_added(): u64 {
+        EADDRESSES_PROVIDER_ALREADY_ADDED
+    }
+
+    public fun get_epool_addresses_do_not_match(): u64 {
+        EPOOL_ADDRESSES_DO_NOT_MATCH
+    }
+
+    public fun get_esiloed_borrowing_violation(): u64 {
+        ESILOED_BORROWING_VIOLATION
+    }
+
+    public fun get_ereserve_debt_not_zero(): u64 {
+        ERESERVE_DEBT_NOT_ZERO
+    }
+
+    public fun get_enot_acl_owner(): u64 {
+        ENOT_ACL_OWNER
+    }
+
+    public fun get_erole_missmatch(): u64 {
+        EROLE_MISSMATCH
+    }
+
+    public fun get_erole_can_only_renounce_self(): u64 {
+        EROLE_CAN_ONLY_RENOUNCE_SELF
+    }
+
+    public fun get_eoverflow(): u64 {
+        EOVERFLOW
+    }
+
+    public fun get_edivision_by_zero(): u64 {
+        EDIVISION_BY_ZERO
+    }
+
+    public fun get_enot_oracle_owner(): u64 {
+        ENOT_ORACLE_OWNER
+    }
+
+    public fun get_eoracle_resource_not_found(): u64 {
+        EORACLE_RESOURCE_NOT_FOUND
+    }
+
+    public fun get_enot_asset_listing_or_pool_admin(): u64 {
+        ENOT_ASSET_LISTING_OR_POOL_ADMIN
+    }
+
+    public fun get_ebase_currency_not_set(): u64 {
+        EBASE_CURRENCY_NOT_SET
+    }
+
+    public fun get_eidentical_base_currency_already_added(): u64 {
+        EIDENTICAL_BASE_CURRENCY_ALREADY_ADDED
+    }
+
+    public fun get_emissing_price_feed_identifier(): u64 {
+        EMISSING_PRICE_FEED_IDENTIFIER
+    }
+
+    public fun get_emissing_price_vaa(): u64 {
+        EMISSING_PRICE_VAA
+    }
+
+    public fun get_eprice_feed_identifier_not_exist(): u64 {
+        EPRICE_FEED_IDENTIFIER_NOT_EXIST
+    }
+
+    public fun get_enot_pool_owner(): u64 {
+        ENOT_POOL_OWNER
+    }
+
+    public fun get_eflashloan_disabled(): u64 {
+        EFLASHLOAN_DISABLED
+    }
+
+    public fun get_euser_not_listed(): u64 {
+        EUSER_NOT_LISTED
+    }
+
+    public fun get_esigner_and_on_behalf_of_no_same(): u64 {
+        ESIGNER_AND_ON_BEHALF_OF_NO_SAME
+    }
+
+    public fun get_eaccount_does_not_exist(): u64 {
+        EACCOUNT_DOES_NOT_EXIST
+    }
+
+    public fun get_flashloan_payer_not_receiver(): u64 {
+        EFLASHLOAN_PAYER_NOT_RECEIVER
+    }
+
+    public fun get_eprice_oracle_check_failed(): u64 {
+        EPRICE_ORACLE_CHECK_FAILED
+    }
+
+    public fun get_enot_rate_owner(): u64 {
+        ENOT_RATE_OWNER
+    }
+
+    public fun get_ereserve_list_not_initialized(): u64 {
+        ERESERVE_LIST_NOT_INITIALIZED
+    }
+
+    public fun get_etoken_already_exists(): u64 {
+        ETOKEN_ALREADY_EXISTS
+    }
+
+    public fun get_etoken_not_exist(): u64 {
+        ETOKEN_NOT_EXIST
+    }
+
+    public fun get_eresource_not_exist(): u64 {
+        ERESOURCE_NOT_EXIST
+    }
+
+    public fun get_etoken_name_already_exist(): u64 {
+        ETOKEN_NAME_ALREADY_EXIST
+    }
+
+    public fun get_etoken_symbol_already_exist(): u64 {
+        ETOKEN_SYMBOL_ALREADY_EXIST
+    }
+
+    public fun get_einsufficient_coins_to_wrap(): u64 {
+        EINSUFFICIENT_COINS_TO_WRAP
+    }
+
+    public fun get_einsufficient_fas_to_unwrap(): u64 {
+        EINSUFFICIENT_FAS_TO_UNWRAP
+    }
+
+    public fun get_eunmapped_coin_to_fa(): u64 {
+        EUNMAPPED_COIN_TO_FA
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/sources/helper.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/sources/helper.move
@@ -1,0 +1,19 @@
+module aave_config::helper {
+
+    /// Get the result of bitwise negation
+    public fun bitwise_negation(m: u256): u256 {
+        let all_ones: u256 =
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        let negated_mask: u256 = m ^ all_ones;
+        return negated_mask
+    }
+
+    #[test]
+    fun test_bitwise_negation() {
+        let ret =
+            bitwise_negation(
+                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000
+            );
+        assert!(ret == 65535, 1);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/sources/reserve_config.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/sources/reserve_config.move
@@ -1,0 +1,612 @@
+/// @title ReserveConfiguration module
+/// @author Aave
+/// @notice Implements the bitmap logic to handle the reserve configuration
+module aave_config::reserve_config {
+    use aave_config::error_config;
+    use aave_config::helper;
+
+    const LTV_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000;
+    const LIQUIDATION_THRESHOLD_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFF;
+    const LIQUIDATION_BONUS_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFF;
+    const DECIMALS_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00FFFFFFFFFFFF;
+    const ACTIVE_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFF;
+    const FROZEN_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDFFFFFFFFFFFFFF;
+    const BORROWING_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFF;
+    const PAUSED_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFF;
+    const BORROWABLE_IN_ISOLATION_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDFFFFFFFFFFFFFFF;
+    const SILOED_BORROWING_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFFFFFFFFFFFF;
+    const FLASHLOAN_ENABLED_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFFFFFFFFFF;
+    const RESERVE_FACTOR_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFF;
+    const BORROW_CAP_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000FFFFFFFFFFFFFFFFFFFF;
+    const SUPPLY_CAP_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFF000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    const LIQUIDATION_PROTOCOL_FEE_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFFFF0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    const EMODE_CATEGORY_MASK: u256 =
+        0xFFFFFFFFFFFFFFFFFFFF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    const UNBACKED_MINT_CAP_MASK: u256 =
+        0xFFFFFFFFFFF000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    const DEBT_CEILING_MASK: u256 =
+        0xF0000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+    /// @dev For the LTV, the start bit is 0 (up to 15), hence no bitshifting is needed
+    const LIQUIDATION_THRESHOLD_START_BIT_POSITION: u256 = 16;
+    const LIQUIDATION_BONUS_START_BIT_POSITION: u256 = 32;
+    const RESERVE_DECIMALS_START_BIT_POSITION: u256 = 48;
+    const IS_ACTIVE_START_BIT_POSITION: u256 = 56;
+    const IS_FROZEN_START_BIT_POSITION: u256 = 57;
+    const BORROWING_ENABLED_START_BIT_POSITION: u256 = 58;
+    const IS_PAUSED_START_BIT_POSITION: u256 = 60;
+    const BORROWABLE_IN_ISOLATION_START_BIT_POSITION: u256 = 61;
+    const SILOED_BORROWING_START_BIT_POSITION: u256 = 62;
+    const FLASHLOAN_ENABLED_START_BIT_POSITION: u256 = 63;
+    const RESERVE_FACTOR_START_BIT_POSITION: u256 = 64;
+    const BORROW_CAP_START_BIT_POSITION: u256 = 80;
+    const SUPPLY_CAP_START_BIT_POSITION: u256 = 116;
+    const LIQUIDATION_PROTOCOL_FEE_START_BIT_POSITION: u256 = 152;
+    const EMODE_CATEGORY_START_BIT_POSITION: u256 = 168;
+    const UNBACKED_MINT_CAP_START_BIT_POSITION: u256 = 176;
+    const DEBT_CEILING_START_BIT_POSITION: u256 = 212;
+
+    // control values
+    const MAX_VALID_LTV: u256 = 65535;
+    const MAX_VALID_LIQUIDATION_THRESHOLD: u256 = 65535;
+    const MAX_VALID_LIQUIDATION_BONUS: u256 = 65535;
+    const MAX_VALID_DECIMALS: u256 = 255;
+    const MAX_VALID_RESERVE_FACTOR: u256 = 65535;
+    const MAX_VALID_BORROW_CAP: u256 = 68719476735;
+    const MAX_VALID_SUPPLY_CAP: u256 = 68719476735;
+    const MAX_VALID_LIQUIDATION_PROTOCOL_FEE: u256 = 65535;
+    const MAX_VALID_EMODE_CATEGORY: u256 = 255;
+    const MAX_VALID_UNBACKED_MINT_CAP: u256 = 68719476735;
+    const MAX_VALID_DEBT_CEILING: u256 = 1099511627775;
+
+    const DEBT_CEILING_DECIMALS: u256 = 2;
+    const MAX_RESERVES_COUNT: u16 = 128;
+
+    struct ReserveConfigurationMap has key, store, copy, drop {
+        /// bit 0-15: LTV
+        /// bit 16-31: Liq. threshold
+        /// bit 32-47: Liq. bonus
+        /// bit 48-55: Decimals
+        /// bit 56: reserve is active
+        /// bit 57: reserve is frozen
+        /// bit 58: borrowing is enabled
+        /// bit 59: stable rate borrowing enabled (already remove)
+        /// bit 60: asset is paused
+        /// bit 61: borrowing in isolation mode is enabled
+        /// bit 62: siloed borrowing enabled
+        /// bit 63: flashloaning enabled
+        /// bit 64-79: reserve factor
+        /// bit 80-115 borrow cap in whole tokens, borrowCap == 0 => no cap
+        /// bit 116-151 supply cap in whole tokens, supplyCap == 0 => no cap
+        /// bit 152-167 liquidation protocol fee
+        /// bit 168-175 eMode category
+        /// bit 176-211 unbacked mint cap in whole tokens, unbackedMintCap == 0 => minting disabled
+        /// bit 212-251 debt ceiling for isolation mode with (ReserveConfigurationMap::DEBT_CEILING_DECIMALS) decimals
+        /// bit 252-255 unused
+        data: u256
+    }
+
+    /// @notice init the reserve configuration
+    public fun init(): ReserveConfigurationMap {
+        ReserveConfigurationMap { data: 0 }
+    }
+
+    /// @notice Sets the Loan to Value of the reserve
+    /// @param self The reserve configuration
+    /// @param ltv The new ltv
+    public fun set_ltv(self: &mut ReserveConfigurationMap, ltv: u256) {
+        assert!(ltv <= MAX_VALID_LTV, error_config::get_einvalid_ltv());
+        self.data = (self.data & LTV_MASK) | ltv;
+    }
+
+    /// @notice Gets the Loan to Value of the reserve
+    /// @param self The reserve configuration
+    /// @return The loan to value
+    public fun get_ltv(self: &ReserveConfigurationMap): u256 {
+        self.data & helper::bitwise_negation(LTV_MASK)
+    }
+
+    /// @notice Sets the liquidation threshold of the reserve
+    /// @param self The reserve configuration
+    /// @param liquidation_threshold The new liquidation threshold
+    public fun set_liquidation_threshold(
+        self: &mut ReserveConfigurationMap, liquidation_threshold: u256
+    ) {
+        assert!(
+            liquidation_threshold <= MAX_VALID_LIQUIDATION_THRESHOLD,
+            error_config::get_einvalid_liq_threshold()
+        );
+        self.data = (self.data & LIQUIDATION_THRESHOLD_MASK)
+            | (liquidation_threshold
+                << (LIQUIDATION_THRESHOLD_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the liquidation threshold of the reserve
+    /// @param self The reserve configuration
+    /// @return The liquidation threshold
+    public fun get_liquidation_threshold(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(LIQUIDATION_THRESHOLD_MASK))
+            >> (LIQUIDATION_THRESHOLD_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the liquidation bonus of the reserve
+    /// @param self The reserve configuration
+    /// @param liquidation_bonus The new liquidation bonus
+    public fun set_liquidation_bonus(
+        self: &mut ReserveConfigurationMap, liquidation_bonus: u256
+    ) {
+        assert!(
+            liquidation_bonus <= MAX_VALID_LIQUIDATION_BONUS,
+            error_config::get_einvalid_liq_bonus()
+        );
+        self.data = (self.data & LIQUIDATION_BONUS_MASK)
+            | (liquidation_bonus << (LIQUIDATION_BONUS_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the liquidation bonus of the reserve
+    /// @param self The reserve configuration
+    /// @return The liquidation bonus
+    public fun get_liquidation_bonus(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(LIQUIDATION_BONUS_MASK))
+            >> (LIQUIDATION_BONUS_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the decimals of the underlying asset of the reserve
+    /// @param self The reserve configuration
+    /// @param decimals The decimals
+    public fun set_decimals(
+        self: &mut ReserveConfigurationMap, decimals: u256
+    ) {
+        assert!(decimals <= MAX_VALID_DECIMALS, error_config::get_einvalid_decimals());
+        self.data = (self.data & DECIMALS_MASK)
+            | (decimals << (RESERVE_DECIMALS_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the decimals of the underlying asset of the reserve
+    /// @param self The reserve configuration
+    /// @return The decimals
+    public fun get_decimals(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(DECIMALS_MASK))
+            >> (RESERVE_DECIMALS_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the active state of the reserve
+    /// @param self The reserve configuration
+    /// @param active The new active state
+    public fun set_active(
+        self: &mut ReserveConfigurationMap, active: bool
+    ) {
+        let active_state: u256 = 0;
+        if (active) {
+            active_state = 1;
+        };
+        self.data = (self.data & ACTIVE_MASK)
+            | active_state << (IS_ACTIVE_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Gets the active state of the reserve
+    /// @param self The reserve configuration
+    /// @return The active state
+    public fun get_active(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(ACTIVE_MASK)) != 0
+    }
+
+    /// @notice Sets the frozen state of the reserve
+    /// @param self The reserve configuration
+    /// @param frozen The new frozen state
+    public fun set_frozen(
+        self: &mut ReserveConfigurationMap, frozen: bool
+    ) {
+        let frozen_state: u256 = 0;
+        if (frozen) {
+            frozen_state = 1;
+        };
+        self.data = (self.data & FROZEN_MASK)
+            | (frozen_state << (IS_FROZEN_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the frozen state of the reserve
+    /// @param self The reserve configuration
+    /// @return The frozen state
+    public fun get_frozen(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(FROZEN_MASK)) != 0
+    }
+
+    /// @notice Sets the paused state of the reserve
+    /// @param self The reserve configuration
+    /// @param paused The new paused state
+    public fun set_paused(
+        self: &mut ReserveConfigurationMap, paused: bool
+    ) {
+        let paused_state: u256 = 0;
+        if (paused) {
+            paused_state = 1;
+        };
+        self.data = (self.data & PAUSED_MASK)
+            | (paused_state << (IS_PAUSED_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the paused state of the reserve
+    /// @param self The reserve configuration
+    /// @return The paused state
+    public fun get_paused(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(PAUSED_MASK)) != 0
+    }
+
+    /// @notice Sets the borrowing in isolation state of the reserve
+    /// @dev When this flag is set to true, the asset will be borrowable against isolated collaterals and the borrowed
+    /// amount will be accumulated in the isolated collateral's total debt exposure.
+    /// @dev Only assets of the same family (eg USD stablecoins) should be borrowable in isolation mode to keep
+    /// consistency in the debt ceiling calculations.
+    /// @param self The reserve configuration
+    /// @param borrowable The new borrowing in isolation state
+    public fun set_borrowable_in_isolation(
+        self: &mut ReserveConfigurationMap, borrowable: bool
+    ) {
+        let borrowable_state: u256 = 0;
+        if (borrowable) {
+            borrowable_state = 1;
+        };
+        self.data = (self.data & BORROWABLE_IN_ISOLATION_MASK)
+            | (borrowable_state << (BORROWABLE_IN_ISOLATION_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the borrowable in isolation flag for the reserve.
+    /// @dev If the returned flag is true, the asset is borrowable against isolated collateral. Assets borrowed with
+    /// isolated collateral is accounted for in the isolated collateral's total debt exposure.
+    /// @dev Only assets of the same family (eg USD stablecoins) should be borrowable in isolation mode to keep
+    /// consistency in the debt ceiling calculations.
+    /// @param self The reserve configuration
+    /// @return The borrowable in isolation flag
+    public fun get_borrowable_in_isolation(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(BORROWABLE_IN_ISOLATION_MASK)) != 0
+    }
+
+    /// @notice Sets the siloed borrowing flag for the reserve.
+    /// @dev When this flag is set to true, users borrowing this asset will not be allowed to borrow any other asset.
+    /// @param self The reserve configuration
+    /// @param siloed_borrowing True if the asset is siloed
+    public fun set_siloed_borrowing(
+        self: &mut ReserveConfigurationMap, siloed_borrowing: bool
+    ) {
+        let siloed_borrowing_state: u256 = 0;
+        if (siloed_borrowing) {
+            siloed_borrowing_state = 1;
+        };
+        self.data = (self.data & SILOED_BORROWING_MASK)
+            | siloed_borrowing_state << (SILOED_BORROWING_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Gets the siloed borrowing flag for the reserve.
+    /// @dev When this flag is set to true, users borrowing this asset will not be allowed to borrow any other asset.
+    /// @param self The reserve configuration
+    /// @return The siloed borrowing flag
+    public fun get_siloed_borrowing(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(SILOED_BORROWING_MASK)) != 0
+    }
+
+    /// @notice Enables or disables borrowing on the reserve
+    /// @param self The reserve configuration
+    /// @param borrowing_enabled True if the borrowing needs to be enabled, false otherwise
+    public fun set_borrowing_enabled(
+        self: &mut ReserveConfigurationMap, borrowing_enabled: bool
+    ) {
+        let borrowing_enabled_state: u256 = 0;
+        if (borrowing_enabled) {
+            borrowing_enabled_state = 1;
+        };
+        self.data = (self.data & BORROWING_MASK)
+            | borrowing_enabled_state << (BORROWING_ENABLED_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Gets the borrowing state of the reserve
+    /// @param self The reserve configuration
+    /// @return The borrowing state
+    public fun get_borrowing_enabled(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(BORROWING_MASK)) != 0
+    }
+
+    /// @notice Sets the reserve factor of the reserve
+    /// @param self The reserve configuration
+    /// @param reserve_factor The reserve factor
+    public fun set_reserve_factor(
+        self: &mut ReserveConfigurationMap, reserve_factor: u256
+    ) {
+        assert!(
+            reserve_factor <= MAX_VALID_RESERVE_FACTOR,
+            error_config::get_einvalid_reserve_factor()
+        );
+
+        self.data = (self.data & RESERVE_FACTOR_MASK)
+            | (reserve_factor << (RESERVE_FACTOR_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the reserve factor of the reserve
+    /// @param self The reserve configuration
+    /// @return The reserve factor
+    public fun get_reserve_factor(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(RESERVE_FACTOR_MASK))
+            >> (RESERVE_FACTOR_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the borrow cap of the reserve
+    /// @param self The reserve configuration
+    /// @param borrow_cap The borrow cap
+    public fun set_borrow_cap(
+        self: &mut ReserveConfigurationMap, borrow_cap: u256
+    ) {
+        assert!(
+            borrow_cap <= MAX_VALID_BORROW_CAP, error_config::get_einvalid_borrow_cap()
+        );
+        self.data = (self.data & BORROW_CAP_MASK)
+            | (borrow_cap << (BORROW_CAP_START_BIT_POSITION as u8));
+    }
+
+    /// @notice Gets the borrow cap of the reserve
+    /// @param self The reserve configuration
+    /// @return The borrow cap
+    public fun get_borrow_cap(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(BORROW_CAP_MASK))
+            >> (BORROW_CAP_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the supply cap of the reserve
+    /// @param self The reserve configuration
+    /// @param supply_cap The supply cap
+    public fun set_supply_cap(
+        self: &mut ReserveConfigurationMap, supply_cap: u256
+    ) {
+        assert!(
+            supply_cap <= MAX_VALID_SUPPLY_CAP, error_config::get_einvalid_supply_cap()
+        );
+        self.data = (self.data & SUPPLY_CAP_MASK)
+            | (supply_cap << (SUPPLY_CAP_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the supply cap of the reserve
+    /// @param self The reserve configuration
+    /// @return The supply cap
+    public fun get_supply_cap(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(SUPPLY_CAP_MASK))
+            >> (SUPPLY_CAP_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the debt ceiling in isolation mode for the asset
+    /// @param self The reserve configuration
+    /// @param debt_ceiling The maximum debt ceiling for the asset
+    public fun set_debt_ceiling(
+        self: &mut ReserveConfigurationMap, debt_ceiling: u256
+    ) {
+        assert!(
+            debt_ceiling <= MAX_VALID_DEBT_CEILING,
+            error_config::get_einvalid_debt_ceiling()
+        );
+
+        self.data = (self.data & DEBT_CEILING_MASK)
+            | (debt_ceiling << (DEBT_CEILING_START_BIT_POSITION as u8));
+    }
+
+    /// @notice Gets the debt ceiling for the asset if the asset is in isolation mode
+    /// @param self The reserve configuration
+    /// @return The debt ceiling (0 = isolation mode disabled)
+    public fun get_debt_ceiling(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(DEBT_CEILING_MASK))
+            >> (DEBT_CEILING_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the liquidation protocol fee of the reserve
+    /// @param self The reserve configuration
+    /// @param liquidation_protocol_fee The liquidation protocol fee
+    public fun set_liquidation_protocol_fee(
+        self: &mut ReserveConfigurationMap, liquidation_protocol_fee: u256
+    ) {
+        assert!(
+            liquidation_protocol_fee <= MAX_VALID_LIQUIDATION_PROTOCOL_FEE,
+            error_config::get_einvalid_liquidation_protocol_fee()
+        );
+        self.data = (self.data & LIQUIDATION_PROTOCOL_FEE_MASK)
+            | (
+                liquidation_protocol_fee
+                    << (LIQUIDATION_PROTOCOL_FEE_START_BIT_POSITION as u8)
+            )
+    }
+
+    /// @dev Gets the liquidation protocol fee
+    /// @param self The reserve configuration
+    /// @return The liquidation protocol fee
+    public fun get_liquidation_protocol_fee(
+        self: &ReserveConfigurationMap
+    ): u256 {
+        (self.data & helper::bitwise_negation(LIQUIDATION_PROTOCOL_FEE_MASK))
+            >> (LIQUIDATION_PROTOCOL_FEE_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the unbacked mint cap of the reserve
+    /// @param self The reserve configuration
+    /// @param unbacked_mint_cap The unbacked mint cap
+    public fun set_unbacked_mint_cap(
+        self: &mut ReserveConfigurationMap, unbacked_mint_cap: u256
+    ) {
+        assert!(
+            unbacked_mint_cap <= MAX_VALID_UNBACKED_MINT_CAP,
+            error_config::get_einvalid_unbacked_mint_cap()
+        );
+
+        self.data = (self.data & UNBACKED_MINT_CAP_MASK)
+            | (unbacked_mint_cap << (UNBACKED_MINT_CAP_START_BIT_POSITION as u8))
+    }
+
+    /// @dev Gets the unbacked mint cap of the reserve
+    /// @param self The reserve configuration
+    /// @return The unbacked mint cap
+    public fun get_unbacked_mint_cap(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(UNBACKED_MINT_CAP_MASK))
+            >> (UNBACKED_MINT_CAP_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the eMode asset category
+    /// @param self The reserve configuration
+    /// @param emode_category The asset category when the user selects the eMode
+    public fun set_emode_category(
+        self: &mut ReserveConfigurationMap, emode_category: u256
+    ) {
+        assert!(
+            emode_category <= MAX_VALID_EMODE_CATEGORY,
+            error_config::get_einvalid_emode_category()
+        );
+        self.data = (self.data & EMODE_CATEGORY_MASK)
+            | (emode_category << (EMODE_CATEGORY_START_BIT_POSITION as u8))
+    }
+
+    /// @dev Gets the eMode asset category
+    /// @param self The reserve configuration
+    /// @return The eMode category for the asset
+    public fun get_emode_category(self: &ReserveConfigurationMap): u256 {
+        (self.data & helper::bitwise_negation(EMODE_CATEGORY_MASK))
+            >> (EMODE_CATEGORY_START_BIT_POSITION as u8)
+    }
+
+    /// @notice Sets the flashloanable flag for the reserve
+    /// @param self The reserve configuration
+    /// @param flash_loan_enabled True if the asset is flashloanable, false otherwise
+    public fun set_flash_loan_enabled(
+        self: &mut ReserveConfigurationMap, flash_loan_enabled: bool
+    ) {
+        let flash_loan_enabled_state: u256 = 0;
+        if (flash_loan_enabled) {
+            flash_loan_enabled_state = 1;
+        };
+        self.data = (self.data & FLASHLOAN_ENABLED_MASK)
+            | (flash_loan_enabled_state << (FLASHLOAN_ENABLED_START_BIT_POSITION as u8))
+    }
+
+    /// @notice Gets the flashloanable flag for the reserve
+    /// @param self The reserve configuration
+    /// @return The flashloanable flag
+    public fun get_flash_loan_enabled(self: &ReserveConfigurationMap): bool {
+        (self.data & helper::bitwise_negation(FLASHLOAN_ENABLED_MASK)) != 0
+    }
+
+    /// @notice Gets the configuration flags of the reserve
+    /// @param self The reserve configuration
+    /// @return The state flag representing active
+    /// @return The state flag representing frozen
+    /// @return The state flag representing borrowing enabled
+    /// @return The state flag representing paused
+    public fun get_flags(self: &ReserveConfigurationMap): (bool, bool, bool, bool) {
+        (
+            get_active(self),
+            get_frozen(self),
+            get_borrowing_enabled(self),
+            get_paused(self)
+        )
+    }
+
+    /// @notice Gets the configuration parameters of the reserve from storage
+    /// @param self The reserve configuration
+    /// @return The state param representing ltv
+    /// @return The state param representing liquidation threshold
+    /// @return The state param representing liquidation bonus
+    /// @return The state param representing reserve decimals
+    /// @return The state param representing reserve factor
+    /// @return The state param representing eMode category
+    public fun get_params(self: &ReserveConfigurationMap):
+        (u256, u256, u256, u256, u256, u256) {
+        (
+            get_ltv(self),
+            get_liquidation_threshold(self),
+            get_liquidation_bonus(self),
+            get_decimals(self),
+            get_reserve_factor(self),
+            get_emode_category(self)
+        )
+    }
+
+    /// @notice Gets the caps parameters of the reserve from storage
+    /// @param self The reserve configuration
+    /// @return The state param representing borrow cap
+    /// @return The state param representing supply cap.
+    public fun get_caps(self: &ReserveConfigurationMap): (u256, u256) {
+        (get_borrow_cap(self), get_supply_cap(self))
+    }
+
+    /// @notice Gets the debt ceiling decimals
+    public fun get_debt_ceiling_decimals(): u256 {
+        DEBT_CEILING_DECIMALS
+    }
+
+    /// @notice Gets the maximum number of reserves
+    public fun get_max_reserves_count(): u16 {
+        MAX_RESERVES_COUNT
+    }
+
+    #[test_only]
+    public fun get_max_valid_ltv(): u256 {
+        MAX_VALID_LTV
+    }
+
+    #[test_only]
+    public fun get_max_valid_liquidation_threshold(): u256 {
+        MAX_VALID_LIQUIDATION_THRESHOLD
+    }
+
+    #[test_only]
+    public fun get_max_valid_liquidation_bonus(): u256 {
+        MAX_VALID_LIQUIDATION_BONUS
+    }
+
+    #[test_only]
+    public fun get_max_valid_decimals(): u256 {
+        MAX_VALID_DECIMALS
+    }
+
+    #[test_only]
+    public fun get_max_valid_reserve_factor(): u256 {
+        MAX_VALID_RESERVE_FACTOR
+    }
+
+    #[test_only]
+    public fun get_max_valid_borrow_cap(): u256 {
+        MAX_VALID_BORROW_CAP
+    }
+
+    #[test_only]
+    public fun get_max_valid_supply_cap(): u256 {
+        MAX_VALID_SUPPLY_CAP
+    }
+
+    #[test_only]
+    public fun get_max_valid_liquidation_protocol_fee(): u256 {
+        MAX_VALID_LIQUIDATION_PROTOCOL_FEE
+    }
+
+    #[test_only]
+    public fun get_max_valid_emode_category(): u256 {
+        MAX_VALID_EMODE_CATEGORY
+    }
+
+    #[test_only]
+    public fun get_max_valid_unbacked_mint_cap(): u256 {
+        MAX_VALID_UNBACKED_MINT_CAP
+    }
+
+    #[test_only]
+    public fun get_max_valid_debt_ceiling(): u256 {
+        MAX_VALID_DEBT_CEILING
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/sources/user_config.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/sources/user_config.move
@@ -1,0 +1,236 @@
+/// @title UserConfiguration library
+/// @author Aave
+/// @notice Implements the bitmap logic to handle the user configuration
+module aave_config::user_config {
+    use aave_config::error_config;
+    use aave_config::helper;
+    use aave_config::reserve_config;
+
+    const BORROWING_MASK: u256 =
+        0x5555555555555555555555555555555555555555555555555555555555555555;
+    const COLLATERAL_MASK: u256 =
+        0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+
+    /// Minimum health factor allowed under any circumstance
+    /// A value of 0.95e18 results in 0.95
+    /// 0.95 * 10 ** 18
+    const MINIMUM_HEALTH_FACTOR_LIQUIDATION_THRESHOLD: u256 = 950000000000000000;
+
+    /// @dev Minimum health factor to consider a user position healthy
+    /// A value of 1e18 results in 1
+    /// 1 * 10 ** 18
+    const HEALTH_FACTOR_LIQUIDATION_THRESHOLD: u256 = 1000000000000000000;
+
+    /// @dev Role identifier for the role allowed to supply isolated reserves as collateral
+    const ISOLATED_COLLATERAL_SUPPLIER_ROLE: vector<u8> = b"ISOLATED_COLLATERAL_SUPPLIER";
+
+    const INTEREST_RATE_MODE_NONE: u8 = 0;
+    /// 1 = Stable Rate, 2 = Variable Rate, Since the Stable Rate service has been removed, only the Variable Rate service is retained.
+    const INTEREST_RATE_MODE_VARIABLE: u8 = 2;
+
+    struct UserConfigurationMap has key, copy, store, drop {
+        /// @dev Bitmap of the users collaterals and borrows. It is divided in pairs of bits, one pair per asset.
+        /// The first bit indicates if an asset is used as collateral by the user, the second whether an
+        /// asset is borrowed by the user.
+        data: u256
+    }
+
+    /// @notice Initializes the user configuration map
+    public fun init(): UserConfigurationMap {
+        UserConfigurationMap { data: 0 }
+    }
+
+    #[test_only]
+    public fun test_init_module(account: &signer) {
+        let config = init();
+        move_to(account, config);
+    }
+
+    public fun get_interest_rate_mode_none(): u8 {
+        INTEREST_RATE_MODE_NONE
+    }
+
+    public fun get_interest_rate_mode_variable(): u8 {
+        INTEREST_RATE_MODE_VARIABLE
+    }
+
+    public fun get_borrowing_mask(): u256 {
+        BORROWING_MASK
+    }
+
+    public fun get_collateral_mask(): u256 {
+        COLLATERAL_MASK
+    }
+
+    public fun get_minimum_health_factor_liquidation_threshold(): u256 {
+        MINIMUM_HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    }
+
+    public fun get_health_factor_liquidation_threshold(): u256 {
+        HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    }
+
+    public fun get_isolated_collateral_supplier_role(): vector<u8> {
+        ISOLATED_COLLATERAL_SUPPLIER_ROLE
+    }
+
+    /// @notice Sets if the user is borrowing the reserve identified by reserve_index
+    /// @param self The configuration object
+    /// @param reserve_index The index of the reserve in the bitmap
+    /// @param borrowing True if the user is borrowing the reserve, false otherwise
+    public fun set_borrowing(
+        self: &mut UserConfigurationMap, reserve_index: u256, borrowing: bool
+    ) {
+        assert!(
+            reserve_index < (reserve_config::get_max_reserves_count() as u256),
+            error_config::get_einvalid_reserve_index()
+        );
+        let bit = 1 << ((reserve_index << 1) as u8);
+        if (borrowing) {
+            self.data = self.data | bit;
+        } else {
+            self.data = self.data & helper::bitwise_negation(bit);
+        }
+    }
+
+    /// @notice Sets if the user is using as collateral the reserve identified by reserve_index
+    /// @param self The configuration object
+    /// @param reserve_index The index of the reserve in the bitmap
+    /// @param using_as_collateral True if the user is using the reserve as collateral, false otherwise
+    public fun set_using_as_collateral(
+        self: &mut UserConfigurationMap, reserve_index: u256, using_as_collateral: bool
+    ) {
+        assert!(
+            reserve_index < (reserve_config::get_max_reserves_count() as u256),
+            error_config::get_einvalid_reserve_index()
+        );
+        let bit: u256 = 1 << (((reserve_index << 1) + 1) as u8);
+        if (using_as_collateral) {
+            self.data = self.data | bit;
+        } else {
+            self.data = self.data & helper::bitwise_negation(bit);
+        }
+    }
+
+    /// @notice Returns if a user has been using the reserve for borrowing or as collateral
+    /// @param self The configuration object
+    /// @param reserve_index The index of the reserve in the bitmap
+    /// @return True if the user has been using a reserve for borrowing or as collateral, false otherwise
+    public fun is_using_as_collateral_or_borrowing(
+        self: &UserConfigurationMap, reserve_index: u256
+    ): bool {
+        assert!(
+            reserve_index < (reserve_config::get_max_reserves_count() as u256),
+            error_config::get_einvalid_reserve_index()
+        );
+        (self.data >> ((reserve_index << 1) as u8))
+        & 3 != 0
+    }
+
+    /// @notice Validate a user has been using the reserve for borrowing
+    /// @param self The configuration object
+    /// @param reserve_index The index of the reserve in the bitmap
+    /// @return True if the user has been using a reserve for borrowing, false otherwise
+    public fun is_borrowing(
+        self: &UserConfigurationMap, reserve_index: u256
+    ): bool {
+        assert!(
+            reserve_index < (reserve_config::get_max_reserves_count() as u256),
+            error_config::get_einvalid_reserve_index()
+        );
+        (self.data >> ((reserve_index << 1) as u8))
+        & 1 != 0
+    }
+
+    /// @notice Validate a user has been using the reserve as collateral
+    /// @param self The configuration object
+    /// @param reserve_index The index of the reserve in the bitmap
+    /// @return True if the user has been using a reserve as collateral, false otherwise
+    public fun is_using_as_collateral(
+        self: &UserConfigurationMap, reserve_index: u256
+    ): bool {
+        assert!(
+            reserve_index < (reserve_config::get_max_reserves_count() as u256),
+            error_config::get_einvalid_reserve_index()
+        );
+        (self.data >> ((reserve_index << 1) as u8) + 1)
+        & 1 != 0
+    }
+
+    /// @notice Checks if a user has been supplying only one reserve as collateral
+    /// @dev this uses a simple trick - if a number is a power of two (only one bit set) then n & (n - 1) == 0
+    /// @param self The configuration object
+    /// @return True if the user has been supplying as collateral one reserve, false otherwise
+    public fun is_using_as_collateral_one(self: &UserConfigurationMap): bool {
+        let self_data = self.data & COLLATERAL_MASK;
+        self_data != 0 && (self_data & (self_data - 1) == 0)
+    }
+
+    /// @notice Checks if a user has been supplying any reserve as collateral
+    /// @param self The configuration object
+    /// @return True if the user has been supplying as collateral any reserve, false otherwise
+    public fun is_using_as_collateral_any(self: &UserConfigurationMap): bool {
+        self.data & COLLATERAL_MASK != 0
+    }
+
+    /// @notice Checks if a user has been borrowing only one asset
+    /// @dev this uses a simple trick - if a number is a power of two (only one bit set) then n & (n - 1) == 0
+    /// @param self The configuration object
+    /// @return True if the user has been supplying as collateral one reserve, false otherwise
+    public fun is_borrowing_one(self: &UserConfigurationMap): bool {
+        let borrowing_data = self.data & BORROWING_MASK;
+        borrowing_data != 0 && (borrowing_data & (borrowing_data - 1) == 0)
+    }
+
+    /// @notice Checks if a user has been borrowing from any reserve
+    /// @param self The configuration object
+    /// @return True if the user has been borrowing any reserve, false otherwise
+    public fun is_borrowing_any(self: &UserConfigurationMap): bool {
+        self.data & BORROWING_MASK != 0
+    }
+
+    /// @notice Checks if a user has not been using any reserve for borrowing or supply
+    /// @param self The configuration object
+    /// @return True if the user has not been borrowing or supplying any reserve, false otherwise
+    public fun is_empty(self: &UserConfigurationMap): bool {
+        self.data == 0
+    }
+
+    /// @notice Returns the address of the first asset flagged in the bitmap given the corresponding bitmask
+    /// @param self The configuration object
+    /// @return The index of the first asset flagged in the bitmap once the corresponding mask is applied
+    public fun get_first_asset_id_by_mask(
+        self: &UserConfigurationMap, mask: u256
+    ): u256 {
+        let bit_map_data = self.data & mask;
+        let first_asset_position = bit_map_data
+            & helper::bitwise_negation(bit_map_data - 1);
+        let id: u256 = 0;
+        first_asset_position = first_asset_position >> 2;
+        while (first_asset_position != 0) {
+            id = id + 1;
+            first_asset_position = first_asset_position >> 2;
+        };
+        id
+    }
+
+    #[test_only]
+    public fun get_user_config_map(): UserConfigurationMap acquires UserConfigurationMap {
+        *borrow_global<UserConfigurationMap>(@aave_config)
+    }
+
+    #[test_only]
+    public fun get_minimum_health_factor_liquidation_threshold_for_testing(): u256 {
+        MINIMUM_HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    }
+
+    #[test_only]
+    public fun get_health_factor_liquidation_threshold_for_testing(): u256 {
+        HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    }
+
+    #[test_only]
+    public fun get_isolated_collateral_supplier_role_for_testing(): vector<u8> {
+        ISOLATED_COLLATERAL_SUPPLIER_ROLE
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/tests/error_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/tests/error_tests.move
@@ -1,0 +1,942 @@
+#[test_only]
+module aave_config::error_tests {
+    use aave_config::error_config::{
+        get_eaccount_does_not_exist,
+        get_eacl_admin_cannot_be_zero,
+        get_eaddresses_provider_already_added,
+        get_eaddresses_provider_not_registered,
+        get_easset_not_borrowable_in_isolation,
+        get_easset_not_listed,
+        get_eborrow_cap_exceeded,
+        get_eborrowing_not_enabled,
+        get_ebridge_protocol_fee_invalid,
+        get_ecaller_must_be_pool,
+        get_ecaller_not_asset_listing_or_pool_admin,
+        get_ecaller_not_atoken,
+        get_ecaller_not_bridge,
+        get_ecaller_not_emergency_admin,
+        get_ecaller_not_pool_admin,
+        get_ecaller_not_pool_configurator,
+        get_ecaller_not_pool_or_emergency_admin,
+        get_ecaller_not_risk_or_pool_admin,
+        get_ecollateral_balance_is_zero,
+        get_ecollateral_cannot_be_liquidated,
+        get_ecollateral_cannot_cover_new_borrow,
+        get_ecollateral_same_as_borrowing_currency,
+        get_edebt_ceiling_exceeded,
+        get_edebt_ceiling_not_zero,
+        get_eemode_category_reserved,
+        get_eflashloan_disabled,
+        get_eflashloan_premium_invalid,
+        get_ehealth_factor_lower_than_liquidation_threshold,
+        get_ehealth_factor_not_below_threshold,
+        get_einconsistent_emode_category,
+        get_einconsistent_flashloan_params,
+        get_einconsistent_params_length,
+        get_einterest_rate_rebalance_conditions_not_met,
+        get_einvalid_addresses_provider,
+        get_einvalid_addresses_provider_id,
+        get_einvalid_amount,
+        get_einvalid_borrow_cap,
+        get_einvalid_burn_amount,
+        get_einvalid_debt_ceiling,
+        get_einvalid_decimals,
+        get_einvalid_emode_category,
+        get_einvalid_emode_category_assignment,
+        get_einvalid_emode_category_params,
+        get_einvalid_expiration,
+        get_einvalid_flashloan_executor_return,
+        get_einvalid_interest_rate_mode_selected,
+        get_einvalid_liq_bonus,
+        get_einvalid_liq_threshold,
+        get_einvalid_liquidation_protocol_fee,
+        get_einvalid_ltv,
+        get_einvalid_mint_amount,
+        get_einvalid_optimal_usage_ratio,
+        get_einvalid_reserve_factor,
+        get_einvalid_reserve_index,
+        get_einvalid_reserve_params,
+        get_einvalid_signature,
+        get_einvalid_supply_cap,
+        get_einvalid_unbacked_mint_cap,
+        get_eltv_validation_failed,
+        get_eno_debt_of_selected_type,
+        get_eno_explicit_amount_to_repay_on_behalf,
+        get_eno_more_reserves_allowed,
+        get_eno_outstanding_variable_debt,
+        get_enot_contract,
+        get_enot_enough_available_user_balance,
+        get_eoperation_not_supported,
+        get_epool_addresses_do_not_match,
+        get_eprice_oracle_check_failed,
+        get_ereserve_already_added,
+        get_ereserve_already_initialized,
+        get_ereserve_debt_not_zero,
+        get_ereserve_frozen,
+        get_ereserve_inactive,
+        get_ereserve_liquidity_not_zero,
+        get_ereserve_paused,
+        get_ereserves_storage_count_mismatch,
+        get_esigner_and_on_behalf_of_no_same,
+        get_esiloed_borrowing_violation,
+        get_especified_currency_not_borrowed_by_user,
+        get_esupply_cap_exceeded,
+        get_eunbacked_mint_cap_exceeded,
+        get_eunderlying_balance_zero,
+        get_eunderlying_cannot_be_rescued,
+        get_eunderlying_claimable_rights_not_zero,
+        get_euser_in_isolation_mode_or_ltv_zero,
+        get_euser_not_listed,
+        get_evariable_debt_supply_not_zero,
+        get_ezero_address_not_valid,
+        get_flashloan_payer_not_receiver
+    };
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    /// The caller of the function is not a pool admin
+    const ECALLER_NOT_POOL_ADMIN: u64 = 1;
+    /// The caller of the function is not an emergency admin
+    const ECALLER_NOT_EMERGENCY_ADMIN: u64 = 2;
+    /// The caller of the function is not a pool or emergency admin
+    const ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN: u64 = 3;
+    /// The caller of the function is not a risk or pool admin
+    const ECALLER_NOT_RISK_OR_POOL_ADMIN: u64 = 4;
+    /// The caller of the function is not an asset listing or pool admin
+    const ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN: u64 = 5;
+    /// The caller of the function is not a bridge
+    const ECALLER_NOT_BRIDGE: u64 = 6;
+    /// Pool addresses provider is not registered
+    const EADDRESSES_PROVIDER_NOT_REGISTERED: u64 = 7;
+    /// Invalid id for the pool addresses provider
+    const EINVALID_ADDRESSES_PROVIDER_ID: u64 = 8;
+    /// Address is not a contract
+    const ENOT_CONTRACT: u64 = 9;
+    /// The caller of the function is not the pool configurator
+    const ECALLER_NOT_POOL_CONFIGURATOR: u64 = 10;
+    /// The caller of the function is not an AToken
+    const ECALLER_NOT_ATOKEN: u64 = 11;
+    /// The address of the pool addresses provider is invalid
+    const EINVALID_ADDRESSES_PROVIDER: u64 = 12;
+    /// Invalid return value of the flashloan executor function
+    const EINVALID_FLASHLOAN_EXECUTOR_RETURN: u64 = 13;
+    /// Reserve has already been added to reserve list
+    const ERESERVE_ALREADY_ADDED: u64 = 14;
+    /// Maximum amount of reserves in the pool reached
+    const ENO_MORE_RESERVES_ALLOWED: u64 = 15;
+    /// Zero eMode category is reserved for volatile heterogeneous assets
+    const EEMODE_CATEGORY_RESERVED: u64 = 16;
+    /// Invalid eMode category assignment to asset
+    const EINVALID_EMODE_CATEGORY_ASSIGNMENT: u64 = 17;
+    /// The liquidity of the reserve needs to be 0
+    const ERESERVE_LIQUIDITY_NOT_ZERO: u64 = 18;
+    /// Invalid flashloan premium
+    const EFLASHLOAN_PREMIUM_INVALID: u64 = 19;
+    /// Invalid risk parameters for the reserve
+    const EINVALID_RESERVE_PARAMS: u64 = 20;
+    /// Invalid risk parameters for the eMode category
+    const EINVALID_EMODE_CATEGORY_PARAMS: u64 = 21;
+    /// Invalid bridge protocol fee
+    const EBRIDGE_PROTOCOL_FEE_INVALID: u64 = 22;
+    /// The caller of this function must be a pool
+    const ECALLER_MUST_BE_POOL: u64 = 23;
+    /// Invalid amount to mint
+    const EINVALID_MINT_AMOUNT: u64 = 24;
+    /// Invalid amount to burn
+    const EINVALID_BURN_AMOUNT: u64 = 25;
+    /// Amount must be greater than 0
+    const EINVALID_AMOUNT: u64 = 26;
+    /// Action requires an active reserve
+    const ERESERVE_INACTIVE: u64 = 27;
+    /// Action cannot be performed because the reserve is frozen
+    const ERESERVE_FROZEN: u64 = 28;
+    /// Action cannot be performed because the reserve is paused
+    const ERESERVE_PAUSED: u64 = 29;
+    /// Borrowing is not enabled
+    const EBORROWING_NOT_ENABLED: u64 = 30;
+    /// User cannot withdraw more than the available balance
+    const ENOT_ENOUGH_AVAILABLE_USER_BALANCE: u64 = 32;
+    /// Invalid interest rate mode selected
+    const EINVALID_INTEREST_RATE_MODE_SELECTED: u64 = 33;
+    /// The collateral balance is 0
+    const ECOLLATERAL_BALANCE_IS_ZERO: u64 = 34;
+    /// Health factor is lesser than the liquidation threshold
+    const EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD: u64 = 35;
+    /// There is not enough collateral to cover a new borrow
+    const ECOLLATERAL_CANNOT_COVER_NEW_BORROW: u64 = 36;
+    /// Collateral is (mostly) the same currency that is being borrowed
+    const ECOLLATERAL_SAME_AS_BORROWING_CURRENCY: u64 = 37;
+    /// For repayment of a specific type of debt, the user needs to have debt that type
+    const ENO_DEBT_OF_SELECTED_TYPE: u64 = 39;
+    /// To repay on behalf of a user an explicit amount to repay is needed
+    const ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF: u64 = 40;
+    /// User does not have outstanding variable rate debt on this reserve
+    const ENO_OUTSTANDING_VARIABLE_DEBT: u64 = 42;
+    /// The underlying balance needs to be greater than 0
+    const EUNDERLYING_BALANCE_ZERO: u64 = 43;
+    /// Interest rate rebalance conditions were not met
+    const EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET: u64 = 44;
+    /// Health factor is not below the threshold
+    const EHEALTH_FACTOR_NOT_BELOW_THRESHOLD: u64 = 45;
+    /// The collateral chosen cannot be liquidated
+    const ECOLLATERAL_CANNOT_BE_LIQUIDATED: u64 = 46;
+    /// User did not borrow the specified currency
+    const ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER: u64 = 47;
+    /// Inconsistent flashloan parameters
+    const EINCONSISTENT_FLASHLOAN_PARAMS: u64 = 49;
+    /// Borrow cap is exceeded
+    const EBORROW_CAP_EXCEEDED: u64 = 50;
+    /// Supply cap is exceeded
+    const ESUPPLY_CAP_EXCEEDED: u64 = 51;
+    /// Unbacked mint cap is exceeded
+    const EUNBACKED_MINT_CAP_EXCEEDED: u64 = 52;
+    /// Debt ceiling is exceeded
+    const EDEBT_CEILING_EXCEEDED: u64 = 53;
+    /// Claimable rights over underlying not zero (aToken supply or accruedToTreasury)
+    const EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO: u64 = 54;
+    /// Variable debt supply is not zero
+    const EVARIABLE_DEBT_SUPPLY_NOT_ZERO: u64 = 56;
+    /// Ltv validation failed
+    const ELTV_VALIDATION_FAILED: u64 = 57;
+    /// Inconsistent eMode category
+    const EINCONSISTENT_EMODE_CATEGORY: u64 = 58;
+    /// Asset is not borrowable in isolation mode
+    const EASSET_NOT_BORROWABLE_IN_ISOLATION: u64 = 60;
+    /// Reserve has already been initialized
+    const ERESERVE_ALREADY_INITIALIZED: u64 = 61;
+    /// User is in isolation mode or ltv is zero
+    const EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO: u64 = 62;
+    /// Invalid ltv parameter for the reserve
+    const EINVALID_LTV: u64 = 63;
+    /// Invalid liquidity threshold parameter for the reserve
+    const EINVALID_LIQ_THRESHOLD: u64 = 64;
+    /// Invalid liquidity bonus parameter for the reserve
+    const EINVALID_LIQ_BONUS: u64 = 65;
+    /// Invalid decimals parameter of the underlying asset of the reserve
+    const EINVALID_DECIMALS: u64 = 66;
+    /// Invalid reserve factor parameter for the reserve
+    const EINVALID_RESERVE_FACTOR: u64 = 67;
+    /// Invalid borrow cap for the reserve
+    const EINVALID_BORROW_CAP: u64 = 68;
+    /// Invalid supply cap for the reserve
+    const EINVALID_SUPPLY_CAP: u64 = 69;
+    /// Invalid liquidation protocol fee for the reserve
+    const EINVALID_LIQUIDATION_PROTOCOL_FEE: u64 = 70;
+    /// Invalid eMode category for the reserve
+    const EINVALID_EMODE_CATEGORY: u64 = 71;
+    /// Invalid unbacked mint cap for the reserve
+    const EINVALID_UNBACKED_MINT_CAP: u64 = 72;
+    /// Invalid debt ceiling for the reserve
+    const EINVALID_DEBT_CEILING: u64 = 73;
+    /// Invalid reserve index
+    const EINVALID_RESERVE_INDEX: u64 = 74;
+    /// ACL admin cannot be set to the zero address
+    const EACL_ADMIN_CANNOT_BE_ZERO: u64 = 75;
+    /// Array parameters that should be equal length are not
+    const EINCONSISTENT_PARAMS_LENGTH: u64 = 76;
+    /// Zero address not valid
+    const EZERO_ADDRESS_NOT_VALID: u64 = 77;
+    /// Invalid expiration
+    const EINVALID_EXPIRATION: u64 = 78;
+    /// Invalid signature
+    const EINVALID_SIGNATURE: u64 = 79;
+    /// Operation not supported
+    const EOPERATION_NOT_SUPPORTED: u64 = 80;
+    /// Debt ceiling is not zero
+    const EDEBT_CEILING_NOT_ZERO: u64 = 81;
+    /// Asset is not listed
+    const EASSET_NOT_LISTED: u64 = 82;
+    /// Invalid optimal usage ratio
+    const EINVALID_OPTIMAL_USAGE_RATIO: u64 = 83;
+    /// The underlying asset cannot be rescued
+    const EUNDERLYING_CANNOT_BE_RESCUED: u64 = 85;
+    /// Reserve has already been added to reserve list
+    const EADDRESSES_PROVIDER_ALREADY_ADDED: u64 = 86;
+    /// The token implementation pool address and the pool address provided by the initializing pool do not match
+    const EPOOL_ADDRESSES_DO_NOT_MATCH: u64 = 87;
+
+    /// User is trying to borrow multiple assets including a siloed one
+    const ESILOED_BORROWING_VIOLATION: u64 = 89;
+    /// the total debt of the reserve needs to be 0
+    const ERESERVE_DEBT_NOT_ZERO: u64 = 90;
+    /// FlashLoaning for this asset is disabled
+    const EFLASHLOAN_DISABLED: u64 = 91;
+
+    /// Aptos has introduced a new business logic error code range from 1001 to 2000.
+
+    /// aave_acl module error code range from 1001 to 1100.
+    /// Account is not the acl's owner.
+    const ENOT_ACL_OWNER: u64 = 1001;
+    /// Account is missing role.
+    const EROLE_MISSMATCH: u64 = 1002;
+    /// can only renounce roles for self
+    const EROLE_CAN_ONLY_RENOUNCE_SELF: u64 = 1003;
+
+    /// aave_math module error code range from 1101 to 1200.
+    /// Calculation results in overflow
+    const EOVERFLOW: u64 = 1101;
+    /// Cannot divide by zero
+    const EDIVISION_BY_ZERO: u64 = 1102;
+
+    /// aave_oracle module error code range from 1201 to 1300.
+    /// Account is not the oracle's owner.
+    const ENOT_ORACLE_OWNER: u64 = 1201;
+    const ERESOURCE_NOT_FOUND: u64 = 1202;
+
+    /// aave_oracle
+    /// Not an asset listing or a pool admin error
+    const ENOT_ASSET_LISTING_OR_POOL_ADMIN: u64 = 1203;
+    /// base currency not set
+    const EBASE_CURRENCY_NOT_SET: u64 = 1204;
+    /// identical base currency already added
+    const EIDENTICAL_BASE_CURRENCY_ALREADY_ADDED: u64 = 1205;
+    /// missing price feed identifier
+    const EMISSING_PRICE_FEED_IDENTIFIER: u64 = 1206;
+    /// missing price vaa
+    const EMISSING_PRICE_VAA: u64 = 1207;
+    /// not existing price feed identifier
+    const EPRICE_FEED_IDENTIFIER_NOT_EXIST: u64 = 1208;
+
+    /// aave_rate module error code range from 1301 to 1400.
+    /// Account is not the rate's owner.
+    const ENOT_RATE_OWNER: u64 = 1301;
+
+    /// aave_pool module error code range from 1401 to 1500.
+    /// Account is not the pool's owner.
+    const ENOT_POOL_OWNER: u64 = 1401;
+    /// User is not listed
+    const EUSER_NOT_LISTED: u64 = 1402;
+    /// Mismatch of reserves count in storage
+    const ERESERVES_STORAGE_COUNT_MISMATCH: u64 = 1403;
+    /// The person who signed must be consistent with on_behalf_of
+    const ESIGNER_AND_ON_BEHALF_OF_NO_SAME: u64 = 1404;
+    /// Account does not exist
+    const EACCOUNT_DOES_NOT_EXIST: u64 = 1405;
+    /// Flashloan payer is different from the flashloan receiver
+    const EFLASHLOAN_PAYER_NOT_RECEIVER: u64 = 1406;
+    /// Price oracle validation failed
+    const EPRICE_ORACLE_CHECK_FAILED: u64 = 1407;
+    /// reserve list not initialized
+    const ERESERVE_LIST_NOT_INITIALIZED: u64 = 1408;
+
+    /// aave_tokens
+    /// Token already exists
+    const ETOKEN_ALREADY_EXISTS: u64 = 1409;
+    /// Token not exist
+    const ETOKEN_NOT_EXIST: u64 = 1410;
+    /// Resource not exist
+    const ERESOURCE_NOT_EXIST: u64 = 1411;
+    /// Token name already exist
+    const ETOKEN_NAME_ALREADY_EXIST: u64 = 1412;
+    /// Token symbol already exist
+    const ETOKEN_SYMBOL_ALREADY_EXIST: u64 = 1413;
+
+    #[test]
+    fun test_get_ecaller_not_pool_admin() {
+        assert!(get_ecaller_not_pool_admin() == ECALLER_NOT_POOL_ADMIN, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_ecaller_not_emergency_admin() {
+        assert!(
+            get_ecaller_not_emergency_admin() == ECALLER_NOT_EMERGENCY_ADMIN,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecaller_not_pool_or_emergency_admin() {
+        assert!(
+            get_ecaller_not_pool_or_emergency_admin()
+                == ECALLER_NOT_POOL_OR_EMERGENCY_ADMIN,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecaller_not_risk_or_pool_admin() {
+        assert!(
+            get_ecaller_not_risk_or_pool_admin() == ECALLER_NOT_RISK_OR_POOL_ADMIN,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecaller_not_asset_listing_or_pool_admin() {
+        assert!(
+            get_ecaller_not_asset_listing_or_pool_admin()
+                == ECALLER_NOT_ASSET_LISTING_OR_POOL_ADMIN,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecaller_not_bridge() {
+        assert!(get_ecaller_not_bridge() == ECALLER_NOT_BRIDGE, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eaddresses_provider_not_registered() {
+        assert!(
+            get_eaddresses_provider_not_registered()
+                == EADDRESSES_PROVIDER_NOT_REGISTERED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_addresses_provider_id() {
+        assert!(
+            get_einvalid_addresses_provider_id() == EINVALID_ADDRESSES_PROVIDER_ID,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_enot_contract() {
+        assert!(get_enot_contract() == ENOT_CONTRACT, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_ecaller_not_pool_configurator() {
+        assert!(
+            get_ecaller_not_pool_configurator() == ECALLER_NOT_POOL_CONFIGURATOR,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecaller_not_atoken() {
+        assert!(get_ecaller_not_atoken() == ECALLER_NOT_ATOKEN, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_addresses_provider() {
+        assert!(
+            get_einvalid_addresses_provider() == EINVALID_ADDRESSES_PROVIDER,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_flashloan_executor_return() {
+        assert!(
+            get_einvalid_flashloan_executor_return()
+                == EINVALID_FLASHLOAN_EXECUTOR_RETURN,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ereserve_already_added() {
+        assert!(get_ereserve_already_added() == ERESERVE_ALREADY_ADDED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_ereserves_storage_count_mismatch() {
+        assert!(
+            get_ereserves_storage_count_mismatch() == ERESERVES_STORAGE_COUNT_MISMATCH,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eno_more_reserves_allowed() {
+        assert!(
+            get_eno_more_reserves_allowed() == ENO_MORE_RESERVES_ALLOWED, TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eemode_category_reserved() {
+        assert!(get_eemode_category_reserved() == EEMODE_CATEGORY_RESERVED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_emode_category_assignment() {
+        assert!(
+            get_einvalid_emode_category_assignment()
+                == EINVALID_EMODE_CATEGORY_ASSIGNMENT,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ereserve_liquidity_not_zero() {
+        assert!(
+            get_ereserve_liquidity_not_zero() == ERESERVE_LIQUIDITY_NOT_ZERO,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eflashloan_premium_invalid() {
+        assert!(
+            get_eflashloan_premium_invalid() == EFLASHLOAN_PREMIUM_INVALID,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_reserve_params() {
+        assert!(get_einvalid_reserve_params() == EINVALID_RESERVE_PARAMS, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_emode_category_params() {
+        assert!(
+            get_einvalid_emode_category_params() == EINVALID_EMODE_CATEGORY_PARAMS,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ebridge_protocol_fee_invalid() {
+        assert!(
+            get_ebridge_protocol_fee_invalid() == EBRIDGE_PROTOCOL_FEE_INVALID,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecaller_must_be_pool() {
+        assert!(get_ecaller_must_be_pool() == ECALLER_MUST_BE_POOL, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_mint_amount() {
+        assert!(get_einvalid_mint_amount() == EINVALID_MINT_AMOUNT, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_burn_amount() {
+        assert!(get_einvalid_burn_amount() == EINVALID_BURN_AMOUNT, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_amount() {
+        assert!(get_einvalid_amount() == EINVALID_AMOUNT, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_ereserve_inactive() {
+        assert!(get_ereserve_inactive() == ERESERVE_INACTIVE, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_ereserve_frozen() {
+        assert!(get_ereserve_frozen() == ERESERVE_FROZEN, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_ereserve_paused() {
+        assert!(get_ereserve_paused() == ERESERVE_PAUSED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eborrowing_not_enabled() {
+        assert!(get_eborrowing_not_enabled() == EBORROWING_NOT_ENABLED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_enot_enough_available_user_balance() {
+        assert!(
+            get_enot_enough_available_user_balance()
+                == ENOT_ENOUGH_AVAILABLE_USER_BALANCE,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_interest_rate_mode_selected() {
+        assert!(
+            get_einvalid_interest_rate_mode_selected()
+                == EINVALID_INTEREST_RATE_MODE_SELECTED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecollateral_balance_is_zero() {
+        assert!(
+            get_ecollateral_balance_is_zero() == ECOLLATERAL_BALANCE_IS_ZERO,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ehealth_factor_lower_than_liquidation_threshold() {
+        assert!(
+            get_ehealth_factor_lower_than_liquidation_threshold()
+                == EHEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecollateral_cannot_cover_new_borrow() {
+        assert!(
+            get_ecollateral_cannot_cover_new_borrow()
+                == ECOLLATERAL_CANNOT_COVER_NEW_BORROW,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecollateral_same_as_borrowing_currency() {
+        assert!(
+            get_ecollateral_same_as_borrowing_currency()
+                == ECOLLATERAL_SAME_AS_BORROWING_CURRENCY,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eno_debt_of_selected_type() {
+        assert!(
+            get_eno_debt_of_selected_type() == ENO_DEBT_OF_SELECTED_TYPE, TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eno_explicit_amount_to_repay_on_behalf() {
+        assert!(
+            get_eno_explicit_amount_to_repay_on_behalf()
+                == ENO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eno_outstanding_variable_debt() {
+        assert!(
+            get_eno_outstanding_variable_debt() == ENO_OUTSTANDING_VARIABLE_DEBT,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eunderlying_balance_zero() {
+        assert!(get_eunderlying_balance_zero() == EUNDERLYING_BALANCE_ZERO, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einterest_rate_rebalance_conditions_not_met() {
+        assert!(
+            get_einterest_rate_rebalance_conditions_not_met()
+                == EINTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ehealth_factor_not_below_threshold() {
+        assert!(
+            get_ehealth_factor_not_below_threshold()
+                == EHEALTH_FACTOR_NOT_BELOW_THRESHOLD,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ecollateral_cannot_be_liquidated() {
+        assert!(
+            get_ecollateral_cannot_be_liquidated() == ECOLLATERAL_CANNOT_BE_LIQUIDATED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_especified_currency_not_borrowed_by_user() {
+        assert!(
+            get_especified_currency_not_borrowed_by_user()
+                == ESPECIFIED_CURRENCY_NOT_BORROWED_BY_USER,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einconsistent_flashloan_params() {
+        assert!(
+            get_einconsistent_flashloan_params() == EINCONSISTENT_FLASHLOAN_PARAMS,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eborrow_cap_exceeded() {
+        assert!(get_eborrow_cap_exceeded() == EBORROW_CAP_EXCEEDED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_esupply_cap_exceeded() {
+        assert!(get_esupply_cap_exceeded() == ESUPPLY_CAP_EXCEEDED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eunbacked_mint_cap_exceededd() {
+        assert!(
+            get_eunbacked_mint_cap_exceeded() == EUNBACKED_MINT_CAP_EXCEEDED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_edebt_ceiling_exceeded() {
+        assert!(get_edebt_ceiling_exceeded() == EDEBT_CEILING_EXCEEDED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eunderlying_claimable_rights_not_zero() {
+        assert!(
+            get_eunderlying_claimable_rights_not_zero()
+                == EUNDERLYING_CLAIMABLE_RIGHTS_NOT_ZERO,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_evariable_debt_supply_not_zero() {
+        assert!(
+            get_evariable_debt_supply_not_zero() == EVARIABLE_DEBT_SUPPLY_NOT_ZERO,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eltv_validation_failed() {
+        assert!(get_eltv_validation_failed() == ELTV_VALIDATION_FAILED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einconsistent_emode_category() {
+        assert!(
+            get_einconsistent_emode_category() == EINCONSISTENT_EMODE_CATEGORY,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_easset_not_borrowable_in_isolation() {
+        assert!(
+            get_easset_not_borrowable_in_isolation()
+                == EASSET_NOT_BORROWABLE_IN_ISOLATION,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ereserve_already_initialized() {
+        assert!(
+            get_ereserve_already_initialized() == ERESERVE_ALREADY_INITIALIZED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_euser_in_isolation_mode_or_ltv_zero() {
+        assert!(
+            get_euser_in_isolation_mode_or_ltv_zero()
+                == EUSER_IN_ISOLATION_MODE_OR_LTV_ZERO,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_ltv() {
+        assert!(get_einvalid_ltv() == EINVALID_LTV, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_liq_threshold() {
+        assert!(get_einvalid_liq_threshold() == EINVALID_LIQ_THRESHOLD, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_decimals() {
+        assert!(get_einvalid_decimals() == EINVALID_DECIMALS, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_reserve_factor() {
+        assert!(get_einvalid_reserve_factor() == EINVALID_RESERVE_FACTOR, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_borrow_cap() {
+        assert!(get_einvalid_borrow_cap() == EINVALID_BORROW_CAP, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_supply_cap() {
+        assert!(get_einvalid_supply_cap() == EINVALID_SUPPLY_CAP, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_liquidation_protocol_fee() {
+        assert!(
+            get_einvalid_liquidation_protocol_fee()
+                == EINVALID_LIQUIDATION_PROTOCOL_FEE,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_emode_category() {
+        assert!(get_einvalid_emode_category() == EINVALID_EMODE_CATEGORY, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_unbacked_mint_cap() {
+        assert!(
+            get_einvalid_unbacked_mint_cap() == EINVALID_UNBACKED_MINT_CAP,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_debt_ceiling() {
+        assert!(get_einvalid_debt_ceiling() == EINVALID_DEBT_CEILING, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_reserve_index() {
+        assert!(get_einvalid_reserve_index() == EINVALID_RESERVE_INDEX, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eacl_admin_cannot_be_zero() {
+        assert!(
+            get_eacl_admin_cannot_be_zero() == EACL_ADMIN_CANNOT_BE_ZERO, TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einconsistent_params_length() {
+        assert!(
+            get_einconsistent_params_length() == EINCONSISTENT_PARAMS_LENGTH,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ezero_address_not_valid() {
+        assert!(get_ezero_address_not_valid() == EZERO_ADDRESS_NOT_VALID, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_expiration() {
+        assert!(get_einvalid_expiration() == EINVALID_EXPIRATION, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_signature() {
+        assert!(get_einvalid_signature() == EINVALID_SIGNATURE, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eoperation_not_supported() {
+        assert!(get_eoperation_not_supported() == EOPERATION_NOT_SUPPORTED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_edebt_ceiling_not_zero() {
+        assert!(get_edebt_ceiling_not_zero() == EDEBT_CEILING_NOT_ZERO, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_easset_not_listed() {
+        assert!(get_easset_not_listed() == EASSET_NOT_LISTED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_einvalid_optimal_usage_ratio() {
+        assert!(
+            get_einvalid_optimal_usage_ratio() == EINVALID_OPTIMAL_USAGE_RATIO,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eunderlying_cannot_be_rescued() {
+        assert!(
+            get_eunderlying_cannot_be_rescued() == EUNDERLYING_CANNOT_BE_RESCUED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eaddresses_provider_already_added() {
+        assert!(
+            get_eaddresses_provider_already_added()
+                == EADDRESSES_PROVIDER_ALREADY_ADDED,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_epool_addresses_do_not_match() {
+        assert!(
+            get_epool_addresses_do_not_match() == EPOOL_ADDRESSES_DO_NOT_MATCH,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_esiloed_borrowing_violation() {
+        assert!(
+            get_esiloed_borrowing_violation() == ESILOED_BORROWING_VIOLATION,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_ereserve_debt_not_zero() {
+        assert!(get_ereserve_debt_not_zero() == ERESERVE_DEBT_NOT_ZERO, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_eflashloan_disabled() {
+        assert!(get_eflashloan_disabled() == EFLASHLOAN_DISABLED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_euser_not_listed() {
+        assert!(get_euser_not_listed() == EUSER_NOT_LISTED, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_esigner_and_on_behalf_of_no_same() {
+        assert!(
+            get_esigner_and_on_behalf_of_no_same() == ESIGNER_AND_ON_BEHALF_OF_NO_SAME,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_eaccount_does_not_exist() {
+        assert!(get_eaccount_does_not_exist() == EACCOUNT_DOES_NOT_EXIST, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_flashloan_payer_not_receiver() {
+        assert!(
+            get_flashloan_payer_not_receiver() == EFLASHLOAN_PAYER_NOT_RECEIVER,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_get_einvalid_liq_bonus() {
+        assert!(get_einvalid_liq_bonus() == EINVALID_LIQ_BONUS, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_get_price_oracle_check_failed() {
+        assert!(
+            get_eprice_oracle_check_failed() == EPRICE_ORACLE_CHECK_FAILED,
+            TEST_SUCCESS
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/tests/reserve_config_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/tests/reserve_config_tests.move
@@ -1,0 +1,487 @@
+#[test_only]
+module aave_config::reserve_tests {
+    use aave_config::reserve_config::{
+        get_borrow_cap,
+        get_borrowing_enabled,
+        get_caps,
+        get_decimals,
+        get_emode_category,
+        get_flags,
+        get_flash_loan_enabled,
+        get_frozen,
+        get_liquidation_bonus,
+        get_liquidation_protocol_fee,
+        get_liquidation_threshold,
+        get_ltv,
+        get_max_valid_decimals,
+        get_max_valid_emode_category,
+        get_max_valid_liquidation_protocol_fee,
+        get_max_valid_liquidation_threshold,
+        get_max_valid_ltv,
+        get_max_valid_reserve_factor,
+        get_params,
+        get_reserve_factor,
+        get_supply_cap,
+        get_unbacked_mint_cap,
+        init,
+        ReserveConfigurationMap,
+        set_borrow_cap,
+        set_borrowing_enabled,
+        set_decimals,
+        set_emode_category,
+        set_flash_loan_enabled,
+        set_frozen,
+        set_liquidation_bonus,
+        set_liquidation_protocol_fee,
+        set_liquidation_threshold,
+        set_ltv,
+        set_reserve_factor,
+        set_supply_cap,
+        set_unbacked_mint_cap
+    };
+
+    //
+    // Test example reference link: https://github.com/aave/aave-v3-core/blob/master/test-suites/reserve-configuration.spec.ts
+    // test functions
+    //
+    #[test_only]
+    const ZERO: u256 = 0;
+    const LTV: u256 = 8000;
+    const LB: u256 = 500;
+    const RESERVE_FACTOR: u256 = 1000;
+    const DECIMALS: u256 = 18;
+    const BORROW_CAP: u256 = 100;
+    const SUPPLY_CAP: u256 = 200;
+    const UNBACKED_MINT_CAP: u256 = 300;
+    const EMODE_CATEGORY: u256 = 1;
+
+    // error
+    const SUCCESS: u64 = 1;
+    const FAILED: u64 = 2;
+
+    // enum
+    const ENUM_LTV: u256 = 1;
+    const ENUM_LIQUIDATION_THRESHOLD: u256 = 2;
+    const ENUM_LIQUIDATION_BONUS: u256 = 3;
+    const ENUM_DECIMALS: u256 = 4;
+    const ENUM_RESERVE_FACTOR: u256 = 5;
+    const ENUM_EMODE_CATEGORY: u256 = 6;
+
+    // check params
+    fun check_params(
+        reserve_config: &ReserveConfigurationMap, param_key: u256, param_val: u256
+    ) {
+        let (
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            decimals,
+            reserve_factor,
+            emode_category
+        ) = get_params(reserve_config);
+        if (param_key == ENUM_LTV) {
+            assert!(ltv == param_val, SUCCESS);
+        } else {
+            assert!(ltv == 0, SUCCESS);
+        };
+
+        if (param_key == ENUM_LIQUIDATION_THRESHOLD) {
+            assert!(liquidation_threshold == param_val, SUCCESS);
+        } else {
+            assert!(liquidation_threshold == 0, SUCCESS);
+        };
+
+        if (param_key == ENUM_LIQUIDATION_BONUS) {
+            assert!(liquidation_bonus == param_val, SUCCESS);
+        } else {
+            assert!(liquidation_bonus == 0, SUCCESS);
+        };
+
+        if (param_key == ENUM_DECIMALS) {
+            assert!(decimals == param_val, SUCCESS);
+        } else {
+            assert!(decimals == 0, SUCCESS);
+        };
+
+        if (param_key == ENUM_RESERVE_FACTOR) {
+            assert!(reserve_factor == param_val, SUCCESS);
+        } else {
+            assert!(reserve_factor == 0, SUCCESS);
+        };
+
+        if (param_key == ENUM_EMODE_CATEGORY) {
+            assert!(emode_category == param_val, SUCCESS);
+        } else {
+            assert!(emode_category == 0, SUCCESS);
+        };
+    }
+
+    #[test]
+    fun test_get_ltv() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_ltv(&reserve_config) == ZERO, SUCCESS);
+
+        set_ltv(&mut reserve_config, LTV);
+        check_params(&reserve_config, ENUM_LTV, LTV);
+        assert!(get_ltv(&reserve_config) == LTV, SUCCESS);
+
+        set_ltv(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_LTV, ZERO);
+        assert!(get_ltv(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_liquidation_bonus() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_liquidation_bonus(&reserve_config) == ZERO, SUCCESS);
+
+        set_liquidation_bonus(&mut reserve_config, LB);
+        check_params(&reserve_config, ENUM_LIQUIDATION_BONUS, LB);
+        assert!(get_liquidation_bonus(&reserve_config) == LB, SUCCESS);
+
+        set_liquidation_bonus(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_LIQUIDATION_BONUS, ZERO);
+        assert!(get_liquidation_bonus(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_decimals() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_decimals(&reserve_config) == ZERO, SUCCESS);
+
+        set_decimals(&mut reserve_config, DECIMALS);
+        check_params(&reserve_config, ENUM_DECIMALS, DECIMALS);
+        assert!(get_decimals(&reserve_config) == DECIMALS, SUCCESS);
+
+        set_decimals(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_DECIMALS, ZERO);
+        assert!(get_decimals(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_emode_category() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_emode_category(&reserve_config) == ZERO, SUCCESS);
+
+        set_emode_category(&mut reserve_config, EMODE_CATEGORY);
+        check_params(&reserve_config, ENUM_EMODE_CATEGORY, EMODE_CATEGORY);
+        assert!(get_emode_category(&reserve_config) == EMODE_CATEGORY, SUCCESS);
+
+        set_emode_category(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_EMODE_CATEGORY, ZERO);
+        assert!(get_emode_category(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_reserve_factor() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_reserve_factor(&reserve_config) == ZERO, SUCCESS);
+
+        set_reserve_factor(&mut reserve_config, RESERVE_FACTOR);
+        check_params(&reserve_config, ENUM_RESERVE_FACTOR, RESERVE_FACTOR);
+        assert!(get_reserve_factor(&reserve_config) == RESERVE_FACTOR, SUCCESS);
+
+        set_reserve_factor(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_RESERVE_FACTOR, ZERO);
+        assert!(get_reserve_factor(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_frozen() {
+        let reserve_config = init();
+        let (active, frozen, borrowing_enabled, paused) = get_flags(&reserve_config);
+        assert!(active == false, SUCCESS);
+        assert!(frozen == false, SUCCESS);
+        assert!(borrowing_enabled == false, SUCCESS);
+        assert!(paused == false, SUCCESS);
+        assert!(get_frozen(&reserve_config) == false, SUCCESS);
+
+        set_frozen(&mut reserve_config, true);
+        let (active, frozen, borrowing_enabled, paused) = get_flags(&reserve_config);
+        assert!(active == false, SUCCESS);
+        assert!(frozen == true, SUCCESS);
+        assert!(borrowing_enabled == false, SUCCESS);
+        assert!(paused == false, SUCCESS);
+        assert!(get_frozen(&reserve_config) == true, SUCCESS);
+
+        set_frozen(&mut reserve_config, false);
+        let (active, frozen, borrowing_enabled, paused) = get_flags(&reserve_config);
+        assert!(active == false, SUCCESS);
+        assert!(frozen == false, SUCCESS);
+        assert!(borrowing_enabled == false, SUCCESS);
+        assert!(paused == false, SUCCESS);
+        assert!(get_frozen(&reserve_config) == false, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_borrowing_enabled() {
+        let reserve_config = init();
+        let (active, frozen, borrowing_enabled, paused) = get_flags(&reserve_config);
+        assert!(active == false, SUCCESS);
+        assert!(frozen == false, SUCCESS);
+        assert!(borrowing_enabled == false, SUCCESS);
+        assert!(paused == false, SUCCESS);
+        assert!(get_borrowing_enabled(&reserve_config) == false, SUCCESS);
+
+        set_borrowing_enabled(&mut reserve_config, true);
+        let (active, frozen, borrowing_enabled, paused) = get_flags(&reserve_config);
+        assert!(active == false, SUCCESS);
+        assert!(frozen == false, SUCCESS);
+        assert!(borrowing_enabled == true, SUCCESS);
+        assert!(paused == false, SUCCESS);
+        assert!(get_borrowing_enabled(&reserve_config) == true, SUCCESS);
+
+        set_borrowing_enabled(&mut reserve_config, false);
+        let (active, frozen, borrowing_enabled, paused) = get_flags(&reserve_config);
+        assert!(active == false, SUCCESS);
+        assert!(frozen == false, SUCCESS);
+        assert!(borrowing_enabled == false, SUCCESS);
+        assert!(paused == false, SUCCESS);
+        assert!(get_borrowing_enabled(&reserve_config) == false, SUCCESS);
+    }
+
+    #[test]
+    // set_reserve_factor() with reserve_factor == MAX_VALID_RESERVE_FACTOR
+    fun test_set_reserve_factor() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+
+        set_reserve_factor(&mut reserve_config, get_max_valid_reserve_factor());
+        check_params(
+            &reserve_config, ENUM_RESERVE_FACTOR, get_max_valid_reserve_factor()
+        );
+    }
+
+    #[test]
+    // set_reserve_factor() with reserve_factor > MAX_VALID_RESERVE_FACTOR
+    #[expected_failure(abort_code = 67, location = aave_config::reserve_config)]
+    fun test_set_reserve_factor_expected_failure() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        set_reserve_factor(&mut reserve_config, get_max_valid_reserve_factor() + 1);
+
+        check_params(&reserve_config, ZERO, ZERO);
+    }
+
+    #[test]
+    fun test_get_borrow_cap() {
+        let reserve_config = init();
+        let (borrow_cap, supply_cap) = get_caps(&reserve_config);
+        assert!(borrow_cap == ZERO, SUCCESS);
+        assert!(supply_cap == ZERO, SUCCESS);
+        assert!(get_borrow_cap(&reserve_config) == ZERO, SUCCESS);
+
+        set_borrow_cap(&mut reserve_config, BORROW_CAP);
+        // borrow cap is the 1st cap
+        let (borrow_cap, supply_cap) = get_caps(&reserve_config);
+        assert!(borrow_cap == BORROW_CAP, SUCCESS);
+        assert!(supply_cap == ZERO, SUCCESS);
+        assert!(get_borrow_cap(&reserve_config) == BORROW_CAP, SUCCESS);
+
+        set_borrow_cap(&mut reserve_config, ZERO);
+        let (borrow_cap, supply_cap) = get_caps(&reserve_config);
+        assert!(borrow_cap == ZERO, SUCCESS);
+        assert!(supply_cap == ZERO, SUCCESS);
+        assert!(get_borrow_cap(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_supply_cap() {
+        let reserve_config = init();
+        let (borrow_cap, supply_cap) = get_caps(&reserve_config);
+        assert!(borrow_cap == ZERO, SUCCESS);
+        assert!(supply_cap == ZERO, SUCCESS);
+        assert!(get_supply_cap(&reserve_config) == ZERO, SUCCESS);
+
+        set_supply_cap(&mut reserve_config, SUPPLY_CAP);
+        // borrow cap is the 1st cap
+        let (borrow_cap, supply_cap) = get_caps(&reserve_config);
+        assert!(borrow_cap == ZERO, SUCCESS);
+        assert!(supply_cap == SUPPLY_CAP, SUCCESS);
+        assert!(get_supply_cap(&reserve_config) == SUPPLY_CAP, SUCCESS);
+
+        set_supply_cap(&mut reserve_config, ZERO);
+        let (borrow_cap, supply_cap) = get_caps(&reserve_config);
+        assert!(borrow_cap == ZERO, SUCCESS);
+        assert!(supply_cap == ZERO, SUCCESS);
+        assert!(get_supply_cap(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_unbacked_mint_cap() {
+        let reserve_config = init();
+        assert!(get_unbacked_mint_cap(&reserve_config) == ZERO, SUCCESS);
+
+        set_unbacked_mint_cap(&mut reserve_config, UNBACKED_MINT_CAP);
+        assert!(get_unbacked_mint_cap(&reserve_config) == UNBACKED_MINT_CAP, SUCCESS);
+
+        set_unbacked_mint_cap(&mut reserve_config, ZERO);
+        assert!(get_unbacked_mint_cap(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    fun test_get_flash_loan_enabled() {
+        let reserve_config = init();
+        assert!(get_flash_loan_enabled(&reserve_config) == false, SUCCESS);
+
+        set_flash_loan_enabled(&mut reserve_config, true);
+        assert!(get_flash_loan_enabled(&reserve_config) == true, SUCCESS);
+
+        set_flash_loan_enabled(&mut reserve_config, false);
+        assert!(get_flash_loan_enabled(&reserve_config) == false, SUCCESS);
+    }
+
+    #[test]
+    // set_ltv() with ltv = MAX_VALID_LTV
+    fun test_set_ltv() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_ltv(&reserve_config) == ZERO, SUCCESS);
+
+        set_ltv(&mut reserve_config, get_max_valid_ltv());
+        check_params(&reserve_config, ENUM_LTV, get_max_valid_ltv());
+        assert!(get_ltv(&reserve_config) == get_max_valid_ltv(), SUCCESS);
+
+        set_ltv(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_LTV, ZERO);
+        assert!(get_ltv(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_ltv() with ltv > MAX_VALID_LTV (revert expected)
+    #[expected_failure(abort_code = 63, location = aave_config::reserve_config)]
+    fun test_set_ltv_expected_failure() {
+        let reserve_config = init();
+        assert!(get_ltv(&reserve_config) == ZERO, SUCCESS);
+
+        set_ltv(&mut reserve_config, get_max_valid_ltv() + 1);
+        assert!(get_ltv(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_liquidation_threshold() with threshold = MAX_VALID_LIQUIDATION_THRESHOLD
+    fun test_set_liquidation_threshold() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_liquidation_threshold(&reserve_config) == ZERO, SUCCESS);
+
+        set_liquidation_threshold(
+            &mut reserve_config, get_max_valid_liquidation_threshold()
+        );
+        check_params(
+            &reserve_config,
+            ENUM_LIQUIDATION_THRESHOLD,
+            get_max_valid_liquidation_threshold()
+        );
+        assert!(
+            get_liquidation_threshold(&reserve_config)
+                == get_max_valid_liquidation_threshold(),
+            SUCCESS
+        );
+
+        set_liquidation_threshold(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_LIQUIDATION_THRESHOLD, ZERO);
+        assert!(get_liquidation_threshold(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_liquidation_threshold() with threshold > MAX_VALID_LIQUIDATION_THRESHOLD (revert expected)
+    #[expected_failure(abort_code = 64, location = aave_config::reserve_config)]
+    fun test_set_liquidation_threshold_expected_failure() {
+        let reserve_config = init();
+        assert!(get_liquidation_threshold(&reserve_config) == ZERO, SUCCESS);
+
+        set_liquidation_threshold(
+            &mut reserve_config, get_max_valid_liquidation_threshold() + 1
+        );
+        assert!(get_liquidation_threshold(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_decimals() with decimals = MAX_VALID_DECIMALS
+    fun test_set_decimals() {
+        let reserve_config = init();
+        check_params(&reserve_config, ZERO, ZERO);
+        assert!(get_decimals(&reserve_config) == ZERO, SUCCESS);
+
+        set_decimals(&mut reserve_config, get_max_valid_decimals());
+        check_params(&reserve_config, ENUM_DECIMALS, get_max_valid_decimals());
+        assert!(get_decimals(&reserve_config) == get_max_valid_decimals(), SUCCESS);
+
+        set_decimals(&mut reserve_config, ZERO);
+        check_params(&reserve_config, ENUM_DECIMALS, ZERO);
+        assert!(get_decimals(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_decimals() with decimals > MAX_VALID_DECIMALS (revert expected)
+    #[expected_failure(abort_code = 66, location = aave_config::reserve_config)]
+    fun test_set_decimals_expected_failure() {
+        let reserve_config = init();
+        assert!(get_decimals(&reserve_config) == ZERO, SUCCESS);
+
+        set_decimals(&mut reserve_config, get_max_valid_decimals() + 1);
+        assert!(get_decimals(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_emode_category() with categoryID = MAX_VALID_EMODE_CATEGORY
+    fun test_set_emode_category() {
+        let reserve_config = init();
+        assert!(get_emode_category(&reserve_config) == ZERO, SUCCESS);
+
+        set_emode_category(&mut reserve_config, get_max_valid_emode_category());
+        assert!(
+            get_emode_category(&reserve_config) == get_max_valid_emode_category(),
+            SUCCESS
+        );
+
+        set_emode_category(&mut reserve_config, ZERO);
+        assert!(get_emode_category(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_emode_category() with category_id > MAX_VALID_EMODE_CATEGORY (revert expected)
+    #[expected_failure(abort_code = 71, location = aave_config::reserve_config)]
+    fun test_set_emode_category_expected_failure() {
+        let reserve_config = init();
+        assert!(get_emode_category(&reserve_config) == ZERO, SUCCESS);
+
+        set_emode_category(&mut reserve_config, get_max_valid_decimals() + 1);
+        assert!(get_emode_category(&reserve_config) == ZERO, SUCCESS);
+    }
+
+    #[test]
+    // set_liquidation_protocol_fee() with liquidation_protocol_fee == MAX_VALID_LIQUIDATION_PROTOCOL_FEE
+    fun test_set_liquidation_protocol_fee() {
+        let reserve_config = init();
+        assert!(get_liquidation_protocol_fee(&reserve_config) == ZERO, SUCCESS);
+
+        set_liquidation_protocol_fee(
+            &mut reserve_config, get_max_valid_liquidation_protocol_fee()
+        );
+        assert!(
+            get_liquidation_protocol_fee(&reserve_config)
+                == get_max_valid_liquidation_protocol_fee(),
+            SUCCESS
+        );
+    }
+
+    #[test]
+    // setLiquidationProtocolFee() with liquidationProtocolFee > MAX_VALID_LIQUIDATION_PROTOCOL_FEE (revert expected)
+    #[expected_failure(abort_code = 70, location = aave_config::reserve_config)]
+    fun test_set_liquidation_protocol_fee_expected_failure() {
+        let reserve_config = init();
+        assert!(get_liquidation_protocol_fee(&reserve_config) == ZERO, SUCCESS);
+
+        set_liquidation_protocol_fee(
+            &mut reserve_config, get_max_valid_liquidation_protocol_fee() + 1
+        );
+        assert!(get_liquidation_protocol_fee(&reserve_config) == ZERO, SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-config/tests/user_config_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-config/tests/user_config_tests.move
@@ -1,0 +1,102 @@
+#[test_only]
+module aave_config::user_tests {
+    use aave_config::helper::Self;
+    use aave_config::user_config::{
+        get_first_asset_id_by_mask,
+        get_health_factor_liquidation_threshold,
+        get_health_factor_liquidation_threshold_for_testing,
+        get_isolated_collateral_supplier_role,
+        get_isolated_collateral_supplier_role_for_testing,
+        get_minimum_health_factor_liquidation_threshold,
+        get_minimum_health_factor_liquidation_threshold_for_testing,
+        get_user_config_map,
+        is_borrowing,
+        is_borrowing_any,
+        is_borrowing_one,
+        is_empty,
+        is_using_as_collateral,
+        is_using_as_collateral_any,
+        is_using_as_collateral_one,
+        is_using_as_collateral_or_borrowing,
+        set_borrowing,
+        set_using_as_collateral,
+        test_init_module
+    };
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(admin = @aave_config)]
+    fun test_user_config(admin: &signer) {
+        test_init_module(admin);
+        assert!(
+            get_minimum_health_factor_liquidation_threshold()
+                == get_minimum_health_factor_liquidation_threshold_for_testing(),
+            TEST_SUCCESS
+        );
+        assert!(
+            get_health_factor_liquidation_threshold()
+                == get_health_factor_liquidation_threshold_for_testing(),
+            TEST_SUCCESS
+        );
+        assert!(
+            get_isolated_collateral_supplier_role()
+                == get_isolated_collateral_supplier_role_for_testing(),
+            TEST_SUCCESS
+        );
+        // test default values
+        let user_config_map = get_user_config_map();
+        assert!(is_empty(&user_config_map), TEST_SUCCESS);
+        assert!(!is_borrowing_any(&user_config_map), TEST_SUCCESS);
+        assert!(!is_using_as_collateral_any(&user_config_map), TEST_SUCCESS);
+        let user_config_map = get_user_config_map();
+        // test borrowing
+        let reserve_index: u256 = 1;
+        set_borrowing(&mut user_config_map, reserve_index, true);
+        assert!(is_borrowing(&mut user_config_map, reserve_index), TEST_SUCCESS);
+        assert!(is_borrowing_any(&mut user_config_map), TEST_SUCCESS);
+        assert!(is_borrowing_one(&mut user_config_map), TEST_SUCCESS);
+        assert!(
+            is_using_as_collateral_or_borrowing(&mut user_config_map, reserve_index),
+            TEST_SUCCESS
+        );
+        // test collateral
+        set_using_as_collateral(&mut user_config_map, reserve_index, true);
+        assert!(is_using_as_collateral(&user_config_map, reserve_index), TEST_SUCCESS);
+        assert!(is_using_as_collateral_any(&user_config_map), TEST_SUCCESS);
+        assert!(is_using_as_collateral_one(&user_config_map), TEST_SUCCESS);
+        assert!(
+            is_using_as_collateral_or_borrowing(&user_config_map, reserve_index),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(admin = @aave_config)]
+    fun test_get_first_asset_id_by_mask(admin: &signer) {
+        test_init_module(admin);
+        let user_config_map = get_user_config_map();
+        let reserve_index: u256 = 1;
+        set_using_as_collateral(&mut user_config_map, reserve_index, true);
+        let mask = 1 << (((reserve_index << 1) + 1) as u8);
+        assert!(get_first_asset_id_by_mask(&user_config_map, mask) == 1, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_bit_shifts() {
+        let reserve_index: u256 = 127;
+        let bit: u256 = 1 << ((reserve_index << 1) as u8);
+        let data: u256 = 100000;
+        data = data & helper::bitwise_negation(bit);
+        assert!(data == 100000, 1);
+    }
+
+    #[test]
+    #[expected_failure(arithmetic_error, location = Self)]
+    fun test_bit_shifts_arithmetic_error() {
+        let reserve_index: u256 = 128;
+        let bit: u256 = 1 << ((reserve_index << 1) as u8);
+        let data: u256 = 100000;
+        data = data & helper::bitwise_negation(bit);
+        assert!(data == 100000, TEST_FAILED);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-data/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-data/Move.toml
@@ -1,0 +1,17 @@
+[package]
+name = "AaveData"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_data = "_"
+
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AaveConfig = { local = "../aave-config" }
+AavePool = { local = "../" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-data/sources/v1.move
+++ b/tests/aptos-aave-v3/aave-core/aave-data/sources/v1.move
@@ -1,0 +1,125 @@
+module aave_data::v1 {
+    // std
+    use std::signer;
+    use std::string;
+    use std::string::String;
+    use aptos_std::string_utils;
+    use aptos_std::smart_table;
+    // locals
+    use aave_config::error_config;
+
+    // prefixes
+    const ATOKEN_NAME_PREFIX: vector<u8> = b"AAVE_A";
+    const ATOKEN_SYMBOL_PREFIX: vector<u8> = b"aaveA";
+    const VARTOKEN_NAME_PREFIX: vector<u8> = b"AAVE_VAR";
+    const VARTOKEN_SYMBOL_PREFIX: vector<u8> = b"aaveVar";
+
+    struct Data has key {
+        price_feeds_testnet: smart_table::SmartTable<string::String, vector<u8>>,
+        price_feeds_mainnet: smart_table::SmartTable<string::String, vector<u8>>,
+        underlying_assets_testnet: smart_table::SmartTable<string::String, address>,
+        underlying_assets_mainnet: smart_table::SmartTable<string::String, address>,
+        reserves_config_testnet: smart_table::SmartTable<string::String, aave_data::v1_values::ReserveConfig>,
+        reserves_config_mainnet: smart_table::SmartTable<string::String, aave_data::v1_values::ReserveConfig>,
+        interest_rate_strategy_testnet: smart_table::SmartTable<string::String, aave_data::v1_values::InterestRateStrategy>,
+        interest_rate_strategy_mainnet: smart_table::SmartTable<string::String, aave_data::v1_values::InterestRateStrategy>,
+        emodes_testnet: smart_table::SmartTable<u256, aave_data::v1_values::EmodeConfig>,
+        emodes_mainnet: smart_table::SmartTable<u256, aave_data::v1_values::EmodeConfig>
+    }
+
+    fun init_module(account: &signer) {
+        assert!(
+            signer::address_of(account) == @aave_data,
+            error_config::get_enot_pool_owner()
+        );
+        move_to(
+            account,
+            Data {
+                price_feeds_testnet: aave_data::v1_values::build_price_feeds_testnet(),
+                price_feeds_mainnet: aave_data::v1_values::build_price_feeds_mainnet(),
+                underlying_assets_testnet: aave_data::v1_values::build_underlying_assets_testnet(),
+                underlying_assets_mainnet: aave_data::v1_values::build_underlying_assets_mainnet(),
+                reserves_config_testnet: aave_data::v1_values::build_reserve_config_testnet(),
+                reserves_config_mainnet: aave_data::v1_values::build_reserve_config_mainnet(),
+                interest_rate_strategy_testnet: aave_data::v1_values::build_interest_rate_strategy_testnet(),
+                interest_rate_strategy_mainnet: aave_data::v1_values::build_interest_rate_strategy_mainnet(),
+                emodes_testnet: aave_data::v1_values::build_emodes_testnet(),
+                emodes_mainnet: aave_data::v1_values::build_emodes_mainnet()
+            }
+        );
+    }
+
+    public inline fun get_atoken_name(underlying_asset_symbol: String): String {
+        string_utils::format2(&b"{}_{}", ATOKEN_NAME_PREFIX, underlying_asset_symbol)
+    }
+
+    public inline fun get_atoken_symbol(underlying_asset_symbol: String): String {
+        string_utils::format2(&b"{}{}", ATOKEN_SYMBOL_PREFIX, underlying_asset_symbol)
+    }
+
+    public inline fun get_vartoken_name(underlying_asset_symbol: String): String {
+        string_utils::format2(&b"{}_{}", VARTOKEN_NAME_PREFIX, underlying_asset_symbol)
+    }
+
+    public inline fun get_vartoken_symbol(underlying_asset_symbol: String): String {
+        string_utils::format2(&b"{}{}", VARTOKEN_SYMBOL_PREFIX, underlying_asset_symbol)
+    }
+
+    public inline fun get_asset_symbols_testnet(): &vector<string::String> acquires Data {
+        &smart_table::keys(&borrow_global<Data>(@aave_pool).price_feeds_testnet)
+    }
+
+    public inline fun get_asset_symbols_mainnet(): &vector<string::String> acquires Data {
+        &smart_table::keys(&borrow_global<Data>(@aave_pool).price_feeds_mainnet)
+    }
+
+    public inline fun get_price_feeds_tesnet():
+        &smart_table::SmartTable<string::String, vector<u8>> acquires Data {
+        &borrow_global<Data>(@aave_pool).price_feeds_testnet
+    }
+
+    public inline fun get_price_feeds_mainnet():
+        &smart_table::SmartTable<string::String, vector<u8>> acquires Data {
+        &borrow_global<Data>(@aave_pool).price_feeds_mainnet
+    }
+
+    public inline fun get_underlying_assets_testnet():
+        &smart_table::SmartTable<string::String, address> acquires Data {
+        &borrow_global<Data>(@aave_pool).underlying_assets_testnet
+    }
+
+    public inline fun get_underlying_assets_mainnet():
+        &smart_table::SmartTable<string::String, address> acquires Data {
+        &borrow_global<Data>(@aave_pool).underlying_assets_mainnet
+    }
+
+    public inline fun get_reserves_config_testnet():
+        &smart_table::SmartTable<string::String, aave_data::v1_values::ReserveConfig> acquires Data {
+        &borrow_global<Data>(@aave_pool).reserves_config_testnet
+    }
+
+    public inline fun get_reserves_config_mainnet():
+        &smart_table::SmartTable<string::String, aave_data::v1_values::ReserveConfig> acquires Data {
+        &borrow_global<Data>(@aave_pool).reserves_config_mainnet
+    }
+
+    public inline fun get_interest_rate_strategy_testnet():
+        &smart_table::SmartTable<string::String, aave_data::v1_values::InterestRateStrategy> acquires Data {
+        &borrow_global<Data>(@aave_pool).interest_rate_strategy_testnet
+    }
+
+    public inline fun get_interest_rate_strategy_mainnet():
+        &smart_table::SmartTable<string::String, aave_data::v1_values::InterestRateStrategy> acquires Data {
+        &borrow_global<Data>(@aave_pool).interest_rate_strategy_mainnet
+    }
+
+    public inline fun get_emodes_mainnet():
+        &smart_table::SmartTable<u256, aave_data::v1_values::EmodeConfig> acquires Data {
+        &borrow_global<Data>(@aave_pool).emodes_mainnet
+    }
+
+    public inline fun get_emodes_testnet():
+        &smart_table::SmartTable<u256, aave_data::v1_values::EmodeConfig> acquires Data {
+        &borrow_global<Data>(@aave_pool).emodes_testnet
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-data/sources/v1_values.move
+++ b/tests/aptos-aave-v3/aave-core/aave-data/sources/v1_values.move
@@ -1,0 +1,608 @@
+module aave_data::v1_values {
+    // std
+    use std::option;
+    use std::option::Option;
+    use std::string;
+    use std::string::{String, utf8};
+    use aptos_std::smart_table;
+    use aptos_std::smart_table::SmartTable;
+    use aptos_framework::aptos_coin;
+    // locals
+    use aave_pool::coin_migrator;
+
+    // assets
+    const USDT_ASSET: vector<u8> = b"USDT";
+    const USDC_ASSET: vector<u8> = b"USDC";
+    const AMAPT_ASSET: vector<u8> = b"amAPT";
+    const THAPT_ASSET: vector<u8> = b"thAPT";
+    const APT_ASSET: vector<u8> = b"APT";
+
+    struct ReserveConfig has store, copy, drop {
+        base_ltv_as_collateral: u256,
+        liquidation_threshold: u256,
+        liquidation_bonus: u256,
+        liquidation_protocol_fee: u256,
+        borrowing_enabled: bool,
+        flashLoan_enabled: bool,
+        reserve_factor: u256,
+        supply_cap: u256,
+        borrow_cap: u256,
+        debt_ceiling: u256,
+        borrowable_isolation: bool,
+        siloed_borrowing: bool,
+        emode_category: Option<u256>
+    }
+
+    struct InterestRateStrategy has store, copy, drop {
+        optimal_usage_ratio: u256,
+        base_variable_borrow_rate: u256,
+        variable_rate_slope1: u256,
+        variable_rate_slope2: u256
+    }
+
+    struct EmodeConfig has store, copy, drop {
+        category_id: u256,
+        ltv: u256,
+        liquidation_threshold: u256,
+        liquidation_bonus: u256,
+        label: String
+    }
+
+    public fun get_emode_category_id(emode_config: &EmodeConfig): u256 {
+        emode_config.category_id
+    }
+
+    public fun get_emode_ltv(emode_config: &EmodeConfig): u256 {
+        emode_config.ltv
+    }
+
+    public fun get_emode_liquidation_threshold(emode_config: &EmodeConfig): u256 {
+        emode_config.liquidation_threshold
+    }
+
+    public fun get_emode_liquidation_bonus(emode_config: &EmodeConfig): u256 {
+        emode_config.liquidation_bonus
+    }
+
+    public fun get_emode_liquidation_label(emode_config: &EmodeConfig): String {
+        emode_config.label
+    }
+
+    public fun get_optimal_usage_ratio(ir_strategy: &InterestRateStrategy): u256 {
+        ir_strategy.optimal_usage_ratio
+    }
+
+    public fun get_base_variable_borrow_rate(
+        ir_strategy: &InterestRateStrategy
+    ): u256 {
+        ir_strategy.base_variable_borrow_rate
+    }
+
+    public fun get_variable_rate_slope1(
+        ir_strategy: &InterestRateStrategy
+    ): u256 {
+        ir_strategy.variable_rate_slope1
+    }
+
+    public fun get_variable_rate_slope2(
+        ir_strategy: &InterestRateStrategy
+    ): u256 {
+        ir_strategy.variable_rate_slope2
+    }
+
+    public fun get_base_ltv_as_collateral(reserve_config: &ReserveConfig): u256 {
+        reserve_config.base_ltv_as_collateral
+    }
+
+    public fun get_liquidation_threshold(reserve_config: &ReserveConfig): u256 {
+        reserve_config.liquidation_threshold
+    }
+
+    public fun get_liquidation_bonus(reserve_config: &ReserveConfig): u256 {
+        reserve_config.liquidation_bonus
+    }
+
+    public fun get_liquidation_protocol_fee(
+        reserve_config: &ReserveConfig
+    ): u256 {
+        reserve_config.liquidation_protocol_fee
+    }
+
+    public fun get_borrowing_enabled(reserve_config: &ReserveConfig): bool {
+        reserve_config.borrowing_enabled
+    }
+
+    public fun get_flashLoan_enabled(reserve_config: &ReserveConfig): bool {
+        reserve_config.flashLoan_enabled
+    }
+
+    public fun get_reserve_factor(reserve_config: &ReserveConfig): u256 {
+        reserve_config.reserve_factor
+    }
+
+    public fun get_supply_cap(reserve_config: &ReserveConfig): u256 {
+        reserve_config.supply_cap
+    }
+
+    public fun get_borrow_cap(reserve_config: &ReserveConfig): u256 {
+        reserve_config.borrow_cap
+    }
+
+    public fun get_debt_ceiling(reserve_config: &ReserveConfig): u256 {
+        reserve_config.debt_ceiling
+    }
+
+    public fun get_borrowable_isolation(reserve_config: &ReserveConfig): bool {
+        reserve_config.borrowable_isolation
+    }
+
+    public fun get_siloed_borrowing(reserve_config: &ReserveConfig): bool {
+        reserve_config.siloed_borrowing
+    }
+
+    public fun get_emode_category(reserve_config: &ReserveConfig): Option<u256> {
+        reserve_config.emode_category
+    }
+
+    // TODO: add settings here per network
+    public fun build_emodes_testnet(): SmartTable<u256, EmodeConfig> {
+        let emodes = smart_table::new<u256, EmodeConfig>();
+        smart_table::add(
+            &mut emodes,
+            1,
+            EmodeConfig {
+                category_id: 1,
+                ltv: 9000,
+                liquidation_threshold: 9300,
+                liquidation_bonus: 10200,
+                label: string::utf8(b"ETH Correlated")
+            }
+        );
+        smart_table::add(
+            &mut emodes,
+            2,
+            EmodeConfig {
+                category_id: 2,
+                ltv: 9500,
+                liquidation_threshold: 9700,
+                liquidation_bonus: 10100,
+                label: string::utf8(b"Stablecoins")
+            }
+        );
+        emodes
+    }
+
+    // TODO: add settings here per network
+    public fun build_emodes_mainnet(): SmartTable<u256, EmodeConfig> {
+        let emodes = smart_table::new<u256, EmodeConfig>();
+        smart_table::add(
+            &mut emodes,
+            1,
+            EmodeConfig {
+                category_id: 1,
+                ltv: 9000,
+                liquidation_threshold: 9300,
+                liquidation_bonus: 10200,
+                label: string::utf8(b"ETH Correlated")
+            }
+        );
+        smart_table::add(
+            &mut emodes,
+            2,
+            EmodeConfig {
+                category_id: 2,
+                ltv: 9500,
+                liquidation_threshold: 9700,
+                liquidation_bonus: 10100,
+                label: string::utf8(b"Stablecoins")
+            }
+        );
+        emodes
+    }
+
+    // TODO: add feed id here per network
+    public fun build_price_feeds_testnet(): SmartTable<String, vector<u8>> {
+        let price_feeds_testnet = smart_table::new<string::String, vector<u8>>();
+        smart_table::add(
+            &mut price_feeds_testnet,
+            string::utf8(APT_ASSET),
+            x"011e22d6bf000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_testnet,
+            string::utf8(USDC_ASSET),
+            x"01a80ff216000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_testnet,
+            string::utf8(USDT_ASSET),
+            x"016d06ebb6000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_testnet,
+            string::utf8(AMAPT_ASSET),
+            x"01a0b4d920000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_testnet,
+            string::utf8(THAPT_ASSET),
+            x"01d585327c000332000000000000000000000000000000000000000000000000"
+        );
+        price_feeds_testnet
+    }
+
+    // TODO: add feed id here per network
+    public fun build_price_feeds_mainnet(): SmartTable<String, vector<u8>> {
+        let price_feeds_mainnet = smart_table::new<string::String, vector<u8>>();
+        smart_table::add(
+            &mut price_feeds_mainnet,
+            string::utf8(APT_ASSET),
+            x"011e22d6bf000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_mainnet,
+            string::utf8(USDC_ASSET),
+            x"01a80ff216000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_mainnet,
+            string::utf8(USDT_ASSET),
+            x"016d06ebb6000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_mainnet,
+            string::utf8(AMAPT_ASSET),
+            x"01a0b4d920000332000000000000000000000000000000000000000000000000"
+        );
+        smart_table::add(
+            &mut price_feeds_mainnet,
+            string::utf8(THAPT_ASSET),
+            x"01d585327c000332000000000000000000000000000000000000000000000000"
+        );
+        price_feeds_mainnet
+    }
+
+    // TODO: add address here per network
+    public fun build_underlying_assets_testnet(): SmartTable<String, address> {
+        let apt_mapped_fa_asset = coin_migrator::get_fa_address<aptos_coin::AptosCoin>();
+        let underlying_assets_testnet = smart_table::new<String, address>();
+        smart_table::upsert(&mut underlying_assets_testnet, utf8(USDT_ASSET), @0x0);
+        smart_table::upsert(&mut underlying_assets_testnet, utf8(USDC_ASSET), @0x0);
+        smart_table::upsert(&mut underlying_assets_testnet, utf8(AMAPT_ASSET), @0x0);
+        smart_table::upsert(&mut underlying_assets_testnet, utf8(THAPT_ASSET), @0x0);
+        smart_table::upsert(
+            &mut underlying_assets_testnet, utf8(APT_ASSET), apt_mapped_fa_asset
+        );
+        underlying_assets_testnet
+    }
+
+    // TODO: add address here per network
+    public fun build_underlying_assets_mainnet(): SmartTable<String, address> {
+        let apt_mapped_fa_asset = coin_migrator::get_fa_address<aptos_coin::AptosCoin>();
+        let underlying_assets_mainnet = smart_table::new<String, address>();
+        smart_table::upsert(&mut underlying_assets_mainnet, utf8(USDT_ASSET), @0x0);
+        smart_table::upsert(&mut underlying_assets_mainnet, utf8(USDC_ASSET), @0x0);
+        smart_table::upsert(&mut underlying_assets_mainnet, utf8(AMAPT_ASSET), @0x0);
+        smart_table::upsert(&mut underlying_assets_mainnet, utf8(THAPT_ASSET), @0x0);
+        smart_table::upsert(
+            &mut underlying_assets_mainnet, utf8(APT_ASSET), apt_mapped_fa_asset
+        );
+        underlying_assets_mainnet
+    }
+
+    // TODO: add data for each value
+    public fun build_reserve_config_testnet(): SmartTable<string::String, ReserveConfig> {
+        let reserve_config = smart_table::new<String, ReserveConfig>();
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(USDT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(USDC_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(AMAPT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(THAPT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(APT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        reserve_config
+    }
+
+    // TODO: add data for each value
+    public fun build_reserve_config_mainnet(): SmartTable<string::String, ReserveConfig> {
+        let reserve_config = smart_table::new<String, ReserveConfig>();
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(USDT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(USDC_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(AMAPT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(THAPT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        smart_table::upsert(
+            &mut reserve_config,
+            utf8(APT_ASSET),
+            ReserveConfig {
+                base_ltv_as_collateral: 8000,
+                liquidation_threshold: 8500,
+                liquidation_bonus: 10500,
+                liquidation_protocol_fee: 1000,
+                borrowing_enabled: true,
+                flashLoan_enabled: true,
+                reserve_factor: 1000,
+                supply_cap: 0,
+                borrow_cap: 0,
+                debt_ceiling: 0,
+                borrowable_isolation: true,
+                siloed_borrowing: true,
+                emode_category: option::none()
+            }
+        );
+        reserve_config
+    }
+
+    // TODO: add data for each value
+    public fun build_interest_rate_strategy_mainnet():
+        SmartTable<string::String, InterestRateStrategy> {
+        let interest_rate_config = smart_table::new<String, InterestRateStrategy>();
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(USDT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(USDC_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(AMAPT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(THAPT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(APT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        interest_rate_config
+    }
+
+    // TODO: add data for each value
+    public fun build_interest_rate_strategy_testnet():
+        SmartTable<string::String, InterestRateStrategy> {
+        let interest_rate_config = smart_table::new<String, InterestRateStrategy>();
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(USDT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(USDC_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(AMAPT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(THAPT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        smart_table::upsert(
+            &mut interest_rate_config,
+            utf8(APT_ASSET),
+            InterestRateStrategy {
+                optimal_usage_ratio: 800000000000000000000000000,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 40000000000000000000000000,
+                variable_rate_slope2: 750000000000000000000000000
+            }
+        );
+        interest_rate_config
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-large-packages/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-large-packages/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "AaveLargePackages"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_large_packages = "_"
+
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-large-packages/doc/large_packages.md
+++ b/tests/aptos-aave-v3/aave-core/aave-large-packages/doc/large_packages.md
@@ -1,0 +1,126 @@
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages"></a>
+
+# Module `0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea::large_packages`
+
+This provides a framework for uploading large packages to standard accounts or objects.
+In each pass, the caller pushes more code by calling <code>stage_code_chunk</code>.
+In the final call, the caller can use <code>stage_code_chunk_and_publish_to_account</code>, <code>stage_code_chunk_and_publish_to_object</code>, or
+<code>stage_code_chunk_and_upgrade_object_code</code> to upload the final data chunk and publish or upgrade the package on-chain.
+
+Note that <code>code_indices</code> must not have gaps. For example, if <code>code_indices</code> are provided as [0, 1, 3]
+(skipping index 2), the inline function <code>assemble_module_code</code> will abort. This is because <code><a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_StagingArea">StagingArea</a>.last_module_idx</code>
+is set to the maximum value from <code>code_indices</code>. When <code>assemble_module_code</code> iterates over the range from 0 to
+<code><a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_StagingArea">StagingArea</a>.last_module_idx</code>, it expects each index to be present in the <code><a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_StagingArea">StagingArea</a>.<a href="">code</a></code> SmartTable.
+Any missing index in this range will cause the function to fail.
+
+
+-  [Resource `StagingArea`](#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_StagingArea)
+-  [Constants](#@Constants_0)
+-  [Function `stage_code_chunk`](#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk)
+-  [Function `stage_code_chunk_and_publish_to_account`](#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_publish_to_account)
+-  [Function `stage_code_chunk_and_publish_to_object`](#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_publish_to_object)
+-  [Function `stage_code_chunk_and_upgrade_object_code`](#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_upgrade_object_code)
+-  [Function `cleanup_staging_area`](#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_cleanup_staging_area)
+
+
+<pre><code><b>use</b> <a href="">0x1::code</a>;
+<b>use</b> <a href="">0x1::error</a>;
+<b>use</b> <a href="">0x1::object</a>;
+<b>use</b> <a href="">0x1::object_code_deployment</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::smart_table</a>;
+<b>use</b> <a href="">0x1::vector</a>;
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_StagingArea"></a>
+
+## Resource `StagingArea`
+
+
+
+<pre><code><b>struct</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_StagingArea">StagingArea</a> <b>has</b> key
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_ECODE_MISMATCH"></a>
+
+code_indices and code_chunks should be the same length.
+
+
+<pre><code><b>const</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_ECODE_MISMATCH">ECODE_MISMATCH</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_EMISSING_OBJECT_REFERENCE"></a>
+
+Object reference should be provided when upgrading object code.
+
+
+<pre><code><b>const</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_EMISSING_OBJECT_REFERENCE">EMISSING_OBJECT_REFERENCE</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk"></a>
+
+## Function `stage_code_chunk`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk">stage_code_chunk</a>(owner: &<a href="">signer</a>, metadata_chunk: <a href="">vector</a>&lt;u8&gt;, code_indices: <a href="">vector</a>&lt;u16&gt;, code_chunks: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;)
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_publish_to_account"></a>
+
+## Function `stage_code_chunk_and_publish_to_account`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_publish_to_account">stage_code_chunk_and_publish_to_account</a>(owner: &<a href="">signer</a>, metadata_chunk: <a href="">vector</a>&lt;u8&gt;, code_indices: <a href="">vector</a>&lt;u16&gt;, code_chunks: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;)
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_publish_to_object"></a>
+
+## Function `stage_code_chunk_and_publish_to_object`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_publish_to_object">stage_code_chunk_and_publish_to_object</a>(owner: &<a href="">signer</a>, metadata_chunk: <a href="">vector</a>&lt;u8&gt;, code_indices: <a href="">vector</a>&lt;u16&gt;, code_chunks: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;)
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_upgrade_object_code"></a>
+
+## Function `stage_code_chunk_and_upgrade_object_code`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_stage_code_chunk_and_upgrade_object_code">stage_code_chunk_and_upgrade_object_code</a>(owner: &<a href="">signer</a>, metadata_chunk: <a href="">vector</a>&lt;u8&gt;, code_indices: <a href="">vector</a>&lt;u16&gt;, code_chunks: <a href="">vector</a>&lt;<a href="">vector</a>&lt;u8&gt;&gt;, code_object: <a href="_Option">option::Option</a>&lt;<a href="_Object">object::Object</a>&lt;<a href="_PackageRegistry">code::PackageRegistry</a>&gt;&gt;)
+</code></pre>
+
+
+
+<a id="0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_cleanup_staging_area"></a>
+
+## Function `cleanup_staging_area`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="large_packages.md#0x7ec90154fa3c01e400effb2c4f73223b8cbe3af63a087cceca7a381c8818c4ea_large_packages_cleanup_staging_area">cleanup_staging_area</a>(owner: &<a href="">signer</a>)
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-large-packages/sources/large_packages.move
+++ b/tests/aptos-aave-v3/aave-core/aave-large-packages/sources/large_packages.move
@@ -1,0 +1,198 @@
+/// This provides a framework for uploading large packages to standard accounts or objects.
+/// In each pass, the caller pushes more code by calling `stage_code_chunk`.
+/// In the final call, the caller can use `stage_code_chunk_and_publish_to_account`, `stage_code_chunk_and_publish_to_object`, or
+/// `stage_code_chunk_and_upgrade_object_code` to upload the final data chunk and publish or upgrade the package on-chain.
+///
+/// Note that `code_indices` must not have gaps. For example, if `code_indices` are provided as [0, 1, 3]
+/// (skipping index 2), the inline function `assemble_module_code` will abort. This is because `StagingArea.last_module_idx`
+/// is set to the maximum value from `code_indices`. When `assemble_module_code` iterates over the range from 0 to
+/// `StagingArea.last_module_idx`, it expects each index to be present in the `StagingArea.code` SmartTable.
+/// Any missing index in this range will cause the function to fail.
+module aave_large_packages::large_packages {
+    use std::error;
+    use std::signer;
+    use std::vector;
+    use aptos_std::smart_table::{Self, SmartTable};
+
+    use aptos_framework::code::{Self, PackageRegistry};
+    use aptos_framework::object::{Object};
+    use aptos_framework::object_code_deployment;
+
+    /// code_indices and code_chunks should be the same length.
+    const ECODE_MISMATCH: u64 = 1;
+    /// Object reference should be provided when upgrading object code.
+    const EMISSING_OBJECT_REFERENCE: u64 = 2;
+
+    struct StagingArea has key {
+        metadata_serialized: vector<u8>,
+        code: SmartTable<u64, vector<u8>>,
+        last_module_idx: u64
+    }
+
+    public entry fun stage_code_chunk(
+        owner: &signer,
+        metadata_chunk: vector<u8>,
+        code_indices: vector<u16>,
+        code_chunks: vector<vector<u8>>
+    ) acquires StagingArea {
+        stage_code_chunk_internal(
+            owner,
+            metadata_chunk,
+            code_indices,
+            code_chunks
+        );
+    }
+
+    public entry fun stage_code_chunk_and_publish_to_account(
+        owner: &signer,
+        metadata_chunk: vector<u8>,
+        code_indices: vector<u16>,
+        code_chunks: vector<vector<u8>>
+    ) acquires StagingArea {
+        let staging_area =
+            stage_code_chunk_internal(
+                owner,
+                metadata_chunk,
+                code_indices,
+                code_chunks
+            );
+        publish_to_account(owner, staging_area);
+        cleanup_staging_area(owner);
+    }
+
+    public entry fun stage_code_chunk_and_publish_to_object(
+        owner: &signer,
+        metadata_chunk: vector<u8>,
+        code_indices: vector<u16>,
+        code_chunks: vector<vector<u8>>
+    ) acquires StagingArea {
+        let staging_area =
+            stage_code_chunk_internal(
+                owner,
+                metadata_chunk,
+                code_indices,
+                code_chunks
+            );
+        publish_to_object(owner, staging_area);
+        cleanup_staging_area(owner);
+    }
+
+    public entry fun stage_code_chunk_and_upgrade_object_code(
+        owner: &signer,
+        metadata_chunk: vector<u8>,
+        code_indices: vector<u16>,
+        code_chunks: vector<vector<u8>>,
+        code_object: Object<PackageRegistry>
+    ) acquires StagingArea {
+        let staging_area =
+            stage_code_chunk_internal(
+                owner,
+                metadata_chunk,
+                code_indices,
+                code_chunks
+            );
+        upgrade_object_code(owner, staging_area, code_object);
+        cleanup_staging_area(owner);
+    }
+
+    inline fun stage_code_chunk_internal(
+        owner: &signer,
+        metadata_chunk: vector<u8>,
+        code_indices: vector<u16>,
+        code_chunks: vector<vector<u8>>
+    ): &mut StagingArea acquires StagingArea {
+        assert!(
+            vector::length(&code_indices) == vector::length(&code_chunks),
+            error::invalid_argument(ECODE_MISMATCH)
+        );
+
+        let owner_address = signer::address_of(owner);
+
+        if (!exists<StagingArea>(owner_address)) {
+            move_to(
+                owner,
+                StagingArea {
+                    metadata_serialized: vector[],
+                    code: smart_table::new(),
+                    last_module_idx: 0
+                }
+            );
+        };
+
+        let staging_area = borrow_global_mut<StagingArea>(owner_address);
+
+        if (!vector::is_empty(&metadata_chunk)) {
+            vector::append(&mut staging_area.metadata_serialized, metadata_chunk);
+        };
+
+        let i = 0;
+        while (i < vector::length(&code_chunks)) {
+            let inner_code = *vector::borrow(&code_chunks, i);
+            let idx = (*vector::borrow(&code_indices, i) as u64);
+
+            if (smart_table::contains(&staging_area.code, idx)) {
+                vector::append(
+                    smart_table::borrow_mut(&mut staging_area.code, idx), inner_code
+                );
+            } else {
+                smart_table::add(&mut staging_area.code, idx, inner_code);
+                if (idx > staging_area.last_module_idx) {
+                    staging_area.last_module_idx = idx;
+                }
+            };
+            i = i + 1;
+        };
+
+        staging_area
+    }
+
+    inline fun publish_to_account(
+        publisher: &signer, staging_area: &mut StagingArea
+    ) {
+        let code = assemble_module_code(staging_area);
+        code::publish_package_txn(publisher, staging_area.metadata_serialized, code);
+    }
+
+    inline fun publish_to_object(
+        publisher: &signer, staging_area: &mut StagingArea
+    ) {
+        let code = assemble_module_code(staging_area);
+        object_code_deployment::publish(
+            publisher, staging_area.metadata_serialized, code
+        );
+    }
+
+    inline fun upgrade_object_code(
+        publisher: &signer,
+        staging_area: &mut StagingArea,
+        code_object: Object<PackageRegistry>
+    ) {
+        let code = assemble_module_code(staging_area);
+        object_code_deployment::upgrade(
+            publisher,
+            staging_area.metadata_serialized,
+            code,
+            code_object
+        );
+    }
+
+    inline fun assemble_module_code(staging_area: &mut StagingArea): vector<vector<u8>> {
+        let last_module_idx = staging_area.last_module_idx;
+        let code = vector[];
+        let i = 0;
+        while (i <= last_module_idx) {
+            vector::push_back(
+                &mut code,
+                *smart_table::borrow(&staging_area.code, i)
+            );
+            i = i + 1;
+        };
+        code
+    }
+
+    public entry fun cleanup_staging_area(owner: &signer) acquires StagingArea {
+        let StagingArea { metadata_serialized: _, code, last_module_idx: _ } =
+            move_from<StagingArea>(signer::address_of(owner));
+        smart_table::destroy(code);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-math/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-math/Move.toml
@@ -1,0 +1,16 @@
+[package]
+name = "AaveMath"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_math = '_'
+
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AaveConfig = { local = "../aave-config" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-math/doc/math_utils.md
+++ b/tests/aptos-aave-v3/aave-core/aave-math/doc/math_utils.md
@@ -1,0 +1,201 @@
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils"></a>
+
+# Module `0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c::math_utils`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `u256_max`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_u256_max)
+-  [Function `calculate_linear_interest`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_linear_interest)
+-  [Function `calculate_compounded_interest`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_compounded_interest)
+-  [Function `calculate_compounded_interest_now`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_compounded_interest_now)
+-  [Function `get_percentage_factor`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_get_percentage_factor)
+-  [Function `percent_mul`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_percent_mul)
+-  [Function `percent_div`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_percent_div)
+-  [Function `pow`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_pow)
+
+
+<pre><code><b>use</b> <a href="">0x1::timestamp</a>;
+<b>use</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math">0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c::wad_ray_math</a>;
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_EDIVISION_BY_ZERO"></a>
+
+Cannot divide by zero
+
+
+<pre><code><b>const</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_EOVERFLOW"></a>
+
+Calculation results in overflow
+
+
+<pre><code><b>const</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_EOVERFLOW">EOVERFLOW</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_U256_MAX"></a>
+
+
+
+<pre><code><b>const</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_U256_MAX">U256_MAX</a>: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_HALF_PERCENTAGE_FACTOR"></a>
+
+Half percentage factor (50.00%)
+
+
+<pre><code><b>const</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_HALF_PERCENTAGE_FACTOR">HALF_PERCENTAGE_FACTOR</a>: u256 = 5000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_PERCENTAGE_FACTOR"></a>
+
+Maximum percentage factor (100.00%)
+
+
+<pre><code><b>const</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_PERCENTAGE_FACTOR">PERCENTAGE_FACTOR</a>: u256 = 10000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_SECONDS_PER_YEAR"></a>
+
+@dev Ignoring leap years
+
+
+<pre><code><b>const</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_SECONDS_PER_YEAR">SECONDS_PER_YEAR</a>: u256 = 31536000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_u256_max"></a>
+
+## Function `u256_max`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_u256_max">u256_max</a>(): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_linear_interest"></a>
+
+## Function `calculate_linear_interest`
+
+@dev Function to calculate the interest accumulated using a linear interest rate formula
+@param rate The interest rate, in ray
+@param last_update_timestamp The timestamp of the last update of the interest
+@return The interest rate linearly accumulated during the timeDelta, in ray
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_linear_interest">calculate_linear_interest</a>(rate: u256, last_update_timestamp: u64): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_compounded_interest"></a>
+
+## Function `calculate_compounded_interest`
+
+@dev Function to calculate the interest using a compounded interest rate formula
+To avoid expensive exponentiation, the calculation is performed using a binomial approximation:
+
+(1+x)^n = 1+n*x+[n/2*(n-1)]*x^2+[n/6*(n-1)*(n-2)*x^3...
+
+The approximation slightly underpays liquidity providers and undercharges borrowers, with the advantage of great
+gas cost reductions. The whitepaper contains reference to the approximation and a table showing the margin of
+error per different time periods
+
+@param rate The interest rate, in ray
+@param last_update_timestamp The timestamp of the last update of the interest
+@return The interest rate compounded during the timeDelta, in ray
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_compounded_interest">calculate_compounded_interest</a>(rate: u256, last_update_timestamp: u64, current_timestamp: u64): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_compounded_interest_now"></a>
+
+## Function `calculate_compounded_interest_now`
+
+@dev Calculates the compounded interest between the timestamp of the last update and the current block timestamp
+@param rate The interest rate (in ray)
+@param last_update_timestamp The timestamp from which the interest accumulation needs to be calculated
+@return The interest rate compounded between lastUpdateTimestamp and current block timestamp, in ray
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_calculate_compounded_interest_now">calculate_compounded_interest_now</a>(rate: u256, last_update_timestamp: u64): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_get_percentage_factor"></a>
+
+## Function `get_percentage_factor`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_get_percentage_factor">get_percentage_factor</a>(): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_percent_mul"></a>
+
+## Function `percent_mul`
+
+@notice Executes a percentage multiplication
+@param value The value of which the percentage needs to be calculated
+@param percentage The percentage of the value to be calculated
+@return result value percentmul percentage
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_percent_mul">percent_mul</a>(value: u256, percentage: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_percent_div"></a>
+
+## Function `percent_div`
+
+@notice Executes a percentage division
+@param value The value of which the percentage needs to be calculated
+@param percentage The percentage of the value to be calculated
+@return result value percentdiv percentage
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_percent_div">percent_div</a>(value: u256, percentage: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_pow"></a>
+
+## Function `pow`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math_utils.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_math_utils_pow">pow</a>(base: u256, exponent: u256): u256
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-math/doc/wad_ray_math.md
+++ b/tests/aptos-aave-v3/aave-core/aave-math/doc/wad_ray_math.md
@@ -1,0 +1,238 @@
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math"></a>
+
+# Module `0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c::wad_ray_math`
+
+@title WadRayMath library
+@author Aave
+@notice Provides functions to perform calculations with Wad and Ray units
+@dev Provides mul and div function for wads (decimal numbers with 18 digits of precision) and rays (decimal numbers
+with 27 digits of precision)
+@dev Operations are rounded. If a value is >=.5, will be rounded up, otherwise rounded down.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `wad`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad)
+-  [Function `half_wad`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_half_wad)
+-  [Function `ray`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray)
+-  [Function `half_ray`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_half_ray)
+-  [Function `wad_mul`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_mul)
+-  [Function `wad_div`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_div)
+-  [Function `ray_mul`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_mul)
+-  [Function `ray_div`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_div)
+-  [Function `ray_to_wad`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_to_wad)
+-  [Function `wad_to_ray`](#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_to_ray)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_EDIVISION_BY_ZERO"></a>
+
+Cannot divide by 0
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_EOVERFLOW"></a>
+
+Overflow resulting from a calculation
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_EOVERFLOW">EOVERFLOW</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_HALF_RAY"></a>
+
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_HALF_RAY">HALF_RAY</a>: u256 = 500000000000000000000000000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_HALF_WAD"></a>
+
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_HALF_WAD">HALF_WAD</a>: u256 = 500000000000000000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_RAY"></a>
+
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_RAY">RAY</a>: u256 = 1000000000000000000000000000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_U256_MAX"></a>
+
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_U256_MAX">U256_MAX</a>: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_WAD"></a>
+
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_WAD">WAD</a>: u256 = 1000000000000000000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_WAD_RAY_RATIO"></a>
+
+
+
+<pre><code><b>const</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_WAD_RAY_RATIO">WAD_RAY_RATIO</a>: u256 = 1000000000;
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad"></a>
+
+## Function `wad`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad">wad</a>(): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_half_wad"></a>
+
+## Function `half_wad`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_half_wad">half_wad</a>(): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray"></a>
+
+## Function `ray`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray">ray</a>(): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_half_ray"></a>
+
+## Function `half_ray`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_half_ray">half_ray</a>(): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_mul"></a>
+
+## Function `wad_mul`
+
+@dev Multiplies two wad, rounding half up to the nearest wad
+@param a Wad
+@param b Wad
+@return c = a*b, in wad
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_mul">wad_mul</a>(a: u256, b: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_div"></a>
+
+## Function `wad_div`
+
+@dev Divides two wad, rounding half up to the nearest wad
+@param a Wad
+@param b Wad
+@return c = a/b, in wad
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_div">wad_div</a>(a: u256, b: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_mul"></a>
+
+## Function `ray_mul`
+
+@notice Multiplies two ray, rounding half up to the nearest ray
+@param a Ray
+@param b Ray
+@return c = a raymul b
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_mul">ray_mul</a>(a: u256, b: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_div"></a>
+
+## Function `ray_div`
+
+@notice Divides two ray, rounding half up to the nearest ray
+@param a Ray
+@param b Ray
+@return c = a raydiv b
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_div">ray_div</a>(a: u256, b: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_to_wad"></a>
+
+## Function `ray_to_wad`
+
+@dev Casts ray down to wad
+@param a Ray
+@return b = a converted to wad, rounded half up to the nearest wad
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_ray_to_wad">ray_to_wad</a>(a: u256): u256
+</code></pre>
+
+
+
+<a id="0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_to_ray"></a>
+
+## Function `wad_to_ray`
+
+@dev Converts wad up to ray
+@param a Wad
+@return b = a converted in ray
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="wad_ray_math.md#0x9efefdec8fe22b7447931b81745048182594ef72653dfbf8e05b815ecc355f7c_wad_ray_math_wad_to_ray">wad_to_ray</a>(a: u256): u256
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-math/sources/math_utils.move
+++ b/tests/aptos-aave-v3/aave-core/aave-math/sources/math_utils.move
@@ -1,0 +1,141 @@
+module aave_math::math_utils {
+    use aptos_framework::timestamp;
+
+    use aave_config::error_config;
+
+    use aave_math::wad_ray_math;
+
+    const U256_MAX: u256 =
+        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
+    /// @dev Ignoring leap years
+    const SECONDS_PER_YEAR: u256 = 365 * 24 * 3600;
+
+    /// Maximum percentage factor (100.00%)
+    const PERCENTAGE_FACTOR: u256 = 10000;
+
+    /// Half percentage factor (50.00%)
+    const HALF_PERCENTAGE_FACTOR: u256 = 5 * 1000;
+
+    public fun u256_max(): u256 {
+        U256_MAX
+    }
+
+    #[test_only]
+    public fun get_seconds_per_year_for_testing(): u256 {
+        SECONDS_PER_YEAR
+    }
+
+    #[test_only]
+    public fun get_half_percentage_factor_for_testing(): u256 {
+        HALF_PERCENTAGE_FACTOR
+    }
+
+    #[test_only]
+    public fun get_u256_max_for_testing(): u256 {
+        u256_max()
+    }
+
+    /// @dev Function to calculate the interest accumulated using a linear interest rate formula
+    /// @param rate The interest rate, in ray
+    /// @param last_update_timestamp The timestamp of the last update of the interest
+    /// @return The interest rate linearly accumulated during the timeDelta, in ray
+    public fun calculate_linear_interest(
+        rate: u256, last_update_timestamp: u64
+    ): u256 {
+        let time_passed = timestamp::now_seconds() - last_update_timestamp;
+        let result = rate * (time_passed as u256);
+        wad_ray_math::ray() + (result / SECONDS_PER_YEAR)
+    }
+
+    /// @dev Function to calculate the interest using a compounded interest rate formula
+    /// To avoid expensive exponentiation, the calculation is performed using a binomial approximation:
+    ///
+    /// (1+x)^n = 1+n*x+[n/2*(n-1)]*x^2+[n/6*(n-1)*(n-2)*x^3...
+    ///
+    /// The approximation slightly underpays liquidity providers and undercharges borrowers, with the advantage of great
+    /// gas cost reductions. The whitepaper contains reference to the approximation and a table showing the margin of
+    /// error per different time periods
+    ///
+    /// @param rate The interest rate, in ray
+    /// @param last_update_timestamp The timestamp of the last update of the interest
+    /// @return The interest rate compounded during the timeDelta, in ray
+    public fun calculate_compounded_interest(
+        rate: u256, last_update_timestamp: u64, current_timestamp: u64
+    ): u256 {
+        let exp = ((current_timestamp - last_update_timestamp) as u256);
+        if (exp == 0) {
+            return wad_ray_math::ray()
+        };
+
+        let exp_minus_one = exp - 1;
+        let exp_minus_two = if (exp > 2) exp - 2 else 0;
+        let base_power_two =
+            wad_ray_math::ray_mul(rate, rate) / (SECONDS_PER_YEAR * SECONDS_PER_YEAR);
+        let base_power_three =
+            wad_ray_math::ray_mul(base_power_two, rate) / SECONDS_PER_YEAR;
+        let second_term = (exp * exp_minus_one * base_power_two) / 2;
+        let third_term = (exp * exp_minus_one * exp_minus_two * base_power_three) / 6;
+
+        wad_ray_math::ray() + (rate * exp) / SECONDS_PER_YEAR + second_term
+            + third_term
+    }
+
+    /// @dev Calculates the compounded interest between the timestamp of the last update and the current block timestamp
+    /// @param rate The interest rate (in ray)
+    /// @param last_update_timestamp The timestamp from which the interest accumulation needs to be calculated
+    /// @return The interest rate compounded between lastUpdateTimestamp and current block timestamp, in ray
+    public fun calculate_compounded_interest_now(
+        rate: u256, last_update_timestamp: u64
+    ): u256 {
+        calculate_compounded_interest(
+            rate, last_update_timestamp, timestamp::now_seconds()
+        )
+    }
+
+    public fun get_percentage_factor(): u256 {
+        PERCENTAGE_FACTOR
+    }
+
+    #[test_only]
+    public fun get_percentage_factor_for_testing(): u256 {
+        PERCENTAGE_FACTOR
+    }
+
+    /// @notice Executes a percentage multiplication
+    /// @param value The value of which the percentage needs to be calculated
+    /// @param percentage The percentage of the value to be calculated
+    /// @return result value percentmul percentage
+    public fun percent_mul(value: u256, percentage: u256): u256 {
+        if (value == 0 || percentage == 0) {
+            return 0
+        };
+        assert!(
+            value <= (U256_MAX - HALF_PERCENTAGE_FACTOR) / percentage,
+            error_config::get_eoverflow()
+        );
+        (value * percentage + HALF_PERCENTAGE_FACTOR) / PERCENTAGE_FACTOR
+    }
+
+    /// @notice Executes a percentage division
+    /// @param value The value of which the percentage needs to be calculated
+    /// @param percentage The percentage of the value to be calculated
+    /// @return result value percentdiv percentage
+    public fun percent_div(value: u256, percentage: u256): u256 {
+        assert!(percentage > 0, error_config::get_edivision_by_zero());
+        assert!(
+            value <= (U256_MAX - HALF_PERCENTAGE_FACTOR) / PERCENTAGE_FACTOR,
+            error_config::get_eoverflow()
+        );
+        (value * PERCENTAGE_FACTOR + percentage / 2) / percentage
+    }
+
+    // Get the power
+    public fun pow(base: u256, exponent: u256): u256 {
+        let result = 1;
+        for (_i in 0..exponent) {
+            result = result * base;
+        };
+        result
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-math/sources/wad_ray_math.move
+++ b/tests/aptos-aave-v3/aave-core/aave-math/sources/wad_ray_math.move
@@ -1,0 +1,155 @@
+/// @title WadRayMath library
+/// @author Aave
+/// @notice Provides functions to perform calculations with Wad and Ray units
+/// @dev Provides mul and div function for wads (decimal numbers with 18 digits of precision) and rays (decimal numbers
+/// with 27 digits of precision)
+/// @dev Operations are rounded. If a value is >=.5, will be rounded up, otherwise rounded down.
+module aave_math::wad_ray_math {
+    use aave_config::error_config;
+
+    /// u256 max
+    const U256_MAX: u256 =
+        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    /// 10^18
+    const WAD: u256 = 1_000_000_000_000_000_000;
+    /// 5 * 10^17
+    const HALF_WAD: u256 = 500_000_000_000_000_000;
+    /// 10^27
+    const RAY: u256 = 1_000_000_000_000_000_000_000_000_000;
+    /// 5 * 10^26
+    const HALF_RAY: u256 = 500_000_000_000_000_000_000_000_000;
+    /// 10^9
+    const WAD_RAY_RATIO: u256 = 1_000_000_000;
+
+    public fun wad(): u256 {
+        WAD
+    }
+
+    #[test_only]
+    public fun get_wad_for_testing(): u256 {
+        wad()
+    }
+
+    public fun half_wad(): u256 {
+        HALF_WAD
+    }
+
+    #[test_only]
+    public fun get_half_wad_for_testing(): u256 {
+        half_wad()
+    }
+
+    public fun ray(): u256 {
+        RAY
+    }
+
+    #[test_only]
+    public fun get_ray_for_testing(): u256 {
+        ray()
+    }
+
+    public fun half_ray(): u256 {
+        HALF_RAY
+    }
+
+    #[test_only]
+    public fun get_half_ray_for_testing(): u256 {
+        half_ray()
+    }
+
+    #[test_only]
+    public fun get_wad_ray_ratio_for_testing(): u256 {
+        WAD_RAY_RATIO
+    }
+
+    #[test_only]
+    public fun get_u256_max_for_testing(): u256 {
+        U256_MAX
+    }
+
+    /// @dev Multiplies two wad, rounding half up to the nearest wad
+    /// @param a Wad
+    /// @param b Wad
+    /// @return c = a*b, in wad
+    public fun wad_mul(a: u256, b: u256): u256 {
+        if (a == 0 || b == 0) {
+            return 0
+        };
+        assert!(
+            a <= (U256_MAX - HALF_WAD) / b,
+            error_config::get_eoverflow()
+        );
+        (a * b + HALF_WAD) / WAD
+    }
+
+    /// @dev Divides two wad, rounding half up to the nearest wad
+    /// @param a Wad
+    /// @param b Wad
+    /// @return c = a/b, in wad
+    public fun wad_div(a: u256, b: u256): u256 {
+        assert!(b > 0, error_config::get_edivision_by_zero());
+        if (a == 0) {
+            return 0
+        };
+        assert!(
+            a <= (U256_MAX - b / 2) / WAD,
+            error_config::get_eoverflow()
+        );
+        (a * WAD + b / 2) / b
+    }
+
+    /// @notice Multiplies two ray, rounding half up to the nearest ray
+    /// @param a Ray
+    /// @param b Ray
+    /// @return c = a raymul b
+    public fun ray_mul(a: u256, b: u256): u256 {
+        if (a == 0 || b == 0) {
+            return 0
+        };
+        assert!(
+            a <= (U256_MAX - HALF_RAY) / b,
+            error_config::get_eoverflow()
+        );
+        (a * b + HALF_RAY) / RAY
+    }
+
+    /// @notice Divides two ray, rounding half up to the nearest ray
+    /// @param a Ray
+    /// @param b Ray
+    /// @return c = a raydiv b
+    public fun ray_div(a: u256, b: u256): u256 {
+        assert!(b > 0, error_config::get_edivision_by_zero());
+        if (a == 0) {
+            return 0
+        };
+        assert!(
+            a <= (U256_MAX - b / 2) / RAY,
+            error_config::get_eoverflow()
+        );
+        (a * RAY + b / 2) / b
+    }
+
+    /// @dev Casts ray down to wad
+    /// @param a Ray
+    /// @return b = a converted to wad, rounded half up to the nearest wad
+    public fun ray_to_wad(a: u256): u256 {
+        let b = a / WAD_RAY_RATIO;
+        let remainder = a % WAD_RAY_RATIO;
+        if (remainder >= WAD_RAY_RATIO / 2) {
+            b = b + 1;
+        };
+        b
+    }
+
+    /// @dev Converts wad up to ray
+    /// @param a Wad
+    /// @return b = a converted in ray
+    public fun wad_to_ray(a: u256): u256 {
+        let b = a * WAD_RAY_RATIO;
+        assert!(
+            b / WAD_RAY_RATIO == a,
+            error_config::get_eoverflow()
+        );
+        b
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-math/tests/math_utils_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-math/tests/math_utils_tests.move
@@ -1,0 +1,137 @@
+#[test_only]
+module aave_math::math_utils_tests {
+    use aptos_framework::timestamp;
+    use aptos_framework::timestamp::{
+        fast_forward_seconds,
+        set_time_has_started_for_testing
+    };
+    use aave_config::error_config::{EOVERFLOW, EDIVISION_BY_ZERO};
+    use aave_math::math_utils::{
+        calculate_compounded_interest_now,
+        calculate_linear_interest,
+        get_half_percentage_factor_for_testing,
+        get_percentage_factor,
+        get_percentage_factor_for_testing,
+        get_seconds_per_year_for_testing,
+        get_u256_max_for_testing,
+        percent_div,
+        percent_mul,
+        pow,
+        u256_max
+    };
+    use aave_math::wad_ray_math::ray;
+
+    const TEST_SUCCESS: u64 = 1;
+
+    #[test]
+    fun test_power() {
+        assert!(pow(0, 0) == 1, TEST_SUCCESS);
+        assert!(pow(1, 0) == 1, TEST_SUCCESS);
+        assert!(pow(1, 1) == 1, TEST_SUCCESS);
+        assert!(pow(10, 0) == 1, TEST_SUCCESS);
+        assert!(pow(10, 1) == 10, TEST_SUCCESS);
+        assert!(pow(10, 2) == 100, TEST_SUCCESS);
+        assert!(pow(10, 3) == 1000, TEST_SUCCESS);
+        assert!(pow(10, 4) == 10000, TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_getters() {
+        assert!(
+            get_percentage_factor() == get_percentage_factor_for_testing(),
+            TEST_SUCCESS
+        );
+        assert!(u256_max() == get_u256_max_for_testing(), TEST_SUCCESS);
+    }
+
+    #[test(creator = @0x1)]
+    fun test_linear_interest(creator: &signer) {
+        let one_hour_in_secs = 1 * 60 * 60;
+        // start the timer
+        set_time_has_started_for_testing(creator);
+        // fast forward 1 hour
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+        // compute the interest rate
+        let interest_rate_per_year = ray(); // ray per year
+        let lin_interest_rate_increase =
+            calculate_linear_interest(interest_rate_per_year, ts_one_hour_ago);
+        // verification
+        let percentage_increase =
+            (interest_rate_per_year * (one_hour_in_secs as u256))
+                / get_seconds_per_year_for_testing();
+        let increased_interest_rate = interest_rate_per_year + percentage_increase;
+        assert!(increased_interest_rate == lin_interest_rate_increase, TEST_SUCCESS);
+    }
+
+    #[test(creator = @0x1)]
+    fun test_compounded_interest(creator: &signer) {
+        let one_hour_in_secs = 1 * 60 * 60;
+        // start the timer
+        set_time_has_started_for_testing(creator);
+        // fast forward 1 hour
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+        // compute the interest rate
+        let interest_rate_per_year = ray(); // ray per year
+        let compunded_interest_rate_increase =
+            calculate_compounded_interest_now(interest_rate_per_year, ts_one_hour_ago);
+        let lin_interest_rate_increase =
+            calculate_linear_interest(interest_rate_per_year, ts_one_hour_ago);
+        // test that the compounded int. rate is indeed higher than the linear
+        assert!(
+            compunded_interest_rate_increase > lin_interest_rate_increase, TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_percent_mul() {
+        let value = 50;
+        let percentage = get_percentage_factor_for_testing() / 5;
+        let percentage_of_value = percent_mul(value, percentage);
+        assert!(percentage_of_value == 50 / 5, TEST_SUCCESS);
+
+        // test mult with 0 value
+        assert!(percent_mul(0, percentage) == 0, TEST_SUCCESS);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EOVERFLOW, location = aave_math::math_utils)]
+    fun test_percent_mul_overflow() {
+        let percentage = get_percentage_factor_for_testing() / 5;
+        let value =
+            (get_u256_max_for_testing() - get_half_percentage_factor_for_testing())
+                / percentage + 1;
+        percent_mul(value, percentage);
+    }
+
+    #[test]
+    fun test_percent_div() {
+        let value = 50;
+        let percentage = get_percentage_factor_for_testing() / 5;
+        let percentage_of_value = percent_div(value, percentage);
+        assert!(
+            percentage_of_value
+                == value * get_percentage_factor_for_testing() / percentage,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EOVERFLOW, location = aave_math::math_utils)]
+    fun test_percent_div_overflow() {
+        let percentage = get_percentage_factor_for_testing() / 5;
+        let value =
+            (get_u256_max_for_testing() - get_half_percentage_factor_for_testing())
+                / get_percentage_factor_for_testing() + 1;
+        percent_div(value, percentage);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EDIVISION_BY_ZERO, location = aave_math::math_utils)]
+    fun test_percent_div_by_zero() {
+        percent_div(50, 0);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-math/tests/wad_ray_math_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-math/tests/wad_ray_math_tests.move
@@ -1,0 +1,159 @@
+#[test_only]
+module aave_math::wad_ray_math_tests {
+    use aave_config::error_config::{EOVERFLOW, EDIVISION_BY_ZERO};
+    use aave_math::wad_ray_math::{
+        get_half_ray_for_testing,
+        get_half_wad_for_testing,
+        get_ray_for_testing,
+        get_u256_max_for_testing,
+        get_wad_for_testing,
+        get_wad_ray_ratio_for_testing,
+        half_ray,
+        half_wad,
+        ray,
+        ray_div,
+        ray_mul,
+        ray_to_wad,
+        wad,
+        wad_div,
+        wad_mul,
+        wad_to_ray
+    };
+
+    const TEST_SUCCESS: u64 = 1;
+
+    #[test]
+    fun test_getters() {
+        assert!(wad() == get_wad_for_testing(), TEST_SUCCESS);
+        assert!(half_wad() == get_half_wad_for_testing(), TEST_SUCCESS);
+        assert!(ray() == get_ray_for_testing(), TEST_SUCCESS);
+        assert!(half_ray() == get_half_ray_for_testing(), TEST_SUCCESS);
+    }
+
+    #[test]
+    fun test_wad_mul() {
+        let a = 134534543232342353231234;
+        let b = 13265462389132757665657;
+        assert!(wad_mul(a, 0) == 0, TEST_SUCCESS);
+        assert!(wad_mul(0, b) == 0, TEST_SUCCESS);
+        let x = wad_mul(a, b);
+        assert!(x == 1784662923287792467070443765, TEST_SUCCESS);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EOVERFLOW, location = aave_math::wad_ray_math)]
+    fun test_wad_overflow_mult() {
+        let b = 13265462389132757665657;
+        let tooLargeA = (get_u256_max_for_testing() - get_half_wad_for_testing()) / b
+            + 1;
+        wad_mul(tooLargeA, b);
+    }
+
+    #[test]
+    fun test_wad_div() {
+        let a = 134534543232342353231234;
+        let b = 13265462389132757665657;
+        let x = wad_div(a, b);
+        assert!(x == 10141715327055228122, TEST_SUCCESS);
+        assert!(wad_div(0, b) == 0, TEST_SUCCESS);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EDIVISION_BY_ZERO, location = aave_math::wad_ray_math)]
+    fun test_wad_div_by_zero() {
+        let a = 134534543232342353231234;
+        wad_div(a, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EOVERFLOW, location = aave_math::wad_ray_math)]
+    fun test_wad_div_overflow() {
+        let b = 13265462389132757665657;
+        let tooLargeA = (get_u256_max_for_testing() - b / 2) / get_wad_for_testing()
+            + 1;
+        wad_div(tooLargeA, b);
+    }
+
+    #[test]
+    fun test_ray_mul() {
+        let a = 134534543232342353231234;
+        let b = 13265462389132757665657;
+        assert!(ray_mul(a, 0) == 0, TEST_SUCCESS);
+        assert!(ray_mul(0, b) == 0, TEST_SUCCESS);
+        let x = ray_mul(a, b);
+        assert!(x == 1784662923287792467, TEST_SUCCESS);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EOVERFLOW, location = aave_math::wad_ray_math)]
+    fun test_ray_overflow_mult() {
+        let b = 13265462389132757665657;
+        let tooLargeA = (get_u256_max_for_testing() - get_half_ray_for_testing()) / b
+            + 1;
+        ray_mul(tooLargeA, b);
+    }
+
+    #[test]
+    fun test_ray_div() {
+        let a = 134534543232342353231234;
+        let b = 13265462389132757665657;
+        let x = ray_div(a, b);
+        assert!(x == 10141715327055228122033939726, TEST_SUCCESS);
+        assert!(ray_div(0, b) == 0, TEST_SUCCESS);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EDIVISION_BY_ZERO, location = aave_math::wad_ray_math)]
+    fun test_ray_div_by_zero() {
+        let a = 134534543232342353231234;
+        ray_div(a, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EOVERFLOW, location = aave_math::wad_ray_math)]
+    fun test_ray_div_overflow() {
+        let b = 13265462389132757665657;
+        let tooLargeA = (get_u256_max_for_testing() - b / 2) / get_ray_for_testing()
+            + 1;
+        ray_div(tooLargeA, b);
+    }
+
+    #[test]
+    fun test_ray_to_way() {
+        let ray = 1 * get_ray_for_testing();
+        let x = ray_to_wad(ray);
+        assert!(x == 1 * get_wad_for_testing(), TEST_SUCCESS);
+
+        let round_down = get_ray_for_testing() + (get_wad_ray_ratio_for_testing() / 2)
+            - 1;
+        let x = ray_to_wad(round_down);
+        assert!(x == 1000000000000000000, TEST_SUCCESS);
+
+        let round_up = get_ray_for_testing() + (get_wad_ray_ratio_for_testing() / 2) + 1;
+        let x = ray_to_wad(round_up);
+        assert!(x == 1000000000000000001, TEST_SUCCESS);
+
+        let too_large = get_u256_max_for_testing()
+            - (get_wad_ray_ratio_for_testing() / 2) + 1;
+        let x = ray_to_wad(too_large);
+        assert!(
+            x == 115792089237316195423570985008687907853269984665640564039457584007913,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    fun test_wad_to_ray() {
+        let ray = 1 * get_wad_for_testing();
+        let x = wad_to_ray(ray);
+        assert!(x == 1 * get_ray_for_testing(), TEST_SUCCESS);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_wad_to_ray_overflow() {
+        let too_large = get_u256_max_for_testing() / get_wad_ray_ratio_for_testing()
+            + 1;
+        wad_to_ray(too_large);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "AaveOracle"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+aave_oracle = "0x111"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AaveConfig = { local = "../aave-config" }
+AaveAcl = { local = "../aave-acl" }
+ChainlinkDataFeeds = { local = "../chainlink-data-feeds" }

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/doc/oracle.md
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/doc/oracle.md
@@ -1,0 +1,254 @@
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle"></a>
+
+# Module `0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e::oracle`
+
+
+
+-  [Struct `OracleEvent`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_OracleEvent)
+-  [Resource `AssetPriceList`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_AssetPriceList)
+-  [Resource `RewardOracle`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle)
+-  [Constants](#@Constants_0)
+-  [Function `create_reward_oracle`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_create_reward_oracle)
+-  [Function `decimals`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_decimals)
+-  [Function `latest_answer`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_answer)
+-  [Function `latest_timestamp`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_timestamp)
+-  [Function `latest_round`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_round)
+-  [Function `get_answer`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_answer)
+-  [Function `get_timestamp`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_timestamp)
+-  [Function `base_currency_unit`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_base_currency_unit)
+-  [Function `get_asset_price`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_asset_price)
+-  [Function `get_base_currency_unit`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_base_currency_unit)
+-  [Function `set_asset_price`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_set_asset_price)
+-  [Function `batch_set_asset_price`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_batch_set_asset_price)
+-  [Function `update_asset_price`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_update_asset_price)
+-  [Function `remove_asset_price`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_remove_asset_price)
+
+
+<pre><code><b>use</b> <a href="">0x1::event</a>;
+<b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::simple_map</a>;
+<b>use</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel">0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e::oracle_sentinel</a>;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_OracleEvent"></a>
+
+## Struct `OracleEvent`
+
+
+
+<pre><code>#[<a href="">event</a>]
+<b>struct</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_OracleEvent">OracleEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_AssetPriceList"></a>
+
+## Resource `AssetPriceList`
+
+
+
+<pre><code><b>struct</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_AssetPriceList">AssetPriceList</a> <b>has</b> key
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle"></a>
+
+## Resource `RewardOracle`
+
+
+
+<pre><code><b>struct</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">RewardOracle</a> <b>has</b> <b>copy</b>, drop, store, key
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_E_ORACLE_NOT_ADMIN"></a>
+
+
+
+<pre><code><b>const</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_E_ORACLE_NOT_ADMIN">E_ORACLE_NOT_ADMIN</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_E_ASSET_ALREADY_EXISTS"></a>
+
+
+
+<pre><code><b>const</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_E_ASSET_ALREADY_EXISTS">E_ASSET_ALREADY_EXISTS</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_E_ASSET_NOT_EXISTS"></a>
+
+
+
+<pre><code><b>const</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_E_ASSET_NOT_EXISTS">E_ASSET_NOT_EXISTS</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_create_reward_oracle"></a>
+
+## Function `create_reward_oracle`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_create_reward_oracle">create_reward_oracle</a>(id: u256): <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_decimals"></a>
+
+## Function `decimals`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_decimals">decimals</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>): u8
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_answer"></a>
+
+## Function `latest_answer`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_answer">latest_answer</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>): u256
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_timestamp"></a>
+
+## Function `latest_timestamp`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_timestamp">latest_timestamp</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>): u256
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_round"></a>
+
+## Function `latest_round`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_latest_round">latest_round</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>): u256
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_answer"></a>
+
+## Function `get_answer`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_answer">get_answer</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>, _round_id: u256): u256
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_timestamp"></a>
+
+## Function `get_timestamp`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_timestamp">get_timestamp</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>, _round_id: u256): u256
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_base_currency_unit"></a>
+
+## Function `base_currency_unit`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_base_currency_unit">base_currency_unit</a>(_reward_oracle: <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_RewardOracle">oracle::RewardOracle</a>, _round_id: u256): u64
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_asset_price"></a>
+
+## Function `get_asset_price`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_asset_price">get_asset_price</a>(asset: <b>address</b>): u256
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_base_currency_unit"></a>
+
+## Function `get_base_currency_unit`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_get_base_currency_unit">get_base_currency_unit</a>(): <a href="_Option">option::Option</a>&lt;u256&gt;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_set_asset_price"></a>
+
+## Function `set_asset_price`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_set_asset_price">set_asset_price</a>(<a href="">account</a>: &<a href="">signer</a>, asset: <b>address</b>, price: u256)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_batch_set_asset_price"></a>
+
+## Function `batch_set_asset_price`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_batch_set_asset_price">batch_set_asset_price</a>(<a href="">account</a>: &<a href="">signer</a>, assets: <a href="">vector</a>&lt;<b>address</b>&gt;, prices: <a href="">vector</a>&lt;u256&gt;)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_update_asset_price"></a>
+
+## Function `update_asset_price`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_update_asset_price">update_asset_price</a>(<a href="">account</a>: &<a href="">signer</a>, asset: <b>address</b>, price: u256)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_remove_asset_price"></a>
+
+## Function `remove_asset_price`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="oracle.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_remove_asset_price">remove_asset_price</a>(<a href="">account</a>: &<a href="">signer</a>, asset: <b>address</b>)
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/doc/oracle_sentinel.md
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/doc/oracle_sentinel.md
@@ -1,0 +1,170 @@
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel"></a>
+
+# Module `0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e::oracle_sentinel`
+
+@title PriceOracleSentinel
+@author Aave
+@notice It validates if operations are allowed depending on the PriceOracle health.
+@dev Once the PriceOracle gets up after an outage/downtime, users can make their positions healthy during a grace
+period. So the PriceOracle is considered completely up once its up and the grace period passed.
+
+
+-  [Struct `GracePeriodUpdated`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_GracePeriodUpdated)
+-  [Resource `OracleSentinel`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_OracleSentinel)
+-  [Constants](#@Constants_0)
+-  [Function `init_oracle_sentinel`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_init_oracle_sentinel)
+-  [Function `set_answer`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_set_answer)
+-  [Function `latest_round_data`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_latest_round_data)
+-  [Function `is_borrow_allowed`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_borrow_allowed)
+-  [Function `is_liquidation_allowed`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_liquidation_allowed)
+-  [Function `is_up_and_grace_period_passed`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_up_and_grace_period_passed)
+-  [Function `set_grace_period`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_set_grace_period)
+-  [Function `get_grace_period`](#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_get_grace_period)
+
+
+<pre><code><b>use</b> <a href="">0x1::event</a>;
+<b>use</b> <a href="">0x1::signer</a>;
+<b>use</b> <a href="">0x1::timestamp</a>;
+<b>use</b> <a href="../../aave-acl/doc/acl_manage.md#0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9_acl_manage">0xd329b8b371bf56fdbfbb66f441a8463f3605ecb27ee0c484f85a4cf88883d2f9::acl_manage</a>;
+<b>use</b> <a href="../../aave-config/doc/error_config.md#0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd_error">0xe984b3b024d14e7aac51fb0aec8d0fbfbc23a230fe3bd8a87f575d243bc0cedd::error</a>;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_GracePeriodUpdated"></a>
+
+## Struct `GracePeriodUpdated`
+
+
+
+<pre><code>#[<a href="">event</a>]
+<b>struct</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_GracePeriodUpdated">GracePeriodUpdated</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_OracleSentinel"></a>
+
+## Resource `OracleSentinel`
+
+
+
+<pre><code><b>struct</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_OracleSentinel">OracleSentinel</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_E_ORACLE_NOT_ADMIN"></a>
+
+
+
+<pre><code><b>const</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_E_ORACLE_NOT_ADMIN">E_ORACLE_NOT_ADMIN</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_E_RESOURCE_NOT_FOUND"></a>
+
+
+
+<pre><code><b>const</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_E_RESOURCE_NOT_FOUND">E_RESOURCE_NOT_FOUND</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_init_oracle_sentinel"></a>
+
+## Function `init_oracle_sentinel`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_init_oracle_sentinel">init_oracle_sentinel</a>(<a href="">account</a>: &<a href="">signer</a>)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_set_answer"></a>
+
+## Function `set_answer`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_set_answer">set_answer</a>(<a href="">account</a>: &<a href="">signer</a>, is_down: bool, <a href="">timestamp</a>: u256)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_latest_round_data"></a>
+
+## Function `latest_round_data`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_latest_round_data">latest_round_data</a>(): (u128, u256, u256, u256, u128)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_borrow_allowed"></a>
+
+## Function `is_borrow_allowed`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_borrow_allowed">is_borrow_allowed</a>(): bool
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_liquidation_allowed"></a>
+
+## Function `is_liquidation_allowed`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_liquidation_allowed">is_liquidation_allowed</a>(): bool
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_up_and_grace_period_passed"></a>
+
+## Function `is_up_and_grace_period_passed`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_is_up_and_grace_period_passed">is_up_and_grace_period_passed</a>(): bool
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_set_grace_period"></a>
+
+## Function `set_grace_period`
+
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_set_grace_period">set_grace_period</a>(<a href="">account</a>: &<a href="">signer</a>, new_grace_period: u256)
+</code></pre>
+
+
+
+<a id="0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_get_grace_period"></a>
+
+## Function `get_grace_period`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="oracle_sentinel.md#0xe02c89369099ad99993cbe3d4c3c80b299df006885854178a8acdb6ab6afb6e_oracle_sentinel_get_grace_period">get_grace_period</a>(): u256
+</code></pre>

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/sources/oracle.move
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/sources/oracle.move
@@ -1,0 +1,93 @@
+module aave_oracle::oracle {
+    use std::vector;
+    use aave_oracle::oracle_base::Self;
+    use data_feeds::router::{Self as chainlink_router};
+    use data_feeds::registry::{Self as chainlink};
+
+    // friends
+    friend aave_oracle::price_cap_stable_adapter;
+
+    fun init_module(account: &signer) {
+        oracle_base::init_oracle(account);
+    }
+
+    #[test_only]
+    public fun test_init_module(account: &signer) {
+        init_module(account);
+    }
+
+    #[view]
+    public fun get_asset_price(asset: address): u256 {
+        let feed_id = oracle_base::assert_asset_feed_id_exists(asset);
+        let benchmarks =
+            chainlink_router::get_benchmarks(
+                &oracle_base::get_resource_account_signer(),
+                vector[feed_id],
+                vector[]
+            );
+        oracle_base::assert_benchmarks_match_assets(vector::length(&benchmarks), 1);
+        let benchmark = vector::borrow(&benchmarks, 0);
+        chainlink::get_benchmark_value(benchmark)
+    }
+
+    #[view]
+    public fun get_assets_prices(assets: vector<address>): vector<u256> {
+        let feed_ids: vector<vector<u8>> = vector[];
+        for (i in 0..vector::length(&assets)) {
+            let asset = *vector::borrow(&assets, i);
+            let feed_id = oracle_base::assert_asset_feed_id_exists(asset);
+            vector::push_back(&mut feed_ids, feed_id);
+        };
+        let benchmarks =
+            chainlink_router::get_benchmarks(
+                &oracle_base::get_resource_account_signer(), feed_ids, vector[]
+            );
+        oracle_base::assert_benchmarks_match_assets(
+            vector::length(&benchmarks), vector::length(&assets)
+        );
+        let prices = vector::map_ref<chainlink::Benchmark, u256>(
+            &benchmarks,
+            |benchmark| { chainlink::get_benchmark_value(benchmark) }
+        );
+        prices
+    }
+
+    public entry fun set_asset_feed_id(
+        account: &signer, asset: address, feed_id: vector<u8>
+    ) {
+        oracle_base::only_risk_or_pool_admin(account);
+        oracle_base::set_asset_feed_id(asset, feed_id);
+        oracle_base::emit_asset_price_feed_updated(asset, feed_id);
+    }
+
+    public entry fun batch_set_asset_feed_ids(
+        account: &signer, assets: vector<address>, feed_ids: vector<vector<u8>>
+    ) {
+        oracle_base::only_risk_or_pool_admin(account);
+        for (i in 0..vector::length(&assets)) {
+            let asset = *vector::borrow(&assets, i);
+            let feed_id = *vector::borrow(&feed_ids, i);
+            oracle_base::set_asset_feed_id(asset, feed_id);
+            oracle_base::emit_asset_price_feed_updated(asset, feed_id);
+        };
+    }
+
+    public entry fun remove_asset_feed_id(account: &signer, asset: address) {
+        oracle_base::only_risk_or_pool_admin(account);
+        let feed_id = oracle_base::assert_asset_feed_id_exists(asset);
+        oracle_base::remove_feed_id(asset);
+        oracle_base::emit_asset_price_feed_removed(asset, feed_id);
+    }
+
+    public entry fun batch_remove_asset_feed_ids(
+        account: &signer, assets: vector<address>
+    ) {
+        oracle_base::only_risk_or_pool_admin(account);
+        for (i in 0..vector::length(&assets)) {
+            let asset = *vector::borrow(&assets, i);
+            let feed_id = oracle_base::assert_asset_feed_id_exists(asset);
+            oracle_base::remove_feed_id(asset);
+            oracle_base::emit_asset_price_feed_removed(asset, feed_id);
+        };
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/sources/oracle_base.move
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/sources/oracle_base.move
@@ -1,0 +1,198 @@
+module aave_oracle::oracle_base {
+
+    use std::signer;
+    use aptos_std::smart_table;
+    use aptos_framework::event;
+    use std::option::{Self, Option};
+    use std::string::String;
+    use aave_acl::acl_manage;
+    use aptos_framework::account::{Self, SignerCapability};
+    use aave_config::error_config::Self;
+
+    // friends
+    friend aave_oracle::price_cap_stable_adapter;
+    friend aave_oracle::oracle;
+
+    // consts
+    const AAVE_ORACLE_SEED: vector<u8> = b"AAVE_ORACLE";
+
+    // errors
+    const E_ORACLE_NOT_ADMIN: u64 = 1;
+    const E_ASSET_ALREADY_EXISTS: u64 = 2;
+    const E_NO_ASSET_FEED: u64 = 3;
+    const E_ORACLE_BENCHMARK_LENGHT_MISMATCH: u64 = 4;
+
+    #[event]
+    struct AssetPriceFeedUpdated has store, drop {
+        asset: address,
+        feed_id: vector<u8>
+    }
+
+    #[event]
+    struct AssetPriceFeedRemoved has store, drop {
+        asset: address,
+        feed_id: vector<u8>
+    }
+
+    struct BaseCurrency has copy, key, store, drop {
+        asset: String,
+        unit: u64
+    }
+
+    struct PriceOracleData has key {
+        asset_feed_ids: smart_table::SmartTable<address, vector<u8>>,
+        signer_cap: SignerCapability,
+        base_currency: Option<BaseCurrency>
+    }
+
+    public fun only_oracle_admin(account: &signer) {
+        assert!(signer::address_of(account) == @aave_oracle, E_ORACLE_NOT_ADMIN);
+    }
+
+    /// @dev Only risk or pool admin can call functions marked by this modifier.
+    public(friend) fun only_risk_or_pool_admin(account: &signer) {
+        let account_address = signer::address_of(account);
+        assert!(
+            acl_manage::is_pool_admin(account_address)
+                || acl_manage::is_risk_admin(account_address),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+    }
+
+    #[test_only]
+    public fun test_only_risk_or_pool_admin(account: &signer) {
+        only_risk_or_pool_admin(account);
+    }
+
+    #[test_only]
+    public fun test_init_oracle(account: &signer) {
+        init_oracle(account);
+    }
+
+    public(friend) fun init_oracle(account: &signer) {
+        only_oracle_admin(account);
+
+        // create a resource account
+        let (resource_signer, signer_cap) =
+            account::create_resource_account(account, AAVE_ORACLE_SEED);
+
+        move_to(
+            &resource_signer,
+            PriceOracleData {
+                asset_feed_ids: smart_table::new(),
+                signer_cap,
+                base_currency: option::none()
+            }
+        )
+    }
+
+    public fun get_base_currency_unit(base_currency: &BaseCurrency): u64 {
+        base_currency.unit
+    }
+
+    public fun get_base_currency_asset(base_currency: &BaseCurrency): String {
+        base_currency.asset
+    }
+
+    #[view]
+    public fun get_oracle_base_currency(): Option<BaseCurrency> acquires PriceOracleData {
+        // get the oracle data
+        let oracle_data = borrow_global_mut<PriceOracleData>(oracle_address());
+        // check and return if exists
+        if (option::is_some(&oracle_data.base_currency)) {
+            option::some(*option::borrow(&oracle_data.base_currency))
+        } else {
+            option::none<BaseCurrency>()
+        }
+    }
+
+    #[view]
+    public fun get_oracle_resource_account(): address acquires PriceOracleData {
+        let collector_data = borrow_global<PriceOracleData>(oracle_address());
+        let account_signer =
+            account::create_signer_with_capability(&collector_data.signer_cap);
+        signer::address_of(&account_signer)
+    }
+
+    #[view]
+    public fun oracle_address(): address {
+        account::create_resource_address(&@aave_oracle, AAVE_ORACLE_SEED)
+    }
+
+    public(friend) fun get_resource_account_signer(): signer acquires PriceOracleData {
+        let oracle_data = borrow_global<PriceOracleData>(oracle_address());
+        account::create_signer_with_capability(&oracle_data.signer_cap)
+    }
+
+    #[test_only]
+    public fun get_resource_account_signer_for_testing(): signer acquires PriceOracleData {
+        get_resource_account_signer()
+    }
+
+    public(friend) fun set_asset_feed_id(
+        asset: address, feed_id: vector<u8>
+    ) acquires PriceOracleData {
+        let asset_price_list = borrow_global_mut<PriceOracleData>(oracle_address());
+        smart_table::upsert(&mut asset_price_list.asset_feed_ids, asset, feed_id);
+    }
+
+    #[test_only]
+    public fun test_set_asset_feed_id(
+        asset: address, feed_id: vector<u8>
+    ) acquires PriceOracleData {
+        set_asset_feed_id(asset, feed_id);
+    }
+
+    public(friend) fun assert_asset_feed_id_exists(
+        asset: address
+    ): vector<u8> acquires PriceOracleData {
+        let asset_price_list = borrow_global<PriceOracleData>(oracle_address());
+        assert!(
+            smart_table::contains(&asset_price_list.asset_feed_ids, asset),
+            E_NO_ASSET_FEED
+        );
+        *smart_table::borrow(&asset_price_list.asset_feed_ids, asset)
+    }
+
+    public(friend) fun get_feed_id(asset: address): vector<u8> acquires PriceOracleData {
+        let asset_price_list = borrow_global<PriceOracleData>(oracle_address());
+        let feed_id = *smart_table::borrow(&asset_price_list.asset_feed_ids, asset);
+        feed_id
+    }
+
+    #[test_only]
+    public fun test_get_feed_id(asset: address): vector<u8> acquires PriceOracleData {
+        get_feed_id(asset)
+    }
+
+    public(friend) fun remove_feed_id(asset: address) acquires PriceOracleData {
+        let asset_price_list = borrow_global_mut<PriceOracleData>(oracle_address());
+        smart_table::remove(&mut asset_price_list.asset_feed_ids, asset);
+    }
+
+    #[test_only]
+    public fun test_remove_feed_id(asset: address) acquires PriceOracleData {
+        remove_feed_id(asset)
+    }
+
+    public(friend) fun emit_asset_price_feed_updated(
+        asset: address, feed_id: vector<u8>
+    ) {
+        event::emit(AssetPriceFeedUpdated { asset, feed_id })
+    }
+
+    public(friend) fun emit_asset_price_feed_removed(
+        asset: address, feed_id: vector<u8>
+    ) {
+        event::emit(AssetPriceFeedRemoved { asset, feed_id })
+    }
+
+    public(friend) fun assert_benchmarks_match_assets(
+        benchmarks_len: u64, requested_assets: u64
+    ) {
+        assert!(
+            benchmarks_len == requested_assets,
+            E_ORACLE_BENCHMARK_LENGHT_MISMATCH
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/sources/price_cap_stable_adapter.move
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/sources/price_cap_stable_adapter.move
@@ -1,0 +1,97 @@
+module aave_oracle::price_cap_stable_adapter {
+    use aptos_framework::event::Self;
+    use std::signer;
+    use aave_acl::acl_manage;
+    use aave_config::error_config::Self;
+    use std::string::String;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::address_to_object;
+    use aave_oracle::oracle::Self;
+
+    // errors
+    const E_ORACLE_NOT_ADMIN: u64 = 1;
+    const E_CAP_LOWER_THAN_ACTUAL_PRICE: u64 = 2;
+
+    // events
+    #[event]
+    struct PriceCapUpdated has store, drop {
+        price_cap: u256
+    }
+
+    struct InternalData has key {
+        asset: address,
+        decimals: u8,
+        description: String,
+        price_cap: u256
+    }
+
+    fun only_oracle_admin(account: &signer) {
+        assert!(signer::address_of(account) == @aave_oracle, E_ORACLE_NOT_ADMIN);
+    }
+
+    fun only_risk_or_pool_admin(account: &signer) {
+        let account_address = signer::address_of(account);
+        assert!(
+            acl_manage::is_pool_admin(account_address)
+                || acl_manage::is_risk_admin(account_address),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+    }
+
+    public fun init_price_cap_stable_adaptor(
+        account: &signer,
+        asset: address,
+        description: String,
+        price_cap: u256
+    ) {
+        only_oracle_admin(account);
+        let base_price = oracle::get_asset_price(asset);
+        assert!(price_cap >= base_price, E_CAP_LOWER_THAN_ACTUAL_PRICE);
+        event::emit(PriceCapUpdated { price_cap });
+
+        move_to(
+            account,
+            InternalData {
+                asset,
+                decimals: fungible_asset::decimals(address_to_object<Metadata>(asset)),
+                description,
+                price_cap
+            }
+        )
+    }
+
+    public entry fun set_price_cap(account: &signer, price_cap: u256) acquires InternalData {
+        only_risk_or_pool_admin(account);
+        set_price_cap_internal(price_cap);
+    }
+
+    fun set_price_cap_internal(price_cap: u256) acquires InternalData {
+        let internal_data = borrow_global_mut<InternalData>(@aave_oracle);
+        let base_price = oracle::get_asset_price(internal_data.asset);
+        assert!(price_cap >= base_price, E_CAP_LOWER_THAN_ACTUAL_PRICE);
+        internal_data.price_cap = price_cap;
+        event::emit(PriceCapUpdated { price_cap })
+    }
+
+    #[view]
+    public fun is_capped(): bool acquires InternalData {
+        let internal_data = borrow_global<InternalData>(@aave_oracle);
+        oracle::get_asset_price(internal_data.asset) > latestAnswer()
+    }
+
+    #[view]
+    public fun latestAnswer(): u256 acquires InternalData {
+        let internal_data = borrow_global<InternalData>(@aave_oracle);
+        let base_price = oracle::get_asset_price(internal_data.asset);
+        if (base_price > internal_data.price_cap) {
+            return internal_data.price_cap
+        };
+        base_price
+    }
+
+    #[view]
+    public fun get_price_cap(): u256 acquires InternalData {
+        borrow_global<InternalData>(@aave_oracle).price_cap
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/sources/reward_oracle.move
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/sources/reward_oracle.move
@@ -1,0 +1,50 @@
+module aave_oracle::reward_oracle {
+
+    // TODO: this is unfinished
+    struct RewardOracle has key, store, drop, copy {
+        id: u256
+    }
+
+    public fun create_reward_oracle(id: u256): RewardOracle {
+        // TODO
+        RewardOracle { id }
+    }
+
+    public fun decimals(_reward_oracle: RewardOracle): u8 {
+        // TODO
+        0
+    }
+
+    public fun latest_answer(_reward_oracle: RewardOracle): u256 {
+        1
+    }
+
+    public fun latest_timestamp(_reward_oracle: RewardOracle): u256 {
+        // TODO
+        0
+    }
+
+    public fun latest_round(_reward_oracle: RewardOracle): u256 {
+        // TODO
+        0
+    }
+
+    public fun get_answer(_reward_oracle: RewardOracle, _round_id: u256): u256 {
+        // TODO
+        0
+    }
+
+    public fun get_timestamp(
+        _reward_oracle: RewardOracle, _round_id: u256
+    ): u256 {
+        // TODO
+        0
+    }
+
+    public fun base_currency_unit(
+        _reward_oracle: RewardOracle, _round_id: u256
+    ): u64 {
+        // TODO
+        0
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/tests/oracle_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/tests/oracle_tests.move
@@ -1,0 +1,401 @@
+#[test_only]
+module aave_oracle::oracle_tests {
+    use std::signer;
+    use std::vector;
+    use std::string::Self;
+    use aave_oracle::oracle::Self;
+    use aave_oracle::oracle_base::Self;
+    use aave_acl::acl_manage::Self;
+    use aptos_framework::timestamp::{set_time_has_started_for_testing};
+    use data_feeds::registry::Self;
+    use aptos_framework::event::emitted_events;
+    use data_feeds::router;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+    const TEST_ASSET: address = @0x444;
+    const TEST_FEED_ID: vector<u8> = x"0003fbba4fce42f65d6032b18aee53efdf526cc734ad296cb57565979d883bdd";
+    const TEST_FEED_PRICE: u256 = 63762090573356116000000;
+
+    public fun get_test_feed_id(): vector<u8> {
+        TEST_FEED_ID
+    }
+
+    public fun config_oracle(
+        aave_oracle: &signer, data_feeds: &signer, platform: &signer
+    ) {
+        oracle::test_init_module(aave_oracle);
+        set_up_chainlink_oracle(data_feeds, platform);
+        set_chainlink_test_data(&oracle_base::get_resource_account_signer_for_testing());
+    }
+
+    fun set_up_chainlink_oracle(data_feeds: &signer, platform: &signer) {
+        use aptos_framework::account::{Self};
+        account::create_account_for_test(signer::address_of(data_feeds));
+        account::create_account_for_test(signer::address_of(platform));
+
+        platform::forwarder::init_module_for_testing(platform);
+        platform::storage::init_module_for_testing(platform);
+        router::init_module_for_testing(data_feeds);
+
+        registry::init_module_for_testing(data_feeds);
+    }
+
+    fun set_chainlink_test_data(owner: &signer) {
+        let report_data = TEST_FEED_ID;
+        vector::append(
+            &mut report_data,
+            x"0000000000000000000000000000000000000000000000000000000066ed173e0000000000000000000000000000000000000000000000000000000066ed174200000000000000007fffffffffffffffffffffffffffffffffffffffffffffff00000000000000007fffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000066ee68c2000000000000000000000000000000000000000000000d808cc35e6ed670bd00000000000000000000000000000000000000000000000d808590c35425347980000000000000000000000000000000000000000000000d8093f5f989878e7c00"
+        );
+        let config_id = vector[1];
+        registry::set_feeds(
+            owner,
+            vector[TEST_FEED_ID],
+            vector[string::utf8(b"description")],
+            config_id
+        );
+        registry::perform_update_for_testing(TEST_FEED_ID, report_data);
+    }
+
+    #[
+        test(
+            super_admin = @aave_acl,
+            oracle_admin = @0x06,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            aptos = @aptos_framework
+        )
+    ]
+    #[expected_failure(abort_code = 3)]
+    fun test_oracle_price_unknown_asset(
+        super_admin: &signer,
+        oracle_admin: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        aptos: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos);
+
+        // init the acl module
+        acl_manage::test_init_module(super_admin);
+
+        // add the roles for the oracle admin
+        acl_manage::add_pool_admin(super_admin, signer::address_of(oracle_admin));
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(oracle_admin)), TEST_SUCCESS
+        );
+        acl_manage::add_asset_listing_admin(
+            super_admin, signer::address_of(oracle_admin)
+        );
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(oracle_admin)),
+            TEST_SUCCESS
+        );
+
+        // init aave oracle
+        config_oracle(aave_oracle, data_feeds, platform);
+
+        // check assets which are not known fail to return a price
+        let undeclared_asset = @0x0;
+        oracle::get_asset_price(undeclared_asset);
+    }
+
+    #[
+        test(
+            super_admin = @aave_acl,
+            oracle_admin = @0x06,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            aptos = @aptos_framework
+        )
+    ]
+    fun test_oracle_set_single_price(
+        super_admin: &signer,
+        oracle_admin: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        aptos: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos);
+
+        // init the acl module
+        acl_manage::test_init_module(super_admin);
+
+        // add the roles for the oracle admin
+        acl_manage::add_pool_admin(super_admin, signer::address_of(oracle_admin));
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(oracle_admin)), TEST_SUCCESS
+        );
+        acl_manage::add_asset_listing_admin(
+            super_admin, signer::address_of(oracle_admin)
+        );
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(oracle_admin)),
+            TEST_SUCCESS
+        );
+
+        // init aave oracle
+        config_oracle(aave_oracle, data_feeds, platform);
+
+        // now set a feed for a given token
+        oracle::set_asset_feed_id(oracle_admin, TEST_ASSET, TEST_FEED_ID);
+
+        // check for specific events
+        let emitted_events = emitted_events<oracle_base::AssetPriceFeedUpdated>();
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+
+        // assert the set price
+        assert!(oracle::get_asset_price(TEST_ASSET) == TEST_FEED_PRICE, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            super_admin = @aave_acl,
+            oracle_admin = @0x06,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            aptos = @aptos_framework
+        )
+    ]
+    fun test_oracle_set_batch_prices(
+        super_admin: &signer,
+        oracle_admin: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        aptos: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos);
+
+        // init the acl module
+        acl_manage::test_init_module(super_admin);
+
+        // add the roles for the oracle admin
+        acl_manage::add_pool_admin(super_admin, signer::address_of(oracle_admin));
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(oracle_admin)), TEST_SUCCESS
+        );
+        acl_manage::add_asset_listing_admin(
+            super_admin, signer::address_of(oracle_admin)
+        );
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(oracle_admin)),
+            TEST_SUCCESS
+        );
+
+        // init aave oracle
+        config_oracle(aave_oracle, data_feeds, platform);
+
+        // define assets and feedids
+        let asset_addresses = vector[@0x0, @0x1, @0x2, @0x3];
+        let asset_feed_ids = vector[TEST_FEED_ID, TEST_FEED_ID, TEST_FEED_ID, TEST_FEED_ID];
+
+        // set in batch mode assets and feed ids
+        oracle::batch_set_asset_feed_ids(oracle_admin, asset_addresses, asset_feed_ids);
+
+        // check for specific events
+        let emitted_events = emitted_events<oracle_base::AssetPriceFeedUpdated>();
+        assert!(
+            vector::length(&emitted_events) == vector::length(&asset_addresses),
+            TEST_SUCCESS
+        );
+
+        // get prices and ensure they are all > 0 since mocked
+        let prices = oracle::get_assets_prices(asset_addresses);
+        assert!(!vector::any(&prices, |price| *price != TEST_FEED_PRICE), TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            super_admin = @aave_acl,
+            oracle_admin = @0x06,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            aptos = @aptos_framework
+        )
+    ]
+    #[expected_failure(abort_code = 3)]
+    fun test_oracle_remove_single_price(
+        super_admin: &signer,
+        oracle_admin: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        aptos: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos);
+
+        // init the acl module
+        acl_manage::test_init_module(super_admin);
+
+        // add the roles for the oracle admin
+        acl_manage::add_pool_admin(super_admin, signer::address_of(oracle_admin));
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(oracle_admin)), TEST_SUCCESS
+        );
+        acl_manage::add_asset_listing_admin(
+            super_admin, signer::address_of(oracle_admin)
+        );
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(oracle_admin)),
+            TEST_SUCCESS
+        );
+
+        // init aave oracle
+        config_oracle(aave_oracle, data_feeds, platform);
+
+        // now set the chainlink feed for a given token
+        let test_token_address = TEST_ASSET;
+        oracle::set_asset_feed_id(oracle_admin, test_token_address, TEST_FEED_ID);
+
+        // assert the set price
+        assert!(
+            oracle::get_asset_price(test_token_address) == TEST_FEED_PRICE,
+            TEST_SUCCESS
+        );
+
+        // remove the feed for dai
+        oracle::remove_asset_feed_id(oracle_admin, test_token_address);
+
+        // check for specific events
+        let emitted_events = emitted_events<oracle_base::AssetPriceFeedRemoved>();
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+
+        // try to query the price again
+        oracle::get_asset_price(test_token_address);
+    }
+
+    #[
+        test(
+            super_admin = @aave_acl,
+            oracle_admin = @0x06,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            aptos = @aptos_framework
+        )
+    ]
+    #[expected_failure(abort_code = 3)]
+    fun test_oracle_remove_batch_prices(
+        super_admin: &signer,
+        oracle_admin: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        aptos: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos);
+
+        // init the acl module
+        acl_manage::test_init_module(super_admin);
+
+        // add the roles for the oracle admin
+        acl_manage::add_pool_admin(super_admin, signer::address_of(oracle_admin));
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(oracle_admin)), TEST_SUCCESS
+        );
+        acl_manage::add_asset_listing_admin(
+            super_admin, signer::address_of(oracle_admin)
+        );
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(oracle_admin)),
+            TEST_SUCCESS
+        );
+
+        // init aave oracle
+        config_oracle(aave_oracle, data_feeds, platform);
+
+        // define assets and feed ids which chainlink does not support
+        let asset_addresses = vector[@0x0, @0x1, @0x2, @0x3];
+        let asset_feed_ids = vector[TEST_FEED_ID, TEST_FEED_ID, TEST_FEED_ID, TEST_FEED_ID];
+
+        // set in batch mode assets and feed ids
+        oracle::batch_set_asset_feed_ids(oracle_admin, asset_addresses, asset_feed_ids);
+
+        // remove assets as a batch
+        oracle::batch_remove_asset_feed_ids(oracle_admin, asset_addresses);
+
+        // check for specific events
+        let emitted_events = emitted_events<oracle_base::AssetPriceFeedRemoved>();
+        assert!(
+            vector::length(&emitted_events) == vector::length(&asset_addresses),
+            TEST_SUCCESS
+        );
+
+        // try to get prices - this would fail as a batch
+        oracle::get_assets_prices(asset_addresses);
+    }
+
+    #[
+        test(
+            super_admin = @aave_acl,
+            oracle_admin = @0x06,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            aptos = @aptos_framework
+        )
+    ]
+    fun test_oracle_remove_one_in_batch_price(
+        super_admin: &signer,
+        oracle_admin: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        aptos: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos);
+
+        // init the acl module
+        acl_manage::test_init_module(super_admin);
+
+        // add the roles for the oracle admin
+        acl_manage::add_pool_admin(super_admin, signer::address_of(oracle_admin));
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(oracle_admin)), TEST_SUCCESS
+        );
+        acl_manage::add_asset_listing_admin(
+            super_admin, signer::address_of(oracle_admin)
+        );
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(oracle_admin)),
+            TEST_SUCCESS
+        );
+
+        // init aave oracle
+        config_oracle(aave_oracle, data_feeds, platform);
+
+        // define assets and feed ids which chainlink does not support
+        let asset_addresses = vector[@0x0, @0x1, @0x2, @0x3];
+        let asset_feed_ids = vector[TEST_FEED_ID, TEST_FEED_ID, TEST_FEED_ID, TEST_FEED_ID];
+
+        // set in batch mode assets and feed ids
+        oracle::batch_set_asset_feed_ids(oracle_admin, asset_addresses, asset_feed_ids);
+
+        // remove assets as a batch
+        let end = vector::length(&asset_addresses);
+        let truncated = vector::slice(&mut asset_addresses, 1, end);
+        oracle::batch_remove_asset_feed_ids(oracle_admin, truncated);
+
+        // check for specific events
+        let emitted_events = emitted_events<oracle_base::AssetPriceFeedRemoved>();
+        assert!(
+            vector::length(&emitted_events) == vector::length(&truncated), TEST_SUCCESS
+        );
+
+        // try to get price for the unremoved asset, should work
+        assert!(oracle::get_asset_price(@0x0) == TEST_FEED_PRICE, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-oracle/tests/reward_oracle_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-oracle/tests/reward_oracle_tests.move
@@ -1,0 +1,56 @@
+#[test_only]
+module aave_oracle::reward_oracle_tests {
+    use aave_oracle::reward_oracle::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test()]
+    fun test_mocked_reward_oracle_decimals() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the decimals which should now be 0
+        assert!(reward_oracle::decimals(reward_oracle) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_mocked_reward_oracle_latest_answer() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the latest_answer which should now be 1
+        assert!(reward_oracle::latest_answer(reward_oracle) == 1, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_mocked_reward_oracle_latest_timestamp() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the latest_timestamp which should now be 0
+        assert!(reward_oracle::latest_timestamp(reward_oracle) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_mocked_reward_oracle_latest_round() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the latest_round which should now be 0
+        assert!(reward_oracle::latest_round(reward_oracle) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_mocked_reward_oracle_get_answer() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the get_answer which should now be 0
+        assert!(reward_oracle::get_answer(reward_oracle, 1) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_mocked_reward_oracle_get_timestamp() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the get_timestamp which should now be 0
+        assert!(reward_oracle::get_timestamp(reward_oracle, 1) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_mocked_reward_oracle_base_currency_unit() {
+        let reward_oracle = reward_oracle::create_reward_oracle(1);
+        // check the base_currency_unit which should now be 0
+        assert!(reward_oracle::base_currency_unit(reward_oracle, 1) == 0, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-rate/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-rate/Move.toml
@@ -1,0 +1,16 @@
+[package]
+name = "AaveRate"
+version = "1.0.0"
+authors = []
+
+[addresses]
+aave_rate = '_'
+[dev-addresses]
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AaveAcl = { local = "../aave-acl" }
+AaveConfig = { local = "../aave-config" }
+AaveMath = { local = "../aave-math" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-rate/sources/default_reserve_interest_rate_strategy.move
+++ b/tests/aptos-aave-v3/aave-core/aave-rate/sources/default_reserve_interest_rate_strategy.move
@@ -1,0 +1,307 @@
+/// @title default_reserve_interest_rate_strategy module
+/// @author Aave
+/// @notice Implements the calculation of the interest rates depending on the reserve state
+/// @dev The model of interest rate is based on 2 slopes, one before the `OPTIMAL_USAGE_RATIO`
+/// point of usage and another from that one to 100%.
+module aave_rate::default_reserve_interest_rate_strategy {
+    use std::signer;
+    use aptos_std::smart_table;
+    use aptos_std::smart_table::SmartTable;
+    use aptos_framework::event;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math::{Self, wad_to_ray};
+    friend aave_rate::interest_rate_strategy;
+
+    #[event]
+    struct ReserveInterestRateStrategy has store, drop {
+        asset: address,
+        optimal_usage_ratio: u256,
+        max_excess_usage_ratio: u256,
+        // Base variable borrow rate when usage rate = 0. Expressed in ray
+        base_variable_borrow_rate: u256,
+        // Slope of the variable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+        variable_rate_slope1: u256,
+        // Slope of the variable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+        variable_rate_slope2: u256
+    }
+
+    struct DefaultReserveInterestRateStrategy has key, store, copy, drop {
+        optimal_usage_ratio: u256,
+        max_excess_usage_ratio: u256,
+        // Base variable borrow rate when usage rate = 0. Expressed in ray
+        base_variable_borrow_rate: u256,
+        // Slope of the variable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+        variable_rate_slope1: u256,
+        // Slope of the variable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+        variable_rate_slope2: u256
+    }
+
+    // List of reserves as a map (underlying_asset => DefaultReserveInterestRateStrategy)
+    struct ReserveInterestRateStrategyMap has key {
+        value: SmartTable<address, DefaultReserveInterestRateStrategy>
+    }
+
+    struct CalcInterestRatesLocalVars has drop {
+        available_liquidity: u256,
+        total_debt: u256,
+        current_variable_borrow_rate: u256,
+        current_liquidity_rate: u256,
+        borrow_usage_ratio: u256,
+        supply_usage_ratio: u256,
+        available_liquidity_plus_debt: u256
+    }
+
+    /// @notice Initializes the interest rate strategy
+    /// @dev Only callable by the interest_rate_strategy module
+    /// @param account The signer account of the caller
+    public fun init_interest_rate_strategy(account: &signer) {
+        assert!(
+            signer::address_of(account) == @aave_rate,
+            error_config::get_enot_rate_owner()
+        );
+
+        move_to(
+            account,
+            ReserveInterestRateStrategyMap {
+                value: smart_table::new<address, DefaultReserveInterestRateStrategy>()
+            }
+        );
+    }
+
+    /// @notice Sets the interest rate strategy of a reserve
+    /// @param account The signer account of the caller
+    /// @param asset The address of the reserve
+    /// @param optimal_usage_ratio The optimal usage ratio
+    /// @param base_variable_borrow_rate The base variable borrow rate
+    /// @param variable_rate_slope1 The variable rate slope below optimal usage ratio
+    /// @param variable_rate_slope2 The variable rate slope above optimal usage ratio
+    public entry fun set_reserve_interest_rate_strategy(
+        account: &signer,
+        asset: address,
+        optimal_usage_ratio: u256,
+        base_variable_borrow_rate: u256,
+        variable_rate_slope1: u256,
+        variable_rate_slope2: u256
+    ) acquires ReserveInterestRateStrategyMap {
+        let account_address = signer::address_of(account);
+        assert!(
+            only_risk_or_pool_admins(account_address),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+        assert!(
+            wad_ray_math::ray() >= optimal_usage_ratio,
+            error_config::get_einvalid_optimal_usage_ratio()
+        );
+
+        let max_excess_usage_ratio = wad_ray_math::ray() - optimal_usage_ratio;
+        let reserve_interest_rate_strategy = DefaultReserveInterestRateStrategy {
+            optimal_usage_ratio,
+            max_excess_usage_ratio,
+            base_variable_borrow_rate,
+            variable_rate_slope1,
+            variable_rate_slope2
+        };
+
+        let rate_strategy = borrow_global_mut<ReserveInterestRateStrategyMap>(@aave_rate);
+        smart_table::upsert(
+            &mut rate_strategy.value, asset, reserve_interest_rate_strategy
+        );
+
+        event::emit(
+            ReserveInterestRateStrategy {
+                asset,
+                optimal_usage_ratio,
+                max_excess_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            }
+        )
+    }
+
+    public fun asset_interest_rate_exists(asset: address) acquires ReserveInterestRateStrategyMap {
+        let rate_strategy = borrow_global<ReserveInterestRateStrategyMap>(@aave_rate);
+        assert!(
+            smart_table::contains(&rate_strategy.value, asset),
+            error_config::get_easset_not_listed()
+        );
+    }
+
+    #[view]
+    public fun get_reserve_interest_rate_strategy(
+        asset: address
+    ): DefaultReserveInterestRateStrategy acquires ReserveInterestRateStrategyMap {
+        let rate_strategy_map = borrow_global<ReserveInterestRateStrategyMap>(@aave_rate);
+        if (!smart_table::contains(&rate_strategy_map.value, asset)) {
+            // If rate do not exist, return zero as default values, to be 1:1 with Solidity
+            return DefaultReserveInterestRateStrategy {
+                optimal_usage_ratio: 0,
+                max_excess_usage_ratio: 0,
+                base_variable_borrow_rate: 0,
+                variable_rate_slope1: 0,
+                variable_rate_slope2: 0
+            }
+        };
+
+        *smart_table::borrow(&rate_strategy_map.value, asset)
+    }
+
+    #[view]
+    public fun get_optimal_usage_ratio(asset: address): u256 acquires ReserveInterestRateStrategyMap {
+        get_reserve_interest_rate_strategy(asset).optimal_usage_ratio
+    }
+
+    #[view]
+    public fun get_max_excess_usage_ratio(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        get_reserve_interest_rate_strategy(asset).max_excess_usage_ratio
+    }
+
+    #[view]
+    public fun get_variable_rate_slope1(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        get_reserve_interest_rate_strategy(asset).variable_rate_slope1
+    }
+
+    #[view]
+    public fun get_variable_rate_slope2(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        get_reserve_interest_rate_strategy(asset).variable_rate_slope2
+    }
+
+    #[view]
+    public fun get_base_variable_borrow_rate(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        get_reserve_interest_rate_strategy(asset).base_variable_borrow_rate
+    }
+
+    #[view]
+    public fun get_max_variable_borrow_rate(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        let rate_data = get_reserve_interest_rate_strategy(asset);
+
+        rate_data.base_variable_borrow_rate + rate_data.variable_rate_slope1
+            + rate_data.variable_rate_slope2
+    }
+
+    #[view]
+    /// @notice Calculates the interest rates depending on the reserve's state and configurations
+    /// @param unbacked The amount of unbacked liquidity
+    /// @param liquidity_added The amount of liquidity added
+    /// @param liquidity_taken The amount of liquidity taken
+    /// @param total_variable_debt The total variable debt of the reserve
+    /// @param reserve_factor The reserve factor
+    /// @param reserve The address of the reserve
+    /// @param a_token_underlying_balance The underlying token balance corresponding to the aToken
+    /// @return current_liquidity_rate The liquidity rate expressed in rays
+    /// @return current_variable_borrow_rate The variable borrow rate expressed in rays
+    public fun calculate_interest_rates(
+        unbacked: u256,
+        liquidity_added: u256,
+        liquidity_taken: u256,
+        total_variable_debt: u256,
+        reserve_factor: u256,
+        reserve: address,
+        a_token_underlying_balance: u256
+    ): (u256, u256) acquires ReserveInterestRateStrategyMap {
+        let rate_data = get_reserve_interest_rate_strategy(reserve);
+        let vars = create_calc_interest_rates_local_vars();
+        vars.total_debt = total_variable_debt;
+        vars.current_liquidity_rate = 0;
+        vars.current_variable_borrow_rate = rate_data.base_variable_borrow_rate;
+        if (vars.total_debt != 0) {
+            vars.available_liquidity = a_token_underlying_balance + liquidity_added
+                - liquidity_taken;
+            vars.available_liquidity_plus_debt = vars.available_liquidity
+                + vars.total_debt;
+            vars.borrow_usage_ratio = wad_ray_math::ray_div(
+                vars.total_debt, vars.available_liquidity_plus_debt
+            );
+            vars.supply_usage_ratio = wad_ray_math::ray_div(
+                vars.total_debt,
+                (vars.available_liquidity_plus_debt + unbacked)
+            );
+        };
+
+        if (vars.borrow_usage_ratio > rate_data.optimal_usage_ratio) {
+            let excess_borrow_usage_ratio =
+                wad_ray_math::ray_div(
+                    (vars.borrow_usage_ratio - rate_data.optimal_usage_ratio),
+                    rate_data.max_excess_usage_ratio
+                );
+
+            vars.current_variable_borrow_rate = vars.current_variable_borrow_rate
+                + rate_data.variable_rate_slope1
+                + wad_ray_math::ray_mul(
+                    rate_data.variable_rate_slope2,
+                    excess_borrow_usage_ratio
+                );
+        } else {
+            vars.current_variable_borrow_rate = vars.current_variable_borrow_rate
+                + wad_ray_math::ray_div(
+                    wad_ray_math::ray_mul(
+                        rate_data.variable_rate_slope1, vars.borrow_usage_ratio
+                    ),
+                    rate_data.optimal_usage_ratio
+                );
+        };
+
+        vars.current_liquidity_rate = math_utils::percent_mul(
+            wad_ray_math::ray_mul(
+                get_overall_borrow_rate(
+                    total_variable_debt, vars.current_variable_borrow_rate
+                ),
+                vars.supply_usage_ratio
+            ),
+            (math_utils::get_percentage_factor() - reserve_factor)
+        );
+
+        return (vars.current_liquidity_rate, vars.current_variable_borrow_rate)
+    }
+
+    fun create_calc_interest_rates_local_vars(): CalcInterestRatesLocalVars {
+        CalcInterestRatesLocalVars {
+            available_liquidity: 0,
+            total_debt: 0,
+            current_variable_borrow_rate: 0,
+            current_liquidity_rate: 0,
+            borrow_usage_ratio: 0,
+            supply_usage_ratio: 0,
+            available_liquidity_plus_debt: 0
+        }
+    }
+
+    /// @dev Calculates the overall borrow rate as the weighted average between the total variable debt
+    /// @param total_variable_debt The total borrowed from the reserve at a variable rate
+    /// @param current_variable_borrow_rate The current variable borrow rate of the reserve
+    /// @return The weighted averaged borrow rate
+    fun get_overall_borrow_rate(
+        total_variable_debt: u256, current_variable_borrow_rate: u256
+    ): u256 {
+        let totalDebt = total_variable_debt;
+        if (totalDebt == 0) return 0;
+
+        let weighted_variable_rate =
+            wad_ray_math::ray_mul(
+                wad_to_ray(total_variable_debt),
+                current_variable_borrow_rate
+            );
+
+        let overall_borrow_rate =
+            wad_ray_math::ray_div((weighted_variable_rate), wad_to_ray(totalDebt));
+
+        overall_borrow_rate
+    }
+
+    fun only_risk_or_pool_admins(account: address): bool {
+        acl_manage::is_risk_admin(account) || acl_manage::is_pool_admin(account)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-rate/sources/gho_interest_rate_strategy.move
+++ b/tests/aptos-aave-v3/aave-core/aave-rate/sources/gho_interest_rate_strategy.move
@@ -1,0 +1,174 @@
+/// @title gho_interest_rate_strategy module
+/// @author Aave
+/// @notice Implements the calculation of GHO interest rates, which defines a fixed variable borrow rate.
+/// @dev The variable borrow interest rate is fixed at deployment time. The rest of parameters are zeroed.
+module aave_rate::gho_interest_rate_strategy {
+    use std::signer;
+    use aptos_std::smart_table;
+    use aptos_std::smart_table::SmartTable;
+    use aptos_framework::event;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+
+    /// the usage ratio at which the pool aims to obtain most competitive borrow rates.
+    const OPTIMAL_USAGE_RATIO: u256 = 0;
+
+    /// the excess usage ratio above the optimal.
+    const MAX_EXCESS_USAGE_RATIO: u256 = 0;
+
+    #[event]
+    struct ReserveInterestRateStrategy has store, drop {
+        asset: address,
+        optimal_usage_ratio: u256,
+        max_excess_usage_ratio: u256,
+        // Base variable borrow rate when usage rate = 0. Expressed in ray
+        base_variable_borrow_rate: u256,
+        // Slope of the variable interest curve when usage ratio > 0 and <= OPTIMAL_USAGE_RATIO. Expressed in ray
+        variable_rate_slope1: u256,
+        // Slope of the variable interest curve when usage ratio > OPTIMAL_USAGE_RATIO. Expressed in ray
+        variable_rate_slope2: u256
+    }
+
+    struct GHOReserveInterestRateStrategy has key, store, copy, drop {
+        // Base variable borrow rate when usage rate = 0. Expressed in ray
+        base_variable_borrow_rate: u256
+    }
+
+    // List of reserves as a map (underlying_asset => GHOReserveInterestRateStrategy)
+    struct ReserveInterestRateStrategyMap has key {
+        value: SmartTable<address, GHOReserveInterestRateStrategy>
+    }
+
+    /// @notice Initializes the interest rate strategy
+    /// @dev Only callable by the interest_rate_strategy module
+    /// @param account The account signer of the caller
+    public fun init_interest_rate_strategy(account: &signer) {
+        assert!(
+            signer::address_of(account) == @aave_rate,
+            error_config::get_enot_rate_owner()
+        );
+
+        move_to(
+            account,
+            ReserveInterestRateStrategyMap {
+                value: smart_table::new<address, GHOReserveInterestRateStrategy>()
+            }
+        );
+    }
+
+    /// @notice Sets the interest rate strategy of a reserve
+    /// @param account The account signer of the caller
+    /// @param asset The address of the reserve
+    /// @param base_variable_borrow_rate The base variable borrow rate
+    public entry fun set_reserve_interest_rate_strategy(
+        account: &signer, asset: address, base_variable_borrow_rate: u256
+    ) acquires ReserveInterestRateStrategyMap {
+        let account_address = signer::address_of(account);
+        assert!(
+            only_risk_or_pool_admins(account_address),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        let reserve_interest_rate_strategy = GHOReserveInterestRateStrategy {
+            base_variable_borrow_rate
+        };
+
+        let rate_strategy = borrow_global_mut<ReserveInterestRateStrategyMap>(@aave_rate);
+        smart_table::upsert(
+            &mut rate_strategy.value, asset, reserve_interest_rate_strategy
+        );
+
+        event::emit(
+            ReserveInterestRateStrategy {
+                asset,
+                optimal_usage_ratio: OPTIMAL_USAGE_RATIO,
+                max_excess_usage_ratio: MAX_EXCESS_USAGE_RATIO,
+                base_variable_borrow_rate,
+                variable_rate_slope1: 0,
+                variable_rate_slope2: 0
+            }
+        )
+    }
+
+    public fun asset_interest_rate_exists(asset: address) acquires ReserveInterestRateStrategyMap {
+        let rate_strategy = borrow_global<ReserveInterestRateStrategyMap>(@aave_rate);
+        assert!(
+            smart_table::contains(&rate_strategy.value, asset),
+            error_config::get_easset_not_listed()
+        );
+    }
+
+    #[view]
+    public fun get_reserve_interest_rate_strategy(
+        asset: address
+    ): GHOReserveInterestRateStrategy acquires ReserveInterestRateStrategyMap {
+        let rate_strategy_map = borrow_global<ReserveInterestRateStrategyMap>(@aave_rate);
+        if (!smart_table::contains(&rate_strategy_map.value, asset)) {
+            // If rate do not exist, return zero as default values, to be 1:1 with Solidity
+            return GHOReserveInterestRateStrategy { base_variable_borrow_rate: 0 }
+        };
+        *smart_table::borrow(&rate_strategy_map.value, asset)
+    }
+
+    #[view]
+    public fun get_optimal_usage_ratio(_asset: address): u256 {
+        OPTIMAL_USAGE_RATIO
+    }
+
+    #[view]
+    public fun get_max_excess_usage_ratio(_asset: address): u256 {
+        MAX_EXCESS_USAGE_RATIO
+    }
+
+    #[view]
+    public fun get_variable_rate_slope1(_asset: address): u256 {
+        0
+    }
+
+    #[view]
+    public fun get_variable_rate_slope2(_asset: address): u256 {
+        0
+    }
+
+    #[view]
+    public fun get_base_variable_borrow_rate(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        get_reserve_interest_rate_strategy(asset).base_variable_borrow_rate
+    }
+
+    #[view]
+    public fun get_max_variable_borrow_rate(
+        asset: address
+    ): u256 acquires ReserveInterestRateStrategyMap {
+        get_base_variable_borrow_rate(asset)
+    }
+
+    #[view]
+    /// @notice Calculates the interest rates depending on the reserve's state and configurations
+    /// @param _unbacked The amount of unbacked liquidity
+    /// @param _liquidity_added The amount of liquidity added
+    /// @param _liquidity_taken The amount of liquidity taken
+    /// @param _total_variable_debt The total variable debt of the reserve
+    /// @param _reserve_factor The reserve factor
+    /// @param reserve The address of the reserve
+    /// @param _a_token_underlying_balance The underlying token balance corresponding to the aToken
+    /// @return current_liquidity_rate The liquidity rate expressed in rays
+    /// @return current_variable_borrow_rate The variable borrow rate expressed in rays
+    public fun calculate_interest_rates(
+        _unbacked: u256,
+        _liquidity_added: u256,
+        _liquidity_taken: u256,
+        _total_variable_debt: u256,
+        _reserve_factor: u256,
+        reserve: address,
+        _a_token_underlying_balance: u256
+    ): (u256, u256) acquires ReserveInterestRateStrategyMap {
+        (0, get_base_variable_borrow_rate(reserve))
+    }
+
+    fun only_risk_or_pool_admins(account: address): bool {
+        acl_manage::is_risk_admin(account) || acl_manage::is_pool_admin(account)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-rate/sources/interest_rate_strategy.move
+++ b/tests/aptos-aave-v3/aave-core/aave-rate/sources/interest_rate_strategy.move
@@ -1,0 +1,92 @@
+/// @title interest_rate_strategy module
+/// @author Aave
+/// This module provides unified methods for managing asset interest rate strategies
+/// offering two main functions:
+/// 1. asset_interest_rate_exists to check if an interest rate strategy exists for a given asset
+/// 2. calculate_interest_rates to compute the interest rates.
+module aave_rate::interest_rate_strategy {
+    use std::signer;
+    use std::string::{String, utf8};
+
+    use aave_config::error_config;
+
+    use aave_rate::default_reserve_interest_rate_strategy;
+    use aave_rate::gho_interest_rate_strategy;
+
+    fun init_module(account: &signer) {
+        assert!(
+            signer::address_of(account) == @aave_rate,
+            error_config::get_enot_rate_owner()
+        );
+        default_reserve_interest_rate_strategy::init_interest_rate_strategy(account);
+        gho_interest_rate_strategy::init_interest_rate_strategy(account);
+    }
+
+    #[test_only]
+    public fun test_init_module(account: &signer) {
+        init_module(account)
+    }
+
+    /// @notice Checks if an interest rate strategy exists for a given asset
+    /// @param asset The address of the underlying asset
+    /// @param reserve_symbol The symbol of the reserve
+    /// @return true if the interest rate strategy exists, false otherwise
+    public fun asset_interest_rate_exists(
+        asset: address, reserve_symbol: String
+    ) {
+        if (reserve_symbol == utf8(b"GHO")) {
+            gho_interest_rate_strategy::asset_interest_rate_exists(asset)
+        } else {
+            default_reserve_interest_rate_strategy::asset_interest_rate_exists(asset)
+        }
+    }
+
+    /// @notice Calculates the interest rates depending on the reserve's state and configurations
+    /// @param unbacked The amount of unbacked liquidity
+    /// @param liquidity_added The amount of liquidity added
+    /// @param liquidity_taken The amount of liquidity taken
+    /// @param total_variable_debt The total variable debt of the reserve
+    /// @param reserve_factor The reserve factor
+    /// @param reserve The address of the reserve
+    /// @param reserve_symbol The symbol of the reserve
+    /// @param a_token_underlying_balance The underlying token balance corresponding to the aToken
+    /// @return current_liquidity_rate The liquidity rate expressed in rays
+    /// @return current_variable_borrow_rate The variable borrow rate expressed in rays
+    public fun calculate_interest_rates(
+        unbacked: u256,
+        liquidity_added: u256,
+        liquidity_taken: u256,
+        total_variable_debt: u256,
+        reserve_factor: u256,
+        reserve: address,
+        reserve_symbol: String,
+        a_token_underlying_balance: u256
+    ): (u256, u256) {
+        let next_liquidity_rate: u256;
+        let next_variable_rate: u256;
+
+        if (reserve_symbol == utf8(b"GHO")) {
+            (next_liquidity_rate, next_variable_rate) = gho_interest_rate_strategy::calculate_interest_rates(
+                unbacked,
+                liquidity_added,
+                liquidity_taken,
+                total_variable_debt,
+                reserve_factor,
+                reserve,
+                a_token_underlying_balance
+            )
+        } else {
+            (next_liquidity_rate, next_variable_rate) = default_reserve_interest_rate_strategy::calculate_interest_rates(
+                unbacked,
+                liquidity_added,
+                liquidity_taken,
+                total_variable_debt,
+                reserve_factor,
+                reserve,
+                a_token_underlying_balance
+            )
+        };
+
+        (next_liquidity_rate, next_variable_rate)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-rate/tests/default_reserve_interest_rate_strategy_tests.move
+++ b/tests/aptos-aave-v3/aave-core/aave-rate/tests/default_reserve_interest_rate_strategy_tests.move
@@ -1,0 +1,131 @@
+#[test_only]
+module aave_rate::default_reserve_interest_rate_strategy_tests {
+    use std::features::change_feature_flags_for_testing;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    use aave_acl::acl_manage::Self;
+    use aave_math::wad_ray_math::Self;
+
+    use aave_rate::default_reserve_interest_rate_strategy::{
+        get_base_variable_borrow_rate,
+        get_max_excess_usage_ratio,
+        get_max_variable_borrow_rate,
+        get_optimal_usage_ratio,
+        get_variable_rate_slope1,
+        get_variable_rate_slope2,
+        init_interest_rate_strategy,
+        set_reserve_interest_rate_strategy
+    };
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            pool = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1
+        )
+    ]
+    fun test_default_reserve_interest_rate_strategy(
+        pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_risk_admin(aave_role_super_admin, @aave_rate);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_rate);
+
+        // init the interest rate strategy module
+        init_interest_rate_strategy(pool);
+
+        // init the strategy
+        let asset_address = @0x42;
+        let optimal_usage_ratio: u256 = wad_ray_math::ray() / 4;
+        let base_variable_borrow_rate: u256 = 100;
+        let variable_rate_slope1: u256 = 200;
+        let variable_rate_slope2: u256 = 300;
+        let max_excess_usage_ratio = wad_ray_math::ray() - optimal_usage_ratio;
+        set_reserve_interest_rate_strategy(
+            pool,
+            asset_address,
+            optimal_usage_ratio,
+            base_variable_borrow_rate,
+            variable_rate_slope1,
+            variable_rate_slope2
+        );
+
+        // assertions on getters
+        assert!(
+            get_max_excess_usage_ratio(asset_address) == max_excess_usage_ratio,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_optimal_usage_ratio(asset_address) == optimal_usage_ratio,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_variable_rate_slope1(asset_address) == variable_rate_slope1,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_variable_rate_slope2(asset_address) == variable_rate_slope2,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_base_variable_borrow_rate(asset_address) == base_variable_borrow_rate,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_max_variable_borrow_rate(asset_address)
+                == base_variable_borrow_rate + variable_rate_slope1
+                    + variable_rate_slope2,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            pool = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1
+        )
+    ]
+    fun test_interest_rate_strategy_for_unset_asset(
+        pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_risk_admin(aave_role_super_admin, @aave_rate);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_rate);
+
+        // init the interest rate strategy module
+        init_interest_rate_strategy(pool);
+
+        // get strategy elements without having initialized the strategy
+        let asset_address = @0x42;
+        assert!(get_max_excess_usage_ratio(asset_address) == 0, TEST_SUCCESS);
+        assert!(get_optimal_usage_ratio(asset_address) == 0, TEST_SUCCESS);
+        assert!(get_variable_rate_slope1(asset_address) == 0, TEST_SUCCESS);
+        assert!(get_variable_rate_slope2(asset_address) == 0, TEST_SUCCESS);
+        assert!(get_base_variable_borrow_rate(asset_address) == 0, TEST_SUCCESS);
+        assert!(get_max_variable_borrow_rate(asset_address) == 0, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/Move.toml
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/Move.toml
@@ -1,0 +1,23 @@
+[package]
+name = "AaveScripts"
+version = "1.0.0"
+upgrade_policy = "compatible"
+authors = []
+
+[addresses]
+
+[dev-addresses]
+
+[dependencies]
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib", rev = "mainnet" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token-objects", rev = "mainnet" }
+AaveAcl = { local = "../aave-acl" }
+AaveConfig = { local = "../aave-config" }
+AaveRate = { local = "../aave-rate" }
+AaveOracle = { local = "../aave-oracle" }
+AaveData = { local = "../aave-data" }
+AavePool = { local = "../" }
+
+[dev-dependencies]

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_acl.move
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_acl.move
@@ -1,0 +1,115 @@
+script {
+    // std
+    use std::option::{Self, Option};
+    use std::signer;
+    use std::vector;
+    // locals
+    use aave_acl::acl_manage::Self;
+
+    fun main(
+        account: &signer,
+        pool_admins: vector<Option<address>>,
+        asset_listing_admins: vector<Option<address>>,
+        risk_admins: vector<Option<address>>,
+        fund_admins: vector<Option<address>>,
+        emergency_admins: vector<Option<address>>,
+        flash_borrower_admins: vector<Option<address>>,
+        bridge_admins: vector<Option<address>>,
+        emission_admins: vector<Option<address>>,
+        admin_controlled_ecosystem_reserve_funds_admins: vector<Option<address>>,
+        rewards_controller_admins: vector<Option<address>>
+    ) {
+        assert!(signer::address_of(account) == @aave_acl);
+
+        acl_manage::grant_default_admin_role(account);
+        vector::for_each(
+            pool_admins,
+            |admin| {
+                acl_manage::add_pool_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            asset_listing_admins,
+            |admin| {
+                acl_manage::add_asset_listing_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            risk_admins,
+            |admin| {
+                acl_manage::add_risk_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            fund_admins,
+            |admin| {
+                acl_manage::add_funds_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            emergency_admins,
+            |admin| {
+                acl_manage::add_emergency_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            flash_borrower_admins,
+            |admin| {
+                acl_manage::add_flash_borrower(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            bridge_admins,
+            |admin| {
+                acl_manage::add_bridge(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            emission_admins,
+            |admin| {
+                acl_manage::add_emission_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            admin_controlled_ecosystem_reserve_funds_admins,
+            |admin| {
+                acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+
+        vector::for_each(
+            rewards_controller_admins,
+            |admin| {
+                acl_manage::add_rewards_controller_admin(
+                    account, option::destroy_with_default(admin, @aave_pool)
+                );
+            }
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_interest_rates.move
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_interest_rates.move
@@ -1,0 +1,89 @@
+script {
+    // std
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::debug::print;
+    use aptos_std::smart_table;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+    // locals
+    use aave_rate::default_reserve_interest_rate_strategy::Self;
+    use aave_acl::acl_manage::Self;
+    use aave_config::error_config;
+
+    const APTOS_MAINNET: vector<u8> = b"mainnet";
+    const APTOS_TESTNET: vector<u8> = b"testnet";
+
+    fun main(account: &signer, network: String) {
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(account))
+                || acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+
+        // get all underlying assets
+        let underlying_assets_map =
+            if (network == utf8(APTOS_MAINNET)) {
+                aave_data::v1::get_underlying_assets_mainnet()
+            } else if (network == utf8(APTOS_TESTNET)) {
+                aave_data::v1::get_underlying_assets_testnet()
+            } else {
+                print(&b"Unknown network");
+                assert!(false, 1);
+            };
+
+        // fetch for each underlying asset the ir strategy config
+        for (i in 0..smart_table::length(underlying_assets_map)) {
+            let underlying_asset_name =
+                *vector::borrow(&smart_table::keys(underlying_assets_map), i);
+            let underlying_asset_address =
+                *smart_table::borrow(underlying_assets_map, underlying_asset_name);
+            let underlying_asset_metadata =
+                object::address_to_object<Metadata>(underlying_asset_address);
+            let underlying_asset_symbol =
+                fungible_asset::symbol(underlying_asset_metadata);
+
+            let interest_rate_strategy_map =
+                if (network == utf8(APTOS_MAINNET)) {
+                    smart_table::borrow(
+                        aave_data::v1::get_interest_rate_strategy_mainnet(),
+                        underlying_asset_symbol
+                    )
+                } else if (network == utf8(APTOS_TESTNET)) {
+                    smart_table::borrow(
+                        aave_data::v1::get_interest_rate_strategy_testnet(),
+                        underlying_asset_symbol
+                    )
+                } else {
+                    smart_table::borrow(
+                        aave_data::v1::get_interest_rate_strategy_testnet(),
+                        underlying_asset_symbol
+                    )
+                };
+
+            // init the default interest rate strategy for each underlying_asset_address
+            let optimal_usage_ratio =
+                aave_data::v1_values::get_optimal_usage_ratio(interest_rate_strategy_map);
+            let base_variable_borrow_rate =
+                aave_data::v1_values::get_base_variable_borrow_rate(
+                    interest_rate_strategy_map
+                );
+            let variable_rate_slope1 =
+                aave_data::v1_values::get_variable_rate_slope1(interest_rate_strategy_map);
+            let variable_rate_slope2: u256 =
+                aave_data::v1_values::get_variable_rate_slope2(interest_rate_strategy_map);
+
+            // set the default ir strategy per underlying asset
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                account,
+                underlying_asset_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+        };
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_price_feeds.move
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_price_feeds.move
@@ -1,0 +1,79 @@
+script {
+    // std
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::debug::print;
+    use aptos_std::smart_table;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+    // locals
+    use aave_acl::acl_manage::Self;
+    use aave_config::error_config;
+    use aave_oracle::oracle::Self;
+    use aave_pool::pool;
+
+    const APTOS_MAINNET: vector<u8> = b"mainnet";
+    const APTOS_TESTNET: vector<u8> = b"testnet";
+
+    fun main(account: &signer, network: String) {
+        assert!(
+            acl_manage::is_risk_admin(signer::address_of(account))
+                || acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+
+        // get all underlying assets
+        let underlying_assets_map =
+            if (network == utf8(APTOS_MAINNET)) {
+                aave_data::v1::get_underlying_assets_mainnet()
+            } else if (network == utf8(APTOS_TESTNET)) {
+                aave_data::v1::get_underlying_assets_testnet()
+            } else {
+                print(&b"Unknown network");
+                assert!(false, 1);
+            };
+
+        // set feed ids for underlying assets, atokens and vartokens
+        for (i in 0..smart_table::length(underlying_assets_map)) {
+            // get all underlying data
+            let underlying_asset_name =
+                *vector::borrow(&smart_table::keys(underlying_assets_map), i);
+            let underlying_asset_address =
+                *smart_table::borrow(underlying_assets_map, underlying_asset_name);
+            let underlying_asset_metadata =
+                object::address_to_object<Metadata>(underlying_asset_address);
+            let underlying_asset_symbol =
+                fungible_asset::symbol(underlying_asset_metadata);
+            let reserve_data = pool::get_reserve_data(underlying_asset_address);
+
+            let price_feed =
+                if (network == utf8(APTOS_MAINNET)) {
+                    smart_table::borrow(
+                        aave_data::v1::get_price_feeds_mainnet(),
+                        underlying_asset_symbol
+                    )
+                } else if (network == utf8(APTOS_TESTNET)) {
+                    smart_table::borrow(
+                        aave_data::v1::get_price_feeds_tesnet(),
+                        underlying_asset_symbol
+                    )
+                } else {
+                    smart_table::borrow(
+                        aave_data::v1::get_price_feeds_tesnet(),
+                        underlying_asset_symbol
+                    )
+                };
+            oracle::set_asset_feed_id(account, underlying_asset_address, *price_feed);
+            oracle::set_asset_feed_id(
+                account, pool::get_reserve_a_token_address(&reserve_data), *price_feed
+            );
+            oracle::set_asset_feed_id(
+                account,
+                pool::get_reserve_variable_debt_token_address(&reserve_data),
+                *price_feed
+            );
+        };
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_reserves.move
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/sources/configure_reserves.move
@@ -1,0 +1,134 @@
+script {
+    // std
+    use std::option;
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::debug::print;
+    use aptos_std::smart_table;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+    // locals
+    use aave_config::reserve_config;
+    use aave_acl::acl_manage::Self;
+    use aave_config::error_config;
+
+    const APTOS_MAINNET: vector<u8> = b"mainnet";
+    const APTOS_TESTNET: vector<u8> = b"testnet";
+
+    fun main(account: &signer, network: String) {
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(account))
+                || acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+
+        // get all underlying assets
+        let underlying_assets_map =
+            if (network == utf8(APTOS_MAINNET)) {
+                aave_data::v1::get_underlying_assets_mainnet()
+            } else if (network == utf8(APTOS_TESTNET)) {
+                aave_data::v1::get_underlying_assets_testnet()
+            } else {
+                print(&b"Unknown network");
+                assert!(false, 1);
+            };
+
+        // assemble each reserve's configuration
+        for (i in 0..smart_table::length(underlying_assets_map)) {
+            // get all underlying data
+            let underlying_asset_name =
+                *vector::borrow(&smart_table::keys(underlying_assets_map), i);
+            let underlying_asset_address =
+                *smart_table::borrow(underlying_assets_map, underlying_asset_name);
+            let underlying_asset_metadata =
+                object::address_to_object<Metadata>(underlying_asset_address);
+            let underlying_asset_symbol =
+                fungible_asset::symbol(underlying_asset_metadata);
+            let underlying_asset_decimals =
+                fungible_asset::decimals(underlying_asset_metadata);
+
+            let reserve_config =
+                if (network == utf8(APTOS_MAINNET)) {
+                    smart_table::borrow(
+                        aave_data::v1::get_reserves_config_mainnet(),
+                        underlying_asset_symbol
+                    )
+                } else if (network == utf8(APTOS_TESTNET)) {
+                    smart_table::borrow(
+                        aave_data::v1::get_reserves_config_testnet(),
+                        underlying_asset_symbol
+                    )
+                } else {
+                    smart_table::borrow(
+                        aave_data::v1::get_reserves_config_testnet(),
+                        underlying_asset_symbol
+                    )
+                };
+            let debt_ceiling = aave_data::v1_values::get_debt_ceiling(reserve_config);
+            let flashLoan_enabled =
+                aave_data::v1_values::get_flashLoan_enabled(reserve_config);
+            let borrowable_isolation =
+                aave_data::v1_values::get_borrowable_isolation(reserve_config);
+            let supply_cap = aave_data::v1_values::get_supply_cap(reserve_config);
+            let borrow_cap = aave_data::v1_values::get_borrow_cap(reserve_config);
+            let ltv = aave_data::v1_values::get_base_ltv_as_collateral(reserve_config);
+            let borrowing_enabled =
+                aave_data::v1_values::get_borrowing_enabled(reserve_config);
+            let reserve_factor = aave_data::v1_values::get_reserve_factor(reserve_config);
+            let liquidation_threshold =
+                aave_data::v1_values::get_liquidation_threshold(reserve_config);
+            let liquidation_bonus =
+                aave_data::v1_values::get_liquidation_bonus(reserve_config);
+            let liquidation_protocol_fee =
+                aave_data::v1_values::get_liquidation_protocol_fee(reserve_config);
+            let siloed_borrowing =
+                aave_data::v1_values::get_siloed_borrowing(reserve_config);
+
+            let reserve_config_new = reserve_config::init();
+            reserve_config::set_decimals(
+                &mut reserve_config_new, (underlying_asset_decimals as u256)
+            );
+            reserve_config::set_liquidation_threshold(
+                &mut reserve_config_new, liquidation_threshold
+            );
+            reserve_config::set_liquidation_bonus(
+                &mut reserve_config_new, liquidation_bonus
+            );
+            reserve_config::set_liquidation_protocol_fee(
+                &mut reserve_config_new, liquidation_protocol_fee
+            );
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_reserve_factor(&mut reserve_config_new, reserve_factor);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_flash_loan_enabled(
+                &mut reserve_config_new, flashLoan_enabled
+            );
+            reserve_config::set_ltv(&mut reserve_config_new, ltv);
+            reserve_config::set_debt_ceiling(&mut reserve_config_new, debt_ceiling);
+            reserve_config::set_supply_cap(&mut reserve_config_new, supply_cap);
+            reserve_config::set_borrow_cap(&mut reserve_config_new, borrow_cap);
+            reserve_config::set_borrowable_in_isolation(
+                &mut reserve_config_new, borrowable_isolation
+            );
+            reserve_config::set_siloed_borrowing(
+                &mut reserve_config_new, siloed_borrowing
+            );
+            reserve_config::set_borrowing_enabled(
+                &mut reserve_config_new, borrowing_enabled
+            );
+            let emode_category = aave_data::v1_values::get_emode_category(reserve_config);
+            if (option::is_some(&emode_category)) {
+                reserve_config::set_emode_category(
+                    &mut reserve_config_new, *option::borrow(&emode_category)
+                )
+            };
+            // attach the config to the reserve
+            aave_pool::pool::set_reserve_configuration_with_guard(
+                account, underlying_asset_address, reserve_config_new
+            );
+        };
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/sources/create_emodes.move
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/sources/create_emodes.move
@@ -1,0 +1,62 @@
+script {
+    // std
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::debug::print;
+    use aptos_std::smart_table;
+    // locals
+    use aave_pool::pool_configurator;
+    use aave_acl::acl_manage::Self;
+    use aave_config::error_config;
+    use aave_oracle::oracle_base;
+
+    const APTOS_MAINNET: vector<u8> = b"mainnet";
+    const APTOS_TESTNET: vector<u8> = b"testnet";
+
+    fun main(account: &signer, network: String) {
+        assert!(
+            acl_manage::is_risk_admin(signer::address_of(account))
+                || acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+
+        // get all underlying assets
+        let emodes_map =
+            if (network == utf8(APTOS_MAINNET)) {
+                aave_data::v1::get_emodes_mainnet()
+            } else if (network == utf8(APTOS_TESTNET)) {
+                aave_data::v1::get_emodes_testnet()
+            } else {
+                print(&b"Unknown network");
+                assert!(false, 1);
+            };
+
+        for (i in 0..smart_table::length(emodes_map)) {
+            let emode_category_id = *vector::borrow(&smart_table::keys(emodes_map), i);
+            let emode_config = *smart_table::borrow(emodes_map, emode_category_id);
+
+            let emode_category_id =
+                aave_data::v1_values::get_emode_category_id(&emode_config);
+            let emode_liquidation_label =
+                aave_data::v1_values::get_emode_liquidation_label(&emode_config);
+            let emode_liquidation_threshold =
+                aave_data::v1_values::get_emode_liquidation_threshold(&emode_config);
+            let emode_liquidation_bonus =
+                aave_data::v1_values::get_emode_liquidation_bonus(&emode_config);
+            let emode_ltv = aave_data::v1_values::get_emode_ltv(&emode_config);
+
+            // create the emode
+            pool_configurator::set_emode_category(
+                account,
+                (emode_category_id as u8),
+                (emode_ltv as u16),
+                (emode_liquidation_threshold as u16),
+                (emode_liquidation_bonus as u16),
+                oracle_base::oracle_address(),
+                emode_liquidation_label
+            );
+        };
+
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/aave-scripts/sources/create_reserves.move
+++ b/tests/aptos-aave-v3/aave-core/aave-scripts/sources/create_reserves.move
@@ -1,0 +1,94 @@
+script {
+    // std
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::debug::print;
+    use aptos_std::smart_table;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+    // locals
+    use aave_pool::collector;
+    use aave_pool::pool_configurator;
+    use aave_acl::acl_manage::Self;
+    use aave_config::error_config;
+
+    const APTOS_MAINNET: vector<u8> = b"mainnet";
+    const APTOS_TESTNET: vector<u8> = b"testnet";
+
+    fun main(account: &signer, network: String) {
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(account))
+                || acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+
+        // get all underlying assets
+        let underlying_assets_map =
+            if (network == utf8(APTOS_MAINNET)) {
+                aave_data::v1::get_underlying_assets_mainnet()
+            } else if (network == utf8(APTOS_TESTNET)) {
+                aave_data::v1::get_underlying_assets_testnet()
+            } else {
+                print(&b"Unknown network");
+                assert!(false, 1);
+            };
+
+        // prepare pool reserves
+        let treasuries: vector<address> = vector[];
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let collector_address = collector::collector_address();
+
+        for (i in 0..smart_table::length(underlying_assets_map)) {
+            // get underlying asset data
+            let underlying_asset_name =
+                *vector::borrow(&smart_table::keys(underlying_assets_map), i);
+            let underlying_asset_address =
+                *smart_table::borrow(underlying_assets_map, underlying_asset_name);
+            let underlying_asset_metadata =
+                object::address_to_object<Metadata>(underlying_asset_address);
+            let underlying_asset_symbol =
+                fungible_asset::symbol(underlying_asset_metadata);
+
+            // prepare the data for reserves' atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_asset_address);
+            vector::push_back(
+                &mut underlying_asset_decimals,
+                fungible_asset::decimals(underlying_asset_metadata)
+            );
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names,
+                aave_data::v1::get_atoken_name(underlying_asset_symbol)
+            );
+            vector::push_back(
+                &mut atokens_symbols,
+                aave_data::v1::get_atoken_symbol(underlying_asset_symbol)
+            );
+            vector::push_back(
+                &mut var_tokens_names,
+                aave_data::v1::get_vartoken_name(underlying_asset_symbol)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols,
+                aave_data::v1::get_vartoken_symbol(underlying_asset_symbol)
+            );
+        };
+        // create pool reserves in one go
+        pool_configurator::init_reserves(
+            account,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/borrow_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/borrow_logic.move
@@ -1,0 +1,443 @@
+/// @title borrow_logic module
+/// @author Aave
+/// @notice Implements the base logic for all the actions related to borrowing
+module aave_pool::borrow_logic {
+    use std::signer;
+    use aptos_framework::event;
+
+    use aave_config::error_config;
+    use aave_config::reserve_config;
+    use aave_config::user_config;
+    use aave_math::math_utils;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::emode_logic;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::isolation_mode_logic;
+    use aave_pool::pool;
+    use aave_pool::validation_logic;
+    use aave_pool::variable_debt_token_factory;
+
+    friend aave_pool::flashloan_logic;
+
+    #[event]
+    /// @dev Emitted on borrow() and flash_loan() when debt needs to be opened
+    /// @param reserve The address of the underlying asset being borrowed
+    /// @param user The address of the user initiating the borrow(), receiving the funds on borrow() or just
+    ///  initiator of the transaction on flash_loan()
+    /// @param on_behalf_of The address that will be getting the debt
+    /// @param amount The amount borrowed out
+    /// @param interest_rate_mode The rate mode: 2 for Variable
+    /// @param borrow_rate The numeric rate at which the user has borrowed, expressed in ray
+    /// @param referral_code The referral code used
+    struct Borrow has store, copy, drop {
+        reserve: address,
+        user: address,
+        on_behalf_of: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        borrow_rate: u256,
+        referral_code: u16
+    }
+
+    #[event]
+    /// @dev Emitted on repay()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The beneficiary of the repayment, getting his debt reduced
+    /// @param repayer The address of the user initiating the repay(), providing the funds
+    /// @param amount The amount repaid
+    /// @param use_a_tokens True if the repayment is done using aTokens, `false` if done with underlying asset directly
+    struct Repay has store, drop {
+        reserve: address,
+        user: address,
+        repayer: address,
+        amount: u256,
+        use_a_tokens: bool
+    }
+
+    #[event]
+    /// @dev Emitted on borrow(), repay() and liquidation_call() when using isolated assets
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param totalDebt The total isolation mode debt for the reserve
+    struct IsolationModeTotalDebtUpdated has store, drop {
+        asset: address,
+        total_debt: u256
+    }
+
+    /// @notice Allows users to borrow a specific `amount` of the reserve underlying asset, provided that the borrower
+    /// already supplied enough collateral
+    /// - E.g. User borrows 100 USDC passing as `on_behalf_of` his own address, receiving the 100 USDC in his wallet
+    /// and 100 variable debt tokens, depending on the `interest_rate_mode`
+    /// @dev  Emits the `Borrow()` event
+    /// @param account The signer account of the caller
+    /// @param asset The address of the underlying asset to borrow
+    /// @param amount The amount to be borrowed
+    /// @param interest_rate_mode The interest rate mode at which the user wants to borrow: 2 for Variable
+    /// @param referral_code The code used to register the integrator originating the operation, for potential rewards.
+    /// 0 if the action is executed directly by the user, without any middle-man
+    /// @param on_behalf_of The address of the user who will receive the debt. Should be the address of the borrower itself
+    public entry fun borrow(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        referral_code: u16,
+        on_behalf_of: address
+    ) {
+        internal_borrow(
+            signer::address_of(account),
+            asset,
+            amount,
+            interest_rate_mode,
+            referral_code,
+            on_behalf_of,
+            true
+        );
+    }
+
+    /// @notice Implements the borrow feature. Borrowing allows users that provided collateral to draw liquidity from the
+    /// Aave protocol proportionally to their collateralization power. For isolated positions, it also increases the
+    /// isolated debt.
+    /// @dev Only callable by the borrow_logic and flashloan_logic module
+    /// @dev  Emits the `Borrow()` event
+    /// @param user The address of the caller
+    /// @param asset The address of the underlying asset to borrow
+    /// @param amount The amount to be borrowed
+    /// @param interest_rate_mode The interest rate mode at which the user wants to borrow: 2 for Variable
+    /// @param referral_code The code used to register the integrator originating the operation, for potential rewards.
+    /// 0 if the action is executed directly by the user, without any middle
+    /// @param on_behalf_of The address of the user who will receive the debt. Should be the address of the borrower itself
+    /// @param release_underlying If true, the underlying asset will be transferred to the user, otherwise it will stay
+    public(friend) fun internal_borrow(
+        user: address,
+        asset: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        referral_code: u16,
+        on_behalf_of: address,
+        release_underlying: bool
+    ) {
+        assert!(
+            user == on_behalf_of, error_config::get_esigner_and_on_behalf_of_no_same()
+        );
+
+        let (reserve_data, reserves_count) =
+            pool::get_reserve_data_and_reserves_count(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        // update pool state
+        pool::update_state(asset, &mut reserve_data, &mut reserve_cache);
+
+        let user_config_map = pool::get_user_configuration(on_behalf_of);
+        let (
+            isolation_mode_active,
+            isolation_mode_collateral_address,
+            isolation_mode_debt_ceiling
+        ) = pool::get_isolation_mode_state(&user_config_map);
+
+        let user_emode_category = (emode_logic::get_user_emode(on_behalf_of) as u8);
+        let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+            emode_logic::get_emode_configuration(user_emode_category);
+
+        let emode_category_data =
+            emode_logic::get_emode_category_data(user_emode_category);
+        let emode_price_source =
+            emode_logic::get_emode_category_price_source(&emode_category_data);
+        // validate borrow
+        validation_logic::validate_borrow(
+            &reserve_cache,
+            &user_config_map,
+            asset,
+            on_behalf_of,
+            amount,
+            interest_rate_mode,
+            reserves_count,
+            user_emode_category,
+            emode_ltv,
+            emode_liq_threshold,
+            emode_asset_price,
+            emode_price_source,
+            isolation_mode_active,
+            isolation_mode_collateral_address,
+            isolation_mode_debt_ceiling
+        );
+
+        let variable_debt_token_address =
+            pool::get_variable_debt_token_address(&reserve_cache);
+        let is_first_borrowing =
+            variable_debt_token_factory::scaled_balance_of(
+                on_behalf_of, variable_debt_token_address
+            ) == 0;
+
+        variable_debt_token_factory::mint(
+            user,
+            on_behalf_of,
+            amount,
+            pool::get_next_variable_borrow_index(&reserve_cache),
+            variable_debt_token_address
+        );
+
+        let next_scaled_variable_debt =
+            variable_debt_token_factory::scaled_total_supply(variable_debt_token_address);
+        // update reserve cache next_scaled_variable_debt
+        pool::set_next_scaled_variable_debt(
+            &mut reserve_cache, next_scaled_variable_debt
+        );
+
+        if (is_first_borrowing) {
+            let reserve_id = pool::get_reserve_id(&reserve_data);
+            user_config::set_borrowing(&mut user_config_map, (reserve_id as u256), true);
+            pool::set_user_configuration(on_behalf_of, user_config_map);
+        };
+
+        if (isolation_mode_active) {
+            let isolation_mode_collateral_reserve_data =
+                pool::get_reserve_data(isolation_mode_collateral_address);
+            let isolation_mode_total_debt =
+                pool::get_reserve_isolation_mode_total_debt(
+                    &isolation_mode_collateral_reserve_data
+                );
+            let reserve_configuration_map =
+                pool::get_reserve_cache_configuration(&reserve_cache);
+            let decimals =
+                reserve_config::get_decimals(&reserve_configuration_map)
+                    - reserve_config::get_debt_ceiling_decimals();
+
+            let next_isolation_mode_total_debt =
+                (isolation_mode_total_debt as u256)
+                    + (amount / math_utils::pow(10, decimals));
+            // update isolation_mode_total_debt
+            pool::set_reserve_isolation_mode_total_debt(
+                isolation_mode_collateral_address,
+                &mut isolation_mode_collateral_reserve_data,
+                (next_isolation_mode_total_debt as u128)
+            );
+
+            event::emit(
+                IsolationModeTotalDebtUpdated {
+                    asset: isolation_mode_collateral_address,
+                    total_debt: next_isolation_mode_total_debt
+                }
+            );
+        };
+
+        // update pool interest rate
+        let liquidity_taken = if (release_underlying) { amount }
+        else { 0 };
+        pool::update_interest_rates(
+            &mut reserve_data,
+            &reserve_cache,
+            asset,
+            0,
+            liquidity_taken
+        );
+
+        if (release_underlying) {
+            a_token_factory::transfer_underlying_to(
+                user,
+                amount,
+                pool::get_a_token_address(&reserve_cache)
+            );
+        };
+
+        // Emit a borrow event
+        event::emit(
+            Borrow {
+                reserve: asset,
+                user,
+                on_behalf_of,
+                amount,
+                interest_rate_mode,
+                borrow_rate: (
+                    pool::get_reserve_current_variable_borrow_rate(&reserve_data) as u256
+                ),
+                referral_code
+            }
+        );
+    }
+
+    /// @notice Repays a borrowed `amount` on a specific reserve, burning the equivalent debt tokens owned
+    /// - E.g. User repays 100 USDC, burning 100 variable debt tokens of the `on_behalf_of` address
+    /// @param account The signer account of the caller
+    /// @param asset The address of the borrowed underlying asset previously borrowed
+    /// @param amount The amount to repay
+    /// - Send the value math_utils::u256_max() in order to repay the whole debt for `asset` on the specific `interest_rate_mode`
+    /// @param interest_rate_mode The interest rate mode at of the debt the user wants to repay: 2 for Variable
+    /// @param on_behalf_of The address of the user who will get his debt reduced/removed. Should be the address of the
+    /// user calling the function if he wants to reduce/remove his own debt, or the address of any other
+    /// other borrower whose debt should be removed
+    public entry fun repay(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        on_behalf_of: address
+    ) {
+        internal_repay(
+            account,
+            asset,
+            amount,
+            interest_rate_mode,
+            on_behalf_of,
+            false
+        )
+    }
+
+    /// @notice Implements the repay feature. Repaying transfers the underlying back to the aToken and clears the
+    /// equivalent amount of debt for the user by burning the corresponding debt token. For isolated positions, it also
+    /// reduces the isolated debt.
+    /// @dev  Emits the `Repay()` event
+    /// @param account The signer account of the caller
+    /// @param asset The address of the underlying asset to repay
+    /// @param amount The amount to be repaid. Can be `math_utils::u256_max()` to repay the whole debt
+    /// @param interest_rate_mode The interest rate mode at which the user wants to repay: 2 for Variable
+    /// @param on_behalf_of The address of the user who will repay the debt. Should be the address of the borrower itself
+    /// calling the function if he wants to repay his own debt, or the address of the credit delegator
+    /// if he wants to repay the debt of a borrower to whom he has given credit delegation allowance
+    /// @param use_a_tokens If true, the user wants to repay using aTokens, otherwise he wants to repay using the underlying
+    fun internal_repay(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        on_behalf_of: address,
+        use_a_tokens: bool
+    ) {
+        let account_address = signer::address_of(account);
+        let reserve_data = pool::get_reserve_data(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        // update pool state
+        pool::update_state(asset, &mut reserve_data, &mut reserve_cache);
+
+        let variable_debt_token_address =
+            pool::get_variable_debt_token_address(&reserve_cache);
+        let variable_debt =
+            pool::variable_debt_token_balance_of(
+                on_behalf_of, variable_debt_token_address
+            );
+
+        // validate repay
+        validation_logic::validate_repay(
+            account_address,
+            &reserve_cache,
+            amount,
+            interest_rate_mode,
+            on_behalf_of,
+            variable_debt
+        );
+
+        let payback_amount = variable_debt;
+        // Allows a user to repay with aTokens without leaving dust from interest.
+        let a_token_address = pool::get_a_token_address(&reserve_cache);
+        if (use_a_tokens && amount == math_utils::u256_max()) {
+            amount = pool::a_token_balance_of(account_address, a_token_address)
+        };
+
+        if (amount < payback_amount) {
+            payback_amount = amount;
+        };
+
+        variable_debt_token_factory::burn(
+            on_behalf_of,
+            payback_amount,
+            pool::get_next_variable_borrow_index(&reserve_cache),
+            variable_debt_token_address
+        );
+        // update reserve cache next_scaled_variable_debt
+        let next_scaled_variable_debt =
+            variable_debt_token_factory::scaled_total_supply(variable_debt_token_address);
+        pool::set_next_scaled_variable_debt(
+            &mut reserve_cache, next_scaled_variable_debt
+        );
+
+        // update pool interest rate
+        let liquidity_added = if (use_a_tokens) { 0 }
+        else {
+            payback_amount
+        };
+        pool::update_interest_rates(
+            &mut reserve_data,
+            &reserve_cache,
+            asset,
+            liquidity_added,
+            0
+        );
+
+        let user_config_map = pool::get_user_configuration(on_behalf_of);
+        if (variable_debt - payback_amount == 0) {
+            user_config::set_borrowing(
+                &mut user_config_map,
+                (pool::get_reserve_id(&reserve_data) as u256),
+                false
+            );
+            pool::set_user_configuration(on_behalf_of, user_config_map);
+        };
+
+        // update reserve_data.isolation_mode_total_debt field
+        isolation_mode_logic::update_isolated_debt_if_isolated(
+            &user_config_map,
+            &reserve_cache,
+            payback_amount
+        );
+
+        // If you choose to repay with AToken, burn Atoken
+        if (use_a_tokens) {
+            a_token_factory::burn(
+                account_address,
+                a_token_factory::get_token_account_address(a_token_address),
+                payback_amount,
+                pool::get_next_liquidity_index(&reserve_cache),
+                a_token_address
+            );
+        } else {
+            fungible_asset_manager::transfer(
+                account,
+                a_token_factory::get_token_account_address(a_token_address),
+                (payback_amount as u64),
+                asset
+            );
+            a_token_factory::handle_repayment(
+                account_address,
+                on_behalf_of,
+                payback_amount,
+                a_token_address
+            );
+        };
+
+        // Emit a Repay event
+        event::emit(
+            Repay {
+                reserve: asset,
+                user: on_behalf_of,
+                repayer: account_address,
+                amount: payback_amount,
+                use_a_tokens
+            }
+        );
+    }
+
+    /// @notice Repays a borrowed `amount` on a specific reserve using the reserve aTokens, burning the
+    /// equivalent debt tokens
+    /// - E.g. User repays 100 USDC using 100 aUSDC, burning 100 variable debt tokens
+    /// @dev  Passing math_utils::u256_max() as amount will clean up any residual aToken dust balance, if the user aToken
+    /// balance is not enough to cover the whole debt
+    /// @param account The signer account of the caller
+    /// @param asset The address of the borrowed underlying asset previously borrowed
+    /// @param amount The amount to repay
+    /// @param interest_rate_mode The interest rate mode at of the debt the user wants to repay: 2 for Variable
+    public entry fun repay_with_a_tokens(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        interest_rate_mode: u8
+    ) {
+        let account_address = signer::address_of(account);
+        internal_repay(
+            account,
+            asset,
+            amount,
+            interest_rate_mode,
+            account_address,
+            true
+        )
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/bridge_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/bridge_logic.move
@@ -1,0 +1,231 @@
+module aave_pool::bridge_logic {
+    use std::signer;
+    use aptos_framework::event;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_config::reserve_config;
+    use aave_config::user_config;
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::pool::Self;
+    use aave_pool::validation_logic;
+
+    #[event]
+    /// @dev Emitted on mint_unbacked()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address of the user enabling the usage as collateral
+    struct ReserveUsedAsCollateralEnabled has store, drop {
+        reserve: address,
+        user: address
+    }
+
+    #[event]
+    /// @dev Emitted on mint_unbacked()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address initiating the supply
+    /// @param on_behalf_of The beneficiary of the supplied assets, receiving the aTokens
+    /// @param amount The amount of supplied assets
+    /// @param referral_code The referral code used
+    struct MintUnbacked has store, drop {
+        reserve: address,
+        user: address,
+        on_behalf_of: address,
+        amount: u256,
+        referral_code: u16
+    }
+
+    #[event]
+    /// @dev Emitted on back_unbacked()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param backer The address paying for the backing
+    /// @param amount The amount added as backing
+    /// @param fee The amount paid in fees
+    struct BackUnbacked has store, drop {
+        reserve: address,
+        backer: address,
+        amount: u256,
+        fee: u256
+    }
+
+    /// @notice Mint unbacked aTokens to a user and updates the unbacked for the reserve.
+    /// @dev Essentially a supply without transferring the underlying.
+    /// @dev Emits the `MintUnbacked` event
+    /// @dev Emits the `ReserveUsedAsCollateralEnabled` if asset is set as collateral
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset to mint aTokens of
+    /// @param amount The amount to mint
+    /// @param on_behalf_of The address that will receive the aTokens
+    /// @param referral_code Code used to register the integrator originating the operation, for potential rewards.
+    /// 0 if the action is executed directly by the user, without any middle-man
+    public entry fun mint_unbacked(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        on_behalf_of: address,
+        referral_code: u16
+    ) {
+        let account_address = signer::address_of(account);
+        assert!(only_bridge(account_address), error_config::get_ecaller_not_bridge());
+        let reserve_data = pool::get_reserve_data(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        // update pool state
+        pool::update_state(asset, &mut reserve_data, &mut reserve_cache);
+
+        // validate supply
+        validation_logic::validate_supply(&reserve_cache, &reserve_data, amount);
+
+        // validate unbacked mint cap
+        let reserve_config_map = pool::get_reserve_cache_configuration(&reserve_cache);
+        let unbacked_mint_cap =
+            reserve_config::get_unbacked_mint_cap(&reserve_config_map);
+        let reserve_decimals = reserve_config::get_decimals(&reserve_config_map);
+        let unbacked = (pool::get_reserve_unbacked(&reserve_data) as u256) + amount;
+        // update pool unbacked
+        pool::set_reserve_unbacked(asset, &mut reserve_data, (unbacked as u128));
+
+        assert!(
+            unbacked <= unbacked_mint_cap * (math_utils::pow(10, reserve_decimals)),
+            error_config::get_eunbacked_mint_cap_exceeded()
+        );
+        // update pool interest rates
+        pool::update_interest_rates(&mut reserve_data, &reserve_cache, asset, 0, 0);
+
+        let token_a_address = pool::get_a_token_address(&reserve_cache);
+        let is_first_supply =
+            a_token_factory::scaled_balance_of(on_behalf_of, token_a_address) == 0;
+        a_token_factory::mint(
+            account_address,
+            on_behalf_of,
+            amount,
+            pool::get_next_liquidity_index(&reserve_cache),
+            token_a_address
+        );
+
+        if (is_first_supply) {
+            let user_config_map = pool::get_user_configuration(on_behalf_of);
+            if (validation_logic::validate_automatic_use_as_collateral(
+                account_address,
+                &user_config_map,
+                &reserve_config_map
+            )) {
+                let reserve_id = pool::get_reserve_id(&reserve_data);
+                user_config::set_using_as_collateral(
+                    &mut user_config_map, (reserve_id as u256), true
+                );
+                pool::set_user_configuration(on_behalf_of, user_config_map);
+
+                event::emit(
+                    ReserveUsedAsCollateralEnabled { reserve: asset, user: on_behalf_of }
+                );
+            }
+        };
+
+        event::emit(
+            MintUnbacked {
+                reserve: asset,
+                user: account_address,
+                on_behalf_of,
+                amount,
+                referral_code
+            }
+        );
+    }
+
+    /// @notice Back the current unbacked with `amount` and pay `fee`.
+    /// @dev It is not possible to back more than the existing unbacked amount of the reserve
+    /// @dev Emits the `BackUnbacked` event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset to repay
+    /// @param amount The amount to back
+    /// @param fee The amount paid in fees
+    /// @return The backed amount
+    public entry fun back_unbacked(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        fee: u256
+    ) {
+        let account_address = signer::address_of(account);
+        assert!(only_bridge(account_address), error_config::get_ecaller_not_bridge());
+
+        let reserve_data = pool::get_reserve_data(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        // update pool state
+        pool::update_state(asset, &mut reserve_data, &mut reserve_cache);
+
+        let unbacked = (pool::get_reserve_unbacked(&reserve_data) as u256);
+        let backing_amount = if (amount < unbacked) { amount }
+        else {
+            unbacked
+        };
+
+        let protocol_fee_bps = pool::get_bridge_protocol_fee();
+        let fee_to_protocol = math_utils::percent_mul(fee, protocol_fee_bps);
+        let fee_to_lp = fee - fee_to_protocol;
+        let added = backing_amount + fee;
+
+        let a_token_address = pool::get_a_token_address(&reserve_cache);
+        let accrued_to_treasury = pool::get_reserve_accrued_to_treasury(&reserve_data);
+        let total_liquidity =
+            pool::a_token_total_supply(a_token_address)
+                + wad_ray_math::ray_mul(
+                    accrued_to_treasury,
+                    pool::get_next_liquidity_index(&reserve_cache)
+                );
+        let next_liquidity_index =
+            pool::cumulate_to_liquidity_index(
+                asset,
+                &mut reserve_data,
+                total_liquidity,
+                fee_to_lp
+            );
+        // update reserve cache next liquidity index
+        pool::set_next_liquidity_index(&mut reserve_cache, next_liquidity_index);
+
+        let new_accrued_to_treasury =
+            accrued_to_treasury
+                + wad_ray_math::ray_div(fee_to_protocol, next_liquidity_index);
+
+        // update pool accrue to treasury
+        pool::set_reserve_accrued_to_treasury(
+            asset, &mut reserve_data, new_accrued_to_treasury
+        );
+
+        // update pool unbacked
+        pool::set_reserve_unbacked(
+            asset, &mut reserve_data, ((unbacked - backing_amount) as u128)
+        );
+        // update pool interest rates
+        pool::update_interest_rates(
+            &mut reserve_data,
+            &reserve_cache,
+            asset,
+            added,
+            0
+        );
+
+        fungible_asset_manager::transfer(
+            account,
+            a_token_factory::get_token_account_address(a_token_address),
+            (added as u64),
+            asset
+        );
+
+        event::emit(
+            BackUnbacked {
+                reserve: asset,
+                backer: account_address,
+                amount: backing_amount,
+                fee
+            }
+        )
+    }
+
+    fun only_bridge(bridge: address): bool {
+        acl_manage::is_bridge(bridge)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/emode_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/emode_logic.move
@@ -1,0 +1,309 @@
+/// @title emode_logic module
+/// @author Aave
+/// @notice Implements the base logic for all the actions related to the eMode
+module aave_pool::emode_logic {
+    use std::signer;
+    use std::string;
+    use std::string::String;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::event;
+
+    use aave_config::error_config;
+    use aave_oracle::oracle;
+    use aave_pool::pool;
+    use aave_pool::validation_logic;
+
+    friend aave_pool::pool_configurator;
+    friend aave_pool::supply_logic;
+    friend aave_pool::borrow_logic;
+
+    #[test_only]
+    friend aave_pool::emode_logic_tests;
+    #[test_only]
+    friend aave_pool::supply_logic_tests;
+    #[test_only]
+    friend aave_pool::borrow_logic_tests;
+    #[test_only]
+    friend aave_pool::ui_pool_data_provider_v3;
+
+    const EMPTY_STRING: vector<u8> = b"";
+
+    #[event]
+    /// @dev Emitted when the user selects a certain asset category for eMode
+    /// @param user The address of the user
+    /// @param category_id The category id
+    struct UserEModeSet has store, drop {
+        user: address,
+        category_id: u8
+    }
+
+    struct EModeCategory has store, copy, drop {
+        ltv: u16,
+        liquidation_threshold: u16,
+        liquidation_bonus: u16,
+        /// each eMode category may or may not have a custom oracle to override the individual assets price oracles
+        price_source: address,
+        label: String
+    }
+
+    /// List of eMode categories as a map (emode_category_id => EModeCategory).
+    struct EModeCategoryList has key {
+        value: SmartTable<u8, EModeCategory>
+    }
+
+    /// Map of users address and their eMode category (user_address => emode_category_id)
+    struct UsersEmodeCategory has key, store {
+        value: SmartTable<address, u8>
+    }
+
+    /// @notice Initializes the eMode
+    /// @dev Only callable by the pool_configurator module
+    /// @param account The account signer of the caller
+    public(friend) fun init_emode(account: &signer) {
+        assert!(
+            (signer::address_of(account) == @aave_pool),
+            error_config::get_enot_pool_owner()
+        );
+        move_to(
+            account,
+            EModeCategoryList {
+                value: smart_table::new<u8, EModeCategory>()
+            }
+        );
+        move_to(
+            account,
+            UsersEmodeCategory {
+                value: smart_table::new<address, u8>()
+            }
+        )
+    }
+
+    /// @notice Updates the user efficiency mode category
+    /// @dev Will revert if user is borrowing non-compatible asset or change will drop HF < HEALTH_FACTOR_LIQUIDATION_THRESHOLD
+    /// @dev Emits the `UserEModeSet` event
+    /// @param account The account signer of the caller
+    /// @param category_id The state of all users efficiency mode category
+    public entry fun set_user_emode(
+        account: &signer, category_id: u8
+    ) acquires UsersEmodeCategory, EModeCategoryList {
+        //  validate set user emode
+        let account_address = signer::address_of(account);
+        let user_config_map = pool::get_user_configuration(account_address);
+        let reserves_count = pool::get_reserves_count();
+        let emode_configuration = get_emode_category_data(category_id);
+        validation_logic::validate_set_user_emode(
+            &user_config_map,
+            reserves_count,
+            category_id,
+            emode_configuration.liquidation_threshold
+        );
+
+        let prev_category_id = get_user_emode(account_address);
+        let user_emode_category = borrow_global_mut<UsersEmodeCategory>(@aave_pool);
+        smart_table::upsert(&mut user_emode_category.value, account_address, category_id);
+        let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+            get_emode_configuration(category_id);
+
+        if (prev_category_id != 0) {
+            validation_logic::validate_health_factor(
+                &user_config_map,
+                account_address,
+                category_id,
+                reserves_count,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+        };
+        event::emit(UserEModeSet { user: account_address, category_id });
+    }
+
+    #[view]
+    /// @notice Returns the eMode the user is using
+    /// @param user The address of the user
+    /// @return The eMode id
+    public fun get_user_emode(user: address): u256 acquires UsersEmodeCategory {
+        let user_emode_category = borrow_global<UsersEmodeCategory>(@aave_pool);
+        if (!smart_table::contains(&user_emode_category.value, user)) {
+            return 0
+        };
+        let user_emode = smart_table::borrow(&user_emode_category.value, user);
+        (*user_emode as u256)
+    }
+
+    /// @notice Get the price source of the eMode category
+    /// @param user_emode_category The user eMode category
+    /// @return The price source of the eMode category
+    public fun get_emode_e_mode_price_source(
+        user_emode_category: u8
+    ): address acquires EModeCategoryList {
+        let emode_category_list = borrow_global<EModeCategoryList>(@aave_pool);
+        if (!smart_table::contains(&emode_category_list.value, user_emode_category)) {
+            return @0x0
+        };
+        let emode_category =
+            smart_table::borrow(&emode_category_list.value, user_emode_category);
+        emode_category.price_source
+    }
+
+    /// @notice Gets the eMode configuration and calculates the eMode asset price if a custom oracle is configured
+    /// @dev The eMode asset price returned is 0 if no oracle is specified
+    /// @param user_emode_category The user eMode category
+    /// @return The eMode ltv
+    /// @return The eMode liquidation threshold
+    /// @return The eMode asset price
+    public fun get_emode_configuration(
+        user_emode_category: u8
+    ): (u256, u256, u256) acquires EModeCategoryList {
+        let emode_asset_price = 0;
+        let emode_category_list = borrow_global<EModeCategoryList>(@aave_pool);
+        if (!smart_table::contains(&emode_category_list.value, user_emode_category)) {
+            return (0, 0, emode_asset_price)
+        };
+        let emode_category =
+            smart_table::borrow(&emode_category_list.value, user_emode_category);
+        let emode_price_source = emode_category.price_source;
+        if (emode_price_source != @0x0) {
+            // TODO Waiting for Chainlink oracle functionality
+            emode_asset_price = oracle::get_asset_price(emode_price_source);
+        };
+        return ((emode_category.ltv as u256),
+        (emode_category.liquidation_threshold as u256),
+        emode_asset_price)
+    }
+
+    /// @notice Gets the eMode category label
+    /// @param user_emode_category The user eMode category
+    /// @return The label of the eMode category
+    public fun get_emode_e_mode_label(user_emode_category: u8): String acquires EModeCategoryList {
+        let emode_category_list = borrow_global<EModeCategoryList>(@aave_pool);
+        if (!smart_table::contains(&emode_category_list.value, user_emode_category)) {
+            return string::utf8(EMPTY_STRING)
+        };
+        let emode_category =
+            smart_table::borrow(&emode_category_list.value, user_emode_category);
+        emode_category.label
+    }
+
+    /// @notice Gets the eMode category liquidation_bonus
+    /// @param user_emode_category The user eMode category
+    /// @return The liquidation bonus of the eMode category
+    public fun get_emode_e_mode_liquidation_bonus(
+        user_emode_category: u8
+    ): u16 acquires EModeCategoryList {
+        let emode_category_list = borrow_global<EModeCategoryList>(@aave_pool);
+        if (!smart_table::contains(&emode_category_list.value, user_emode_category)) {
+            return 0
+        };
+        let emode_category =
+            smart_table::borrow(&emode_category_list.value, user_emode_category);
+        emode_category.liquidation_bonus
+    }
+
+    /// @notice Configures a new category for the eMode.
+    /// @dev Only callable by the pool_configurator module
+    /// @dev In eMode, the protocol allows very high borrowing power to borrow assets of the same category.
+    /// The category 0 is reserved as it's the default for volatile assets
+    /// @param id The id of the category
+    /// @param ltv The loan to value ratio
+    /// @param liquidation_threshold The liquidation threshold
+    /// @param liquidation_bonus The liquidation bonus
+    /// @param price_source The address of the oracle to override the individual assets price oracles
+    /// @param label The label of the category
+    public(friend) fun configure_emode_category(
+        id: u8,
+        ltv: u16,
+        liquidation_threshold: u16,
+        liquidation_bonus: u16,
+        price_source: address,
+        label: String
+    ) acquires EModeCategoryList {
+        assert!(id != 0, error_config::get_eemode_category_reserved());
+        // Currently, custom oracle is not supported. Only a unified oracle is used. Therefore, the price_source is equal to @0x0
+        price_source = @0x0;
+
+        let emode_category_list = borrow_global_mut<EModeCategoryList>(@aave_pool);
+        smart_table::upsert(
+            &mut emode_category_list.value,
+            id,
+            EModeCategory {
+                ltv,
+                liquidation_threshold,
+                liquidation_bonus,
+                price_source,
+                label
+            }
+        );
+    }
+
+    /// @notice Checks if eMode is active for a user and if yes, if the asset belongs to the eMode category chosen
+    /// @param emode_user_category The user eMode category
+    /// @param emode_asset_category The asset eMode category
+    /// @return True if eMode is active and the asset belongs to the eMode category chosen by the user, false otherwise
+    public fun is_in_emode_category(
+        emode_user_category: u256, emode_asset_category: u256
+    ): bool {
+        emode_user_category != 0 && emode_asset_category == emode_user_category
+    }
+
+    #[view]
+    /// @notice Returns the data of an eMode category
+    /// @param id The id of the category
+    /// @return The configuration data of the category
+    public fun get_emode_category_data(id: u8): EModeCategory acquires EModeCategoryList {
+        let emode_category_data = borrow_global<EModeCategoryList>(@aave_pool);
+        if (!smart_table::contains(&emode_category_data.value, id)) {
+            return EModeCategory {
+                ltv: 0,
+                liquidation_threshold: 0,
+                liquidation_bonus: 0,
+                // each eMode category may or may not have a custom oracle to override the individual assets price oracles
+                price_source: @0x0,
+                label: string::utf8(EMPTY_STRING)
+            }
+        };
+
+        *smart_table::borrow<u8, EModeCategory>(&emode_category_data.value, id)
+    }
+
+    /// @notice Get the ltv of the eMode category
+    /// @param emode_category The eMode category
+    /// @return The ltv of the eMode category
+    public fun get_emode_category_ltv(emode_category: &EModeCategory): u16 {
+        emode_category.ltv
+    }
+
+    /// @notice Get the liquidation threshold of the eMode category
+    /// @param emode_category The eMode category
+    /// @return The liquidation threshold of the eMode category
+    public fun get_emode_category_liquidation_threshold(
+        emode_category: &EModeCategory
+    ): u16 {
+        emode_category.liquidation_threshold
+    }
+
+    /// @notice Get the liquidation bonus of the eMode category
+    /// @param emode_category The eMode category
+    /// @return The liquidation bonus of the eMode category
+    public fun get_emode_category_liquidation_bonus(
+        emode_category: &EModeCategory
+    ): u16 {
+        emode_category.liquidation_bonus
+    }
+
+    /// @notice Get the price source of the eMode category
+    /// @param emode_category The eMode category
+    /// @return The price source of the eMode category
+    public fun get_emode_category_price_source(
+        emode_category: &EModeCategory
+    ): address {
+        emode_category.price_source
+    }
+
+    /// @notice Get the label of the eMode category
+    /// @param emode_category The eMode category
+    /// @return The label of the eMode category
+    public fun get_emode_category_label(emode_category: &EModeCategory): String {
+        emode_category.label
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/flashloan_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/flashloan_logic.move
@@ -1,0 +1,577 @@
+/// @title flashloan_logic module
+/// @author Aave
+/// @notice Implements the logic for the flash loans
+module aave_pool::flashloan_logic {
+    use std::option::Option;
+    use std::option::Self;
+    use std::signer;
+    use std::vector;
+    use aptos_framework::event;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config::Self;
+    use aave_config::user_config::Self;
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::borrow_logic;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::pool;
+    use aave_pool::pool::ReserveData;
+    use aave_pool::validation_logic::Self;
+
+    //// ================= STRUCTS ==================== ///
+    #[event]
+    /// @dev Emitted on pay_flash_loan_complex() and handle_flash_loan_repayment()
+    /// @param target The address of the flash loan receiver contract
+    /// @param initiator The address initiating the flash loan
+    /// @param asset The address of the asset being flash borrowed
+    /// @param amount The amount flash borrowed
+    /// @param interest_rate_mode The flashloan mode: 0 for regular flashloan, 2 for Variable debt
+    /// @param premium The fee flash borrowed
+    /// @param referral_code The referral code used
+    struct FlashLoan has store, drop {
+        target: address,
+        initiator: address,
+        asset: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        premium: u256,
+        referral_code: u16
+    }
+
+    /// Helper struct for internal variables used in the `execute_flash_loan_complex` and `execute_flash_loan_simple`  function
+    struct FlashLoanLocalVars has copy, drop {
+        sender: address,
+        receiver: address,
+        i: u256,
+        current_asset: address,
+        current_amount: u256,
+        total_premium: u256,
+        flashloan_premium_total: u256,
+        flashloan_premium_to_protocol: u256
+    }
+
+    struct SimpleFlashLoansReceipt {
+        sender: address,
+        receiver: address,
+        i: u256,
+        current_asset: address,
+        current_amount: u256,
+        total_premium: u256,
+        flashloan_premium_total: u256,
+        flashloan_premium_to_protocol: u256,
+        referral_code: u16,
+        interest_rate_mode: Option<u8>,
+        on_behalf_of: address
+    }
+
+    struct ComplexFlashLoansReceipt {
+        sender: address,
+        receiver: address,
+        i: u256,
+        current_asset: address,
+        current_amount: u256,
+        total_premium: u256,
+        flashloan_premium_total: u256,
+        flashloan_premium_to_protocol: u256,
+        referral_code: u16,
+        interest_rate_mode: Option<u8>,
+        on_behalf_of: address
+    }
+
+    struct FlashLoanRepaymentParams has drop {
+        amount: u256,
+        total_premium: u256,
+        flashloan_premium_to_protocol: u256,
+        asset: address,
+        receiver_address: address,
+        referral_code: u16
+    }
+
+    //// ================= METHODS ==================== ///
+    /// @notice Allows smartcontracts to access the liquidity of the pool within one transaction,
+    /// as long as the amount taken plus a fee is returned.
+    /// @dev IMPORTANT There are security concerns for developers of flashloan receiver contracts that must be kept
+    /// into consideration. For further details please visit https://docs.aave.com/developers/
+    /// @param initiator The signer account of the flash loan initiator
+    /// @param receiver_address The address of the contract receiving the funds
+    /// @param assets The addresses of the assets being flash-borrowed
+    /// @param amounts The amounts of the assets being flash-borrowed
+    /// @param interest_rate_modes Types of the debt to open if the flash loan is not returned:
+    ///   0 -> Don't open any debt, just revert if funds can't be transferred from the receiver
+    ///   2 -> Open debt at variable rate for the value of the amount flash-borrowed to the `on_behalf_of` address
+    /// @param on_behalf_of The address  that will receive the debt in the case of using on `interest_rate_modes` 2, on_behalf_of Should be the account address
+    /// @param referral_code The code used to register the integrator originating the operation, for potential rewards.
+    ///   0 if the action is executed directly by the user, without any middle-man
+    public fun flash_loan(
+        initiator: &signer,
+        receiver_address: address,
+        assets: vector<address>,
+        amounts: vector<u256>,
+        interest_rate_modes: vector<u8>,
+        on_behalf_of: address,
+        referral_code: u16
+    ): vector<ComplexFlashLoansReceipt> {
+        execute_flash_loan_complex(
+            initiator,
+            receiver_address,
+            assets,
+            amounts,
+            interest_rate_modes,
+            on_behalf_of,
+            referral_code,
+            (pool::get_flashloan_premium_to_protocol() as u256),
+            (pool::get_flashloan_premium_total() as u256),
+            acl_manage::is_flash_borrower(signer::address_of(initiator))
+        )
+    }
+
+    fun execute_flash_loan_complex(
+        initiator: &signer,
+        receiver_address: address,
+        assets: vector<address>,
+        amounts: vector<u256>,
+        interest_rate_modes: vector<u8>,
+        on_behalf_of: address,
+        referral_code: u16,
+        flash_loan_premium_to_protocol: u256,
+        flash_loan_premium_total: u256,
+        is_authorized_flash_borrower: bool
+    ): vector<ComplexFlashLoansReceipt> {
+        // get signer account
+        let initiator_address = signer::address_of(initiator);
+        assert!(
+            initiator_address == on_behalf_of,
+            error_config::get_esigner_and_on_behalf_of_no_same()
+        );
+        // get all reserves data
+        let reservesData = vector::map_ref<address, ReserveData>(
+            &assets,
+            |asset| {
+                let reserve_data = pool::get_reserve_data(*asset);
+                reserve_data
+            }
+        );
+
+        // validate flashloans logic
+        validation_logic::validate_flashloan_complex(
+            &reservesData,
+            &assets,
+            &amounts,
+            &interest_rate_modes
+        );
+
+        // validate interest rates
+        assert!(
+            !vector::any(
+                &interest_rate_modes,
+                |interest_rate| {
+                    let legitimate_interes_rate =
+                        *interest_rate == user_config::get_interest_rate_mode_none()
+                            || *interest_rate
+                                == user_config::get_interest_rate_mode_variable();
+                    !legitimate_interes_rate
+                }
+            ),
+            error_config::get_einvalid_interest_rate_mode_selected()
+        );
+
+        let flashloan_premium_total =
+            if (is_authorized_flash_borrower) { 0 }
+            else {
+                flash_loan_premium_total
+            };
+        let flashloan_premium_to_protocol =
+            if (is_authorized_flash_borrower) { 0 }
+            else {
+                flash_loan_premium_to_protocol
+            };
+        let flashloans = vector<FlashLoanLocalVars>[];
+
+        for (i in 0..vector::length(&assets)) {
+            // calculate premiums
+            let total_premium =
+                if (*vector::borrow(&interest_rate_modes, i)
+                    == user_config::get_interest_rate_mode_none()) {
+                    math_utils::percent_mul(
+                        *vector::borrow(&amounts, i), flashloan_premium_total
+                    )
+                } else { 0 };
+
+            let flashloan_vars = FlashLoanLocalVars {
+                sender: initiator_address,
+                receiver: receiver_address,
+                i: (i as u256),
+                current_asset: *vector::borrow(&assets, i),
+                current_amount: *vector::borrow(&amounts, i),
+                total_premium,
+                flashloan_premium_total,
+                flashloan_premium_to_protocol
+            };
+
+            // transfer the underlying to the receiver
+            transfer_underlying_to(&flashloan_vars);
+
+            // save the taken flashloan
+            vector::push_back(&mut flashloans, flashloan_vars);
+        };
+
+        let flashloan_receipts = vector::map<FlashLoanLocalVars, ComplexFlashLoansReceipt>(
+            flashloans,
+            |flashloan| {
+                let flashloan: FlashLoanLocalVars = flashloan;
+                let interest_rate_mode =
+                    *vector::borrow(&interest_rate_modes, (flashloan.i as u64));
+                create_complex_flashloan_receipt(
+                    &flashloan,
+                    initiator_address,
+                    referral_code,
+                    on_behalf_of,
+                    option::some(interest_rate_mode)
+                )
+            }
+        );
+
+        flashloan_receipts
+    }
+
+    /// @notice Repays flashloaned assets + premium
+    /// @dev Will pull the amount + premium from the receiver
+    /// @param flash_loan_receiver The signer account of the flash loan receiver
+    /// @param flashloan_receipts The receipts of the flashloaned assets
+    public fun pay_flash_loan_complex(
+        flash_loan_receiver: &signer, flashloan_receipts: vector<ComplexFlashLoansReceipt>
+    ) {
+        // get the payer account
+        let flash_loan_receiver_address = signer::address_of(flash_loan_receiver);
+
+        // destroy all receipts and handle their repayment
+        vector::destroy(
+            flashloan_receipts,
+            |flashloan| {
+                let ComplexFlashLoansReceipt {
+                    sender,
+                    receiver,
+                    i: _,
+                    current_asset,
+                    current_amount,
+                    total_premium,
+                    flashloan_premium_total: _,
+                    flashloan_premium_to_protocol,
+                    referral_code,
+                    interest_rate_mode,
+                    on_behalf_of
+                } = flashloan;
+
+                // check the signer is the receiver that the receipt was issued for
+                assert!(
+                    flash_loan_receiver_address == receiver,
+                    error_config::get_flashloan_payer_not_receiver()
+                );
+
+                if (*option::borrow(&interest_rate_mode)
+                    == user_config::get_interest_rate_mode_none()) {
+                    // do flashloan repayment
+                    let repayment_params = FlashLoanRepaymentParams {
+                        amount: current_amount,
+                        total_premium,
+                        flashloan_premium_to_protocol,
+                        asset: current_asset,
+                        receiver_address: receiver,
+                        referral_code
+                    };
+                    handle_flash_loan_repayment(
+                        flash_loan_receiver, &repayment_params, sender
+                    );
+                } else {
+                    // If the user chose to not return the funds, the system checks if there is enough collateral and
+                    // eventually opens a debt position
+                    borrow_logic::internal_borrow(
+                        sender, // flash loan initiator
+                        current_asset, // asset
+                        current_amount, // amount
+                        *option::borrow(&interest_rate_mode), //interest_rate_mode
+                        referral_code, // referral_code
+                        on_behalf_of, // on behalf of,
+                        false // release_underlying
+                    );
+                    event::emit(
+                        FlashLoan {
+                            target: receiver,
+                            initiator: sender,
+                            asset: current_asset,
+                            amount: current_amount,
+                            interest_rate_mode: *option::borrow(&interest_rate_mode),
+                            premium: 0,
+                            referral_code
+                        }
+                    );
+                };
+            }
+        )
+    }
+
+    fun create_simple_flashloan_receipt(
+        flashloan: &FlashLoanLocalVars,
+        sender: address,
+        referral_code: u16,
+        on_behalf_of: address,
+        interest_rate_mode: Option<u8>
+    ): SimpleFlashLoansReceipt {
+        SimpleFlashLoansReceipt {
+            sender,
+            receiver: flashloan.receiver,
+            i: flashloan.i,
+            current_asset: flashloan.current_asset,
+            current_amount: flashloan.current_amount,
+            total_premium: flashloan.total_premium,
+            flashloan_premium_total: flashloan.flashloan_premium_total,
+            flashloan_premium_to_protocol: flashloan.flashloan_premium_to_protocol,
+            referral_code,
+            on_behalf_of,
+            interest_rate_mode
+        }
+    }
+
+    fun create_complex_flashloan_receipt(
+        flashloan: &FlashLoanLocalVars,
+        sender: address,
+        referral_code: u16,
+        on_behalf_of: address,
+        interest_rate_mode: Option<u8>
+    ): ComplexFlashLoansReceipt {
+        ComplexFlashLoansReceipt {
+            sender,
+            receiver: flashloan.receiver,
+            i: flashloan.i,
+            current_asset: flashloan.current_asset,
+            current_amount: flashloan.current_amount,
+            total_premium: flashloan.total_premium,
+            flashloan_premium_total: flashloan.flashloan_premium_total,
+            flashloan_premium_to_protocol: flashloan.flashloan_premium_to_protocol,
+            referral_code,
+            on_behalf_of,
+            interest_rate_mode
+        }
+    }
+
+    fun transfer_underlying_to(flashloan_vars: &FlashLoanLocalVars) {
+        let reserve_data = pool::get_reserve_data(flashloan_vars.current_asset);
+        let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+        a_token_factory::transfer_underlying_to(
+            flashloan_vars.receiver, flashloan_vars.current_amount, a_token_address
+        )
+    }
+
+    /// @notice Allows smartcontracts to access the liquidity of the pool within one transaction,
+    /// as long as the amount taken plus a fee is returned.
+    /// @dev IMPORTANT There are security concerns for developers of flashloan receiver contracts that must be kept
+    /// into consideration. For further details please visit https://docs.aave.com/developers/
+    /// @param initiator The signer account of the flash loan initiator
+    /// @param receiver_address The address of the contract receiving the funds
+    /// @param asset The address of the asset being flash-borrowed
+    /// @param amount The amount of the asset being flash-borrowed
+    /// @param referral_code The code used to register the integrator originating the operation, for potential rewards.
+    ///  0 if the action is executed directly by the user, without any middle-man
+    public fun flash_loan_simple(
+        initiator: &signer,
+        receiver_address: address,
+        asset: address,
+        amount: u256,
+        referral_code: u16
+    ): SimpleFlashLoansReceipt {
+        execute_flash_loan_simple(
+            initiator,
+            receiver_address,
+            asset,
+            amount,
+            referral_code,
+            (pool::get_flashloan_premium_to_protocol() as u256),
+            (pool::get_flashloan_premium_total() as u256)
+        )
+    }
+
+    fun execute_flash_loan_simple(
+        initiator: &signer,
+        receiver_address: address,
+        asset: address,
+        amount: u256,
+        referral_code: u16,
+        flashloan_premium_to_protocol: u256,
+        flashloan_premium_total: u256
+    ): SimpleFlashLoansReceipt {
+        // sender account address
+        let initiator_address = signer::address_of(initiator);
+
+        // get the reserve data
+        let reserve_data = pool::get_reserve_data(asset);
+
+        // validate flashloan logic
+        validation_logic::validate_flashloan_simple(&reserve_data);
+
+        // create flashloan
+        let flashloan = FlashLoanLocalVars {
+            sender: initiator_address,
+            receiver: receiver_address,
+            i: 0,
+            current_asset: asset,
+            current_amount: amount,
+            total_premium: math_utils::percent_mul(amount, flashloan_premium_total),
+            flashloan_premium_total,
+            flashloan_premium_to_protocol
+        };
+
+        // transfer the underlying to the receiver
+        transfer_underlying_to(&flashloan);
+
+        // create and return the flashloan receipt
+        let flashloan_receipt =
+            create_simple_flashloan_receipt(
+                &flashloan,
+                initiator_address,
+                referral_code,
+                receiver_address,
+                option::none()
+            );
+
+        flashloan_receipt
+    }
+
+    /// @notice Repays flashloaned assets + premium
+    /// @dev Will pull the amount + premium from the receiver
+    /// @param flash_loan_receiver The signer account of flash loan receiver
+    /// @param flashloan_receipt The receipt of the flashloaned asset
+    public fun pay_flash_loan_simple(
+        flash_loan_receiver: &signer, flashloan_receipt: SimpleFlashLoansReceipt
+    ) {
+        // destructure the receipt
+        let SimpleFlashLoansReceipt {
+            sender,
+            receiver,
+            i: _,
+            current_asset,
+            current_amount,
+            total_premium,
+            flashloan_premium_total: _,
+            flashloan_premium_to_protocol,
+            referral_code,
+            interest_rate_mode: _,
+            on_behalf_of: _
+        } = flashloan_receipt;
+
+        // check the signer is the receiver that the receipt was issued for
+        assert!(
+            signer::address_of(flash_loan_receiver) == receiver,
+            error_config::get_flashloan_payer_not_receiver()
+        );
+
+        // do flashloan repayment
+        let repayment_params = FlashLoanRepaymentParams {
+            amount: current_amount,
+            total_premium,
+            flashloan_premium_to_protocol,
+            asset: current_asset,
+            receiver_address: receiver,
+            referral_code
+        };
+        handle_flash_loan_repayment(flash_loan_receiver, &repayment_params, sender);
+    }
+
+    /// @notice Handles repayment of flashloaned assets + premium
+    /// @dev Will pull the amount + premium from the receiver, so must have approved pool
+    /// @param flash_loan_receiver The signer account of flash loan receiver
+    /// @param repayment_params The additional parameters needed to execute the repayment function
+    /// @param sender Flash loan initiators.
+    fun handle_flash_loan_repayment(
+        flash_loan_receiver: &signer,
+        repayment_params: &FlashLoanRepaymentParams,
+        sender: address
+    ) {
+        // get the reserve data
+        let reserve_data = pool::get_reserve_data(repayment_params.asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+
+        // compute amount plus premiums
+        let premium_to_protocol =
+            math_utils::percent_mul(
+                repayment_params.total_premium,
+                repayment_params.flashloan_premium_to_protocol
+            );
+        let premium_to_lp = repayment_params.total_premium - premium_to_protocol;
+        let amount_plus_premium = repayment_params.amount
+            + repayment_params.total_premium;
+
+        // update the pool state
+        pool::update_state(repayment_params.asset, &mut reserve_data, &mut reserve_cache);
+
+        // update liquidity index
+        let a_token_total_supply = pool::a_token_total_supply(a_token_address);
+        let reserve_accrued_to_treasury =
+            pool::get_reserve_accrued_to_treasury(&reserve_data);
+        let total_liquidity =
+            a_token_total_supply
+                + wad_ray_math::ray_mul(
+                    reserve_accrued_to_treasury,
+                    pool::get_next_liquidity_index(&reserve_cache)
+                );
+        let next_liquidity_index =
+            pool::cumulate_to_liquidity_index(
+                repayment_params.asset,
+                &mut reserve_data,
+                total_liquidity,
+                premium_to_lp
+            );
+        // update reserve cache next liquidity index
+        pool::set_next_liquidity_index(&mut reserve_cache, next_liquidity_index);
+
+        // update accrued to treasury
+        let new_reserve_accrued_to_treasury =
+            reserve_accrued_to_treasury
+                + wad_ray_math::ray_div(premium_to_protocol, next_liquidity_index);
+        pool::set_reserve_accrued_to_treasury(
+            repayment_params.asset, &mut reserve_data, new_reserve_accrued_to_treasury
+        );
+
+        // update pool interest rates
+        pool::update_interest_rates(
+            &mut reserve_data,
+            &reserve_cache,
+            repayment_params.asset,
+            amount_plus_premium,
+            0
+        );
+
+        // transfer underlying tokens
+        let a_token_account_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        fungible_asset_manager::transfer(
+            flash_loan_receiver,
+            a_token_account_address,
+            (amount_plus_premium as u64),
+            repayment_params.asset
+        );
+
+        // handle the a token repayment
+        a_token_factory::handle_repayment(
+            repayment_params.receiver_address,
+            repayment_params.receiver_address,
+            amount_plus_premium,
+            a_token_address
+        );
+
+        event::emit(
+            FlashLoan {
+                target: repayment_params.receiver_address,
+                initiator: sender,
+                asset: repayment_params.asset,
+                amount: repayment_params.amount,
+                interest_rate_mode: user_config::get_interest_rate_mode_none(),
+                premium: repayment_params.total_premium,
+                referral_code: repayment_params.referral_code
+            }
+        )
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/generic_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/generic_logic.move
@@ -1,0 +1,286 @@
+/// @title GenericLogic module
+/// @author Aave
+/// @notice Implements protocol-level logic to calculate and validate the state of a user
+module aave_pool::generic_logic {
+
+    use aave_config::reserve_config;
+    use aave_config::user_config::{Self, UserConfigurationMap};
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+    use aave_oracle::oracle;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::pool::{Self, ReserveData};
+    use aave_pool::variable_debt_token_factory;
+
+    struct CalculateUserAccountDataVars has drop {
+        asset_price: u256,
+        asset_unit: u256,
+        user_balance_in_base_currency: u256,
+        decimals: u256,
+        ltv: u256,
+        liquidation_threshold: u256,
+        i: u256,
+        health_factor: u256,
+        total_collateral_in_base_currency: u256,
+        total_debt_in_base_currency: u256,
+        avg_ltv: u256,
+        avg_liquidation_threshold: u256,
+        emode_asset_price: u256,
+        emode_ltv: u256,
+        emode_liq_threshold: u256,
+        emode_asset_category: u256,
+        current_reserve_address: address,
+        has_zero_ltv_collateral: bool,
+        is_in_emode_category: bool
+    }
+
+    fun create_calculate_user_account_data_vars(): CalculateUserAccountDataVars {
+        CalculateUserAccountDataVars {
+            asset_price: 0,
+            asset_unit: 0,
+            user_balance_in_base_currency: 0,
+            decimals: 0,
+            ltv: 0,
+            liquidation_threshold: 0,
+            i: 0,
+            health_factor: 0,
+            total_collateral_in_base_currency: 0,
+            total_debt_in_base_currency: 0,
+            avg_ltv: 0,
+            avg_liquidation_threshold: 0,
+            emode_asset_price: 0,
+            emode_ltv: 0,
+            emode_liq_threshold: 0,
+            emode_asset_category: 0,
+            current_reserve_address: @0x0,
+            has_zero_ltv_collateral: false,
+            is_in_emode_category: false
+        }
+    }
+
+    /// @notice Calculates the user data across the reserves.
+    /// @dev It includes the total liquidity/collateral/borrow balances in the base currency used by the price feed,
+    /// the average Loan To Value, the average Liquidation Ratio, and the Health factor.
+    /// @param params user_config_map The user configuration map
+    /// @param params reserves_count The number of reserves
+    /// @param params user The address of the user
+    /// @param params user_emode_category The category of the user in the emode
+    /// @param params emode_ltv The ltv of the user in the emode
+    /// @param params emode_liq_threshold The liquidation threshold of the user in the emode
+    /// @param params emode_asset_price The price of the asset in the emode
+    /// @return The total collateral of the user in the base currency used by the price feed
+    /// @return The total debt of the user in the base currency used by the price feed
+    /// @return The average ltv of the user
+    /// @return The average liquidation threshold of the user
+    /// @return The health factor of the user
+    /// @return True if the ltv is zero, false otherwise
+    public fun calculate_user_account_data(
+        user_config_map: &UserConfigurationMap,
+        reserves_count: u256,
+        user: address,
+        user_emode_category: u8,
+        emode_ltv: u256,
+        emode_liq_threshold: u256,
+        emode_asset_price: u256
+    ): (u256, u256, u256, u256, u256, bool) {
+        if (user_config::is_empty(user_config_map)) {
+            return (0, 0, 0, 0, math_utils::u256_max(), false)
+        };
+
+        let vars = create_calculate_user_account_data_vars();
+        if (user_emode_category != 0) {
+            vars.emode_ltv = emode_ltv;
+            vars.emode_liq_threshold = emode_liq_threshold;
+            vars.emode_asset_price = emode_asset_price;
+        };
+
+        while (vars.i < reserves_count) {
+            if (!user_config::is_using_as_collateral_or_borrowing(
+                user_config_map, vars.i
+            )) {
+                vars.i = vars.i + 1;
+                continue
+            };
+
+            vars.current_reserve_address = pool::get_reserve_address_by_id(vars.i);
+            if (vars.current_reserve_address == @0x0) {
+                vars.i = vars.i + 1;
+                continue
+            };
+
+            let current_reserve = pool::get_reserve_data(vars.current_reserve_address);
+            let current_reserve_config_map =
+                pool::get_reserve_configuration_by_reserve_data(&current_reserve);
+            let (ltv, liquidation_threshold, _, decimals, _, emode_asset_category) =
+                reserve_config::get_params(&current_reserve_config_map);
+            vars.ltv = ltv;
+            vars.liquidation_threshold = liquidation_threshold;
+            vars.decimals = decimals;
+            vars.emode_asset_category = emode_asset_category;
+
+            vars.asset_unit = math_utils::pow(10, vars.decimals);
+
+            vars.asset_price = if (vars.emode_asset_price != 0
+                && user_emode_category == (vars.emode_asset_category as u8)) {
+                vars.emode_asset_price
+            } else {
+                oracle::get_asset_price(vars.current_reserve_address)
+            };
+
+            if (vars.liquidation_threshold != 0
+                && user_config::is_using_as_collateral(user_config_map, vars.i)) {
+                vars.user_balance_in_base_currency = get_user_balance_in_base_currency(
+                    user,
+                    &current_reserve,
+                    vars.asset_price,
+                    vars.asset_unit
+                );
+
+                vars.total_collateral_in_base_currency = vars.total_collateral_in_base_currency
+                    + vars.user_balance_in_base_currency;
+
+                vars.is_in_emode_category = user_emode_category != 0
+                    && vars.emode_asset_category == (user_emode_category as u256);
+
+                if (vars.ltv != 0) {
+                    let ltv = if (vars.is_in_emode_category) {
+                        vars.emode_ltv
+                    } else {
+                        vars.ltv
+                    };
+                    vars.avg_ltv = vars.avg_ltv
+                        + vars.user_balance_in_base_currency * ltv;
+                } else {
+                    vars.has_zero_ltv_collateral = true
+                };
+
+                let liquidation_threshold =
+                    if (vars.is_in_emode_category) {
+                        vars.emode_liq_threshold
+                    } else {
+                        vars.liquidation_threshold
+                    };
+                vars.avg_liquidation_threshold = vars.avg_liquidation_threshold
+                    + vars.user_balance_in_base_currency * liquidation_threshold;
+            };
+
+            if (user_config::is_borrowing(user_config_map, vars.i)) {
+                let user_debt_in_base_currency =
+                    get_user_debt_in_base_currency(
+                        user,
+                        &current_reserve,
+                        vars.asset_price,
+                        vars.asset_unit
+                    );
+                vars.total_debt_in_base_currency = vars.total_debt_in_base_currency
+                    + user_debt_in_base_currency;
+            };
+
+            vars.i = vars.i + 1;
+        };
+
+        vars.avg_ltv = if (vars.total_collateral_in_base_currency != 0) {
+            vars.avg_ltv / vars.total_collateral_in_base_currency
+        } else { 0 };
+
+        vars.avg_liquidation_threshold = if (vars.total_collateral_in_base_currency
+            != 0) {
+            vars.avg_liquidation_threshold / vars.total_collateral_in_base_currency
+        } else { 0 };
+
+        vars.health_factor = if (vars.total_debt_in_base_currency == 0) {
+            math_utils::u256_max()
+        } else {
+            wad_ray_math::wad_div(
+                math_utils::percent_mul(
+                    vars.total_collateral_in_base_currency,
+                    vars.avg_liquidation_threshold
+                ),
+                vars.total_debt_in_base_currency
+            )
+        };
+
+        return (
+            vars.total_collateral_in_base_currency,
+            vars.total_debt_in_base_currency,
+            vars.avg_ltv,
+            vars.avg_liquidation_threshold,
+            vars.health_factor,
+            vars.has_zero_ltv_collateral
+        )
+    }
+
+    /// @notice Calculates the maximum amount that can be borrowed depending on the available collateral, the total debt
+    /// and the average Loan To Value
+    /// @param total_collateral_in_base_currency The total collateral in the base currency used by the price feed
+    /// @param total_debt_in_base_currency The total borrow balance in the base currency used by the price feed
+    /// @param ltv The average loan to value
+    /// @return The amount available to borrow in the base currency of the used by the price feed
+    public fun calculate_available_borrows(
+        total_collateral_in_base_currency: u256,
+        total_debt_in_base_currency: u256,
+        ltv: u256
+    ): u256 {
+        let available_borrows_in_base_currency =
+            math_utils::percent_mul(total_collateral_in_base_currency, ltv);
+
+        if (available_borrows_in_base_currency < total_debt_in_base_currency) {
+            return 0
+        };
+
+        available_borrows_in_base_currency - total_debt_in_base_currency
+    }
+
+    /// @notice Calculates total debt of the user in the based currency used to normalize the values of the assets
+    /// the variable debt balance is calculated by fetching `scaled_balance_of` normalized debt
+    /// @param user The address of the user
+    /// @param reserve_data The data of the reserve for which the total debt of the user is being calculated
+    /// @param asset_price The price of the asset for which the total debt of the user is being calculated
+    /// @param asset_unit The value representing one full unit of the asset (10^decimals)
+    /// @return The total debt of the user normalized to the base currency
+    fun get_user_debt_in_base_currency(
+        user: address,
+        reserve_data: &ReserveData,
+        asset_price: u256,
+        asset_unit: u256
+    ): u256 {
+        let user_total_debt =
+            variable_debt_token_factory::scaled_balance_of(
+                user, pool::get_reserve_variable_debt_token_address(reserve_data)
+            );
+
+        if (user_total_debt != 0) {
+            let normalized_debt = pool::get_normalized_debt_by_reserve_data(reserve_data);
+            user_total_debt = wad_ray_math::ray_mul(user_total_debt, normalized_debt);
+        };
+
+        user_total_debt = asset_price * user_total_debt;
+
+        user_total_debt / asset_unit
+    }
+
+    /// @notice Calculates total aToken balance of the user in the based currency used by the price oracle
+    /// @dev the aToken balance is calculated by fetching `scaled_balance_of` normalized debt
+    /// @param user The address of the user
+    /// @param reserve_data The data of the reserve for which the total aToken balance of the user is being calculated
+    /// @param asset_price The price of the asset for which the total aToken balance of the user is being calculated
+    /// @param asset_unit The value representing one full unit of the asset (10^decimals)
+    /// @return The total aToken balance of the user normalized to the base currency of the price oracle
+    fun get_user_balance_in_base_currency(
+        user: address,
+        reserve_data: &ReserveData,
+        asset_price: u256,
+        asset_unit: u256
+    ): u256 {
+        let normalized_income = pool::get_normalized_income_by_reserve_data(reserve_data);
+        let balance =
+            wad_ray_math::ray_mul(
+                a_token_factory::scaled_balance_of(
+                    user, pool::get_reserve_a_token_address(reserve_data)
+                ),
+                normalized_income
+            ) * asset_price;
+        balance / asset_unit
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/isolation_mode_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/isolation_mode_logic.move
@@ -1,0 +1,81 @@
+module aave_pool::isolation_mode_logic {
+    use aptos_framework::event;
+
+    use aave_config::reserve_config;
+    use aave_config::user_config::UserConfigurationMap;
+    use aave_math::math_utils;
+
+    use aave_pool::pool::{Self, ReserveCache};
+
+    friend aave_pool::borrow_logic;
+    friend aave_pool::liquidation_logic;
+
+    #[event]
+    /// @dev Emitted on borrow(), repay() and liquidation_call() when using isolated assets
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param total_debt The total isolation mode debt for the reserve
+    struct IsolationModeTotalDebtUpdated has store, drop {
+        asset: address,
+        total_debt: u256
+    }
+
+    /// @notice updated the isolated debt whenever a position collateralized by an isolated asset is repaid or liquidated
+    /// @dev Only callable by the borrow_logic and liquidation_logic module
+    /// @param user_config_map The user configuration map
+    /// @param reserve_cache The reserve cache
+    /// @param repay_amount The amount being repaid
+    public(friend) fun update_isolated_debt_if_isolated(
+        user_config_map: &UserConfigurationMap,
+        reserve_cache: &ReserveCache,
+        repay_amount: u256
+    ) {
+        let (isolation_mode_active, isolation_mode_collateral_address, _) =
+            pool::get_isolation_mode_state(user_config_map);
+
+        if (isolation_mode_active) {
+            let isolation_mode_debt_reserve_data =
+                pool::get_reserve_data(isolation_mode_collateral_address);
+            let isolation_mode_total_debt =
+                pool::get_reserve_isolation_mode_total_debt(
+                    &isolation_mode_debt_reserve_data
+                );
+            let reserve_config_map = pool::get_reserve_cache_configuration(reserve_cache);
+            let debt_decimals =
+                reserve_config::get_decimals(&reserve_config_map)
+                    - reserve_config::get_debt_ceiling_decimals();
+
+            let isolated_debt_repaid = (repay_amount
+                / math_utils::pow(10, debt_decimals));
+
+            // since the debt ceiling does not take into account the interest accrued, it might happen that amount
+            // repaid > debt in isolation mode
+            if (isolation_mode_total_debt <= (isolated_debt_repaid as u128)) {
+                pool::set_reserve_isolation_mode_total_debt(
+                    isolation_mode_collateral_address,
+                    &mut isolation_mode_debt_reserve_data,
+                    0
+                );
+                event::emit(
+                    IsolationModeTotalDebtUpdated {
+                        asset: isolation_mode_collateral_address,
+                        total_debt: 0
+                    }
+                )
+            } else {
+                let next_isolation_mode_total_debt =
+                    isolation_mode_total_debt - (isolated_debt_repaid as u128);
+                pool::set_reserve_isolation_mode_total_debt(
+                    isolation_mode_collateral_address,
+                    &mut isolation_mode_debt_reserve_data,
+                    next_isolation_mode_total_debt
+                );
+                event::emit(
+                    IsolationModeTotalDebtUpdated {
+                        asset: isolation_mode_collateral_address,
+                        total_debt: (next_isolation_mode_total_debt as u256)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/liquidation_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/liquidation_logic.move
@@ -1,0 +1,714 @@
+/// @title liquidation_logic module
+/// @author Aave
+/// @notice Implements actions involving management of collateral in the protocol, the main one being the liquidations
+module aave_pool::liquidation_logic {
+    use std::signer;
+    use aptos_framework::event;
+
+    use aave_config::reserve_config;
+    use aave_config::user_config;
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+    use aave_oracle::oracle;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::emode_logic;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::generic_logic;
+    use aave_pool::isolation_mode_logic;
+    use aave_pool::pool::{Self, ReserveCache, ReserveData};
+    use aave_pool::validation_logic;
+    use aave_pool::variable_debt_token_factory;
+
+    #[event]
+    /// @dev Emitted on liquidate_a_tokens()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address of the user enabling the usage as collateral
+    struct ReserveUsedAsCollateralEnabled has store, drop {
+        reserve: address,
+        user: address
+    }
+
+    #[event]
+    /// @dev Emitted on liquidation_call()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address of the user disabling the usage as collateral
+    struct ReserveUsedAsCollateralDisabled has store, drop {
+        reserve: address,
+        user: address
+    }
+
+    #[event]
+    /// @dev Emitted when a borrower is liquidated.
+    /// @param collateral_asset The address of the underlying asset used as collateral, to receive as result of the liquidation
+    /// @param debt_asset The address of the underlying borrowed asset to be repaid with the liquidation
+    /// @param user The address of the borrower getting liquidated
+    /// @param debt_to_cover The debt amount of borrowed `asset` the liquidator wants to cover
+    /// @param liquidated_collateral_amount The amount of collateral received by the liquidator
+    /// @param liquidator The address of the liquidator
+    /// @param receive_a_token True if the liquidators wants to receive the collateral aTokens, `false` if he wants
+    /// to receive the underlying collateral asset directly
+    struct LiquidationCall has store, drop {
+        collateral_asset: address,
+        debt_asset: address,
+        user: address,
+        debt_to_cover: u256,
+        liquidated_collateral_amount: u256,
+        liquidator: address,
+        receive_a_token: bool
+    }
+
+    /// @dev Default percentage of borrower's debt to be repaid in a liquidation.
+    /// @dev Percentage applied when the users health factor is above `CLOSE_FACTOR_HF_THRESHOLD`
+    /// Expressed in bps, a value of 0.5e4 results in 50.00%
+    /// 5 * 10 ** 3
+    const DEFAULT_LIQUIDATION_CLOSE_FACTOR: u256 = 5000;
+
+    /// @dev Maximum percentage of borrower's debt to be repaid in a liquidation
+    /// @dev Percentage applied when the users health factor is below `CLOSE_FACTOR_HF_THRESHOLD`
+    /// Expressed in bps, a value of 1e4 results in 100.00%
+    /// 1 * 10 ** 4
+    const MAX_LIQUIDATION_CLOSE_FACTOR: u256 = 10000;
+
+    /// @dev This constant represents below which health factor value it is possible to liquidate
+    /// an amount of debt corresponding to `MAX_LIQUIDATION_CLOSE_FACTOR`.
+    /// A value of 0.95e18 results in 0.95
+    /// 0.95 * 10 ** 18
+    const CLOSE_FACTOR_HF_THRESHOLD: u256 = 950000000000000000;
+
+    struct LiquidationCallLocalVars has drop {
+        user_collateral_balance: u256,
+        user_variable_debt: u256,
+        user_total_debt: u256,
+        actual_debt_to_liquidate: u256,
+        actual_collateral_to_liquidate: u256,
+        liquidation_bonus: u256,
+        health_factor: u256,
+        liquidation_protocol_fee_amount: u256,
+        collateral_price_source: address,
+        debt_price_source: address,
+        collateral_a_token: address
+    }
+
+    fun create_liquidation_call_local_vars(): LiquidationCallLocalVars {
+        LiquidationCallLocalVars {
+            user_collateral_balance: 0,
+            user_variable_debt: 0,
+            user_total_debt: 0,
+            actual_debt_to_liquidate: 0,
+            actual_collateral_to_liquidate: 0,
+            liquidation_bonus: 0,
+            health_factor: 0,
+            liquidation_protocol_fee_amount: 0,
+            collateral_price_source: @0x0,
+            debt_price_source: @0x0,
+            collateral_a_token: @0x0
+        }
+    }
+
+    struct ExecuteLiquidationCallParams has drop {
+        reserves_count: u256,
+        debt_to_cover: u256,
+        collateral_asset: address,
+        debt_asset: address,
+        user: address,
+        receive_a_token: bool,
+        user_emode_category: u8
+    }
+
+    fun create_execute_liquidation_call_params(
+        reserves_count: u256,
+        collateral_asset: address,
+        debt_asset: address,
+        user: address,
+        debt_to_cover: u256,
+        receive_a_token: bool
+    ): ExecuteLiquidationCallParams {
+        ExecuteLiquidationCallParams {
+            reserves_count,
+            debt_to_cover,
+            collateral_asset,
+            debt_asset,
+            user,
+            receive_a_token,
+            user_emode_category: (emode_logic::get_user_emode(user) as u8)
+        }
+    }
+
+    /// @notice Function to liquidate a non-healthy position collateral-wise, with Health Factor below 1
+    /// - The caller (liquidator) covers `debt_to_cover` amount of debt of the user getting liquidated, and receives
+    /// a proportionally amount of the `collateral_asset` plus a bonus to cover market risk
+    /// @dev Emits the `LiquidationCall()` event
+    /// @param account The account signer of the caller
+    /// @param collateral_asset The address of the underlying asset used as collateral, to receive as result of the liquidation
+    /// @param debt_asset The address of the underlying borrowed asset to be repaid with the liquidation
+    /// @param user The address of the borrower getting liquidated
+    /// @param debt_to_cover The debt amount of borrowed `asset` the liquidator wants to cover
+    /// @param receive_a_token True if the liquidators wants to receive the collateral aTokens, `false` if he wants
+    /// to receive the underlying collateral asset directly
+    public entry fun liquidation_call(
+        account: &signer,
+        collateral_asset: address,
+        debt_asset: address,
+        user: address,
+        debt_to_cover: u256,
+        receive_a_token: bool
+    ) {
+        let reserves_count = pool::get_reserves_count();
+        let account_address = signer::address_of(account);
+        let vars = create_liquidation_call_local_vars();
+        let params =
+            create_execute_liquidation_call_params(
+                reserves_count,
+                collateral_asset,
+                debt_asset,
+                user,
+                debt_to_cover,
+                receive_a_token
+            );
+        let collateral_reserve = pool::get_reserve_data(params.collateral_asset);
+        let debt_reserve = pool::get_reserve_data(params.debt_asset);
+        let debt_reserve_cache = pool::cache(&debt_reserve);
+        // update debt reserve state
+        pool::update_state(debt_asset, &mut debt_reserve, &mut debt_reserve_cache);
+
+        let user_config_map = pool::get_user_configuration(user);
+        let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+            emode_logic::get_emode_configuration(params.user_emode_category);
+
+        let (_, _, _, _, health_factor, _) =
+            generic_logic::calculate_user_account_data(
+                &user_config_map,
+                params.reserves_count,
+                params.user,
+                params.user_emode_category,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+        vars.health_factor = health_factor;
+
+        let (user_variable_debt, user_total_debt, actual_debt_to_liquidate) =
+            calculate_debt(&debt_reserve_cache, &params, health_factor);
+        vars.user_variable_debt = user_variable_debt;
+        vars.user_total_debt = user_total_debt;
+        vars.actual_debt_to_liquidate = actual_debt_to_liquidate;
+
+        // validate liquidation call
+        validation_logic::validate_liquidation_call(
+            &user_config_map,
+            &collateral_reserve,
+            &debt_reserve_cache,
+            vars.user_total_debt,
+            vars.health_factor
+        );
+
+        // get configuration data
+        let (
+            collateral_a_token,
+            collateral_price_source,
+            debt_price_source,
+            liquidation_bonus
+        ) = get_configuration_data(&collateral_reserve, &params);
+
+        vars.collateral_a_token = collateral_a_token;
+        vars.collateral_price_source = collateral_price_source;
+        vars.debt_price_source = debt_price_source;
+        vars.liquidation_bonus = liquidation_bonus;
+
+        vars.user_collateral_balance = pool::a_token_balance_of(
+            params.user, collateral_a_token
+        );
+
+        let (
+            actual_collateral_to_liquidate,
+            actual_debt_to_liquidate,
+            liquidation_protocol_fee_amount
+        ) =
+            calculate_available_collateral_to_liquidate(
+                &collateral_reserve,
+                &debt_reserve_cache,
+                vars.collateral_price_source, // Currently, custom oracle is not supported. Only a unified oracle is used. Therefore, the price is obtained by calling the oracle directly with the collateral_asset.
+                vars.debt_price_source, // Currently, custom oracle is not supported. Only a unified oracle is used. Therefore, the price is obtained by calling the oracle directly with the debt_asset.
+                vars.actual_debt_to_liquidate,
+                vars.user_collateral_balance,
+                vars.liquidation_bonus
+            );
+        vars.actual_collateral_to_liquidate = actual_collateral_to_liquidate;
+        vars.actual_debt_to_liquidate = actual_debt_to_liquidate;
+        vars.liquidation_protocol_fee_amount = liquidation_protocol_fee_amount;
+
+        if (vars.user_total_debt == vars.actual_debt_to_liquidate) {
+            let debt_reserve_id = pool::get_reserve_id(&debt_reserve);
+            user_config::set_borrowing(
+                &mut user_config_map, (debt_reserve_id as u256), false
+            );
+            pool::set_user_configuration(params.user, user_config_map);
+        };
+
+        // If the collateral being liquidated is equal to the user balance,
+        // we set the currency as not being used as collateral anymore
+        if (vars.actual_collateral_to_liquidate + vars.liquidation_protocol_fee_amount
+            == vars.user_collateral_balance) {
+            let collateral_reserve_id = pool::get_reserve_id(&collateral_reserve);
+            user_config::set_using_as_collateral(
+                &mut user_config_map,
+                (collateral_reserve_id as u256),
+                false
+            );
+            pool::set_user_configuration(params.user, user_config_map);
+            event::emit(
+                ReserveUsedAsCollateralDisabled {
+                    reserve: params.collateral_asset,
+                    user: params.user
+                }
+            );
+        };
+
+        // burn debt tokens
+        burn_debt_tokens(&mut debt_reserve_cache, &params, &vars);
+
+        // update pool interest rates
+        pool::update_interest_rates(
+            &mut debt_reserve,
+            &debt_reserve_cache,
+            params.debt_asset,
+            vars.actual_debt_to_liquidate,
+            0
+        );
+
+        isolation_mode_logic::update_isolated_debt_if_isolated(
+            &user_config_map,
+            &debt_reserve_cache,
+            vars.actual_debt_to_liquidate
+        );
+
+        let collateral_reserve = pool::get_reserve_data(params.collateral_asset);
+        if (params.receive_a_token) {
+            liquidate_a_tokens(
+                account_address,
+                &collateral_reserve,
+                &params,
+                &vars
+            );
+        } else {
+            burn_collateral_a_tokens(
+                account_address,
+                &mut collateral_reserve,
+                &params,
+                &vars
+            )
+        };
+
+        // Transfer fee to treasury if it is non-zero
+        if (vars.liquidation_protocol_fee_amount != 0) {
+            let liquidity_index =
+                pool::get_normalized_income_by_reserve_data(&collateral_reserve);
+            let scaled_down_liquidation_protocol_fee =
+                wad_ray_math::ray_div(
+                    vars.liquidation_protocol_fee_amount,
+                    liquidity_index
+                );
+
+            let scaled_down_user_balance =
+                a_token_factory::scaled_balance_of(params.user, vars.collateral_a_token);
+            // To avoid trying to send more aTokens than available on balance, due to 1 wei imprecision
+            if (scaled_down_liquidation_protocol_fee > scaled_down_user_balance) {
+                vars.liquidation_protocol_fee_amount = wad_ray_math::ray_mul(
+                    scaled_down_user_balance, liquidity_index
+                )
+            };
+
+            let a_token_treasury =
+                a_token_factory::get_reserve_treasury_address(vars.collateral_a_token);
+            a_token_factory::transfer_on_liquidation(
+                params.user,
+                a_token_treasury,
+                vars.liquidation_protocol_fee_amount,
+                liquidity_index,
+                vars.collateral_a_token
+            );
+        };
+
+        // Transfers the debt asset being repaid to the aToken, where the liquidity is kept
+        let a_token_address = pool::get_a_token_address(&debt_reserve_cache);
+        fungible_asset_manager::transfer(
+            account,
+            a_token_factory::get_token_account_address(a_token_address),
+            (vars.actual_debt_to_liquidate as u64),
+            debt_asset
+        );
+
+        a_token_factory::handle_repayment(
+            account_address,
+            params.user,
+            vars.actual_debt_to_liquidate,
+            a_token_address
+        );
+
+        event::emit(
+            LiquidationCall {
+                collateral_asset,
+                debt_asset,
+                user,
+                debt_to_cover: vars.actual_debt_to_liquidate,
+                liquidated_collateral_amount: vars.actual_collateral_to_liquidate,
+                liquidator: account_address,
+                receive_a_token
+            }
+        );
+    }
+
+    /// @notice Burns the collateral aTokens and transfers the underlying to the liquidator.
+    /// @param account_address The liquidator account address
+    /// @param collateral_reserve The data of the collateral reserve
+    /// @param params The additional parameters needed to execute the liquidation function
+    /// @param vars The liquidation_call() function local vars
+    fun burn_collateral_a_tokens(
+        account_address: address,
+        collateral_reserve: &mut ReserveData,
+        params: &ExecuteLiquidationCallParams,
+        vars: &LiquidationCallLocalVars
+    ) {
+        let collateral_reserve_cache = pool::cache(collateral_reserve);
+        // update pool state
+        pool::update_state(
+            params.collateral_asset, collateral_reserve, &mut collateral_reserve_cache
+        );
+
+        // update pool interest rates
+        pool::update_interest_rates(
+            collateral_reserve,
+            &collateral_reserve_cache,
+            params.collateral_asset,
+            0,
+            vars.actual_collateral_to_liquidate
+        );
+
+        // Burn the equivalent amount of aToken, sending the underlying to the liquidator
+        a_token_factory::burn(
+            params.user,
+            account_address,
+            vars.actual_collateral_to_liquidate,
+            pool::get_next_liquidity_index(&collateral_reserve_cache),
+            pool::get_a_token_address(&collateral_reserve_cache)
+        )
+    }
+
+    /// @notice Liquidates the user aTokens by transferring them to the liquidator.
+    /// @dev The function also checks the state of the liquidator and activates the aToken as collateral
+    /// as in standard transfers if the isolation mode constraints are respected.
+    /// @param account_address The liquidator account address
+    /// @param collateral_reserve The data of the collateral reserve
+    /// @param params The additional parameters needed to execute the liquidation function
+    /// @param vars The liquidation_call() function local vars
+    fun liquidate_a_tokens(
+        account_address: address,
+        collateral_reserve: &ReserveData,
+        params: &ExecuteLiquidationCallParams,
+        vars: &LiquidationCallLocalVars
+    ) {
+        let liquidator_previous_a_token_balance =
+            pool::a_token_balance_of(account_address, vars.collateral_a_token);
+
+        let underlying_asset =
+            a_token_factory::get_underlying_asset_address(vars.collateral_a_token);
+        let index = pool::get_reserve_normalized_income(underlying_asset);
+
+        a_token_factory::transfer_on_liquidation(
+            params.user,
+            account_address,
+            vars.actual_collateral_to_liquidate,
+            index,
+            vars.collateral_a_token
+        );
+
+        if (liquidator_previous_a_token_balance == 0) {
+            let liquidator_config = pool::get_user_configuration(account_address);
+            let reserve_config_map =
+                pool::get_reserve_configuration_by_reserve_data(collateral_reserve);
+            if (validation_logic::validate_automatic_use_as_collateral(
+                account_address,
+                &liquidator_config,
+                &reserve_config_map
+            )) {
+                user_config::set_using_as_collateral(
+                    &mut liquidator_config,
+                    (pool::get_reserve_id(collateral_reserve) as u256),
+                    true
+                );
+                pool::set_user_configuration(account_address, liquidator_config);
+
+                event::emit(
+                    ReserveUsedAsCollateralEnabled {
+                        reserve: params.collateral_asset,
+                        user: account_address
+                    }
+                );
+            };
+        }
+    }
+
+    /// @notice Burns the debt tokens of the user up to the amount being repaid by the liquidator.
+    /// @param debt_reserve_cache The reserve cache object of the debt reserve cache
+    /// @param params The additional parameters needed to execute the liquidation function
+    /// @param vars the liquidation_call() function local vars
+    fun burn_debt_tokens(
+        debt_reserve_cache: &mut ReserveCache,
+        params: &ExecuteLiquidationCallParams,
+        vars: &LiquidationCallLocalVars
+    ) {
+        let variable_debt_token_address =
+            pool::get_variable_debt_token_address(debt_reserve_cache);
+        let next_variable_borrow_index =
+            pool::get_next_variable_borrow_index(debt_reserve_cache);
+        if (vars.user_variable_debt >= vars.actual_debt_to_liquidate) {
+            variable_debt_token_factory::burn(
+                params.user,
+                vars.actual_debt_to_liquidate,
+                next_variable_borrow_index,
+                variable_debt_token_address
+            );
+            let next_scaled_variable_debt =
+                variable_debt_token_factory::scaled_total_supply(
+                    variable_debt_token_address
+                );
+            pool::set_next_scaled_variable_debt(
+                debt_reserve_cache,
+                next_scaled_variable_debt
+            );
+        } else {
+            // If the user doesn't have variable debt, no need to try to burn variable debt tokens
+            if (vars.user_variable_debt != 0) {
+                variable_debt_token_factory::burn(
+                    params.user,
+                    vars.user_variable_debt,
+                    next_variable_borrow_index,
+                    variable_debt_token_address
+                );
+                let next_scaled_variable_debt =
+                    variable_debt_token_factory::scaled_total_supply(
+                        variable_debt_token_address
+                    );
+                pool::set_next_scaled_variable_debt(
+                    debt_reserve_cache,
+                    next_scaled_variable_debt
+                );
+            }
+        }
+    }
+
+    /// @notice Calculates the total debt of the user and the actual amount to liquidate depending on the health factor
+    /// and corresponding close factor.
+    /// @dev If the Health Factor is below CLOSE_FACTOR_HF_THRESHOLD, the close factor is increased to MAX_LIQUIDATION_CLOSE_FACTOR
+    /// @param debt_reserve_cache The reserve cache object of the debt reserve cache
+    /// @param params The additional parameters needed to execute the liquidation function
+    /// @param health_factor The health factor of the position
+    /// @return The variable debt of the user
+    /// @return The total debt of the user
+    /// @return The actual debt to liquidate as a function of the closeFactor
+    fun calculate_debt(
+        debt_reserve_cache: &ReserveCache,
+        params: &ExecuteLiquidationCallParams,
+        health_factor: u256
+    ): (u256, u256, u256) {
+        let user_variable_debt =
+            pool::variable_debt_token_balance_of(
+                params.user,
+                pool::get_variable_debt_token_address(debt_reserve_cache)
+            );
+        let user_total_debt = user_variable_debt;
+
+        let close_factor =
+            if (health_factor > CLOSE_FACTOR_HF_THRESHOLD) {
+                DEFAULT_LIQUIDATION_CLOSE_FACTOR
+            } else {
+                MAX_LIQUIDATION_CLOSE_FACTOR
+            };
+
+        let max_liquidatable_debt = math_utils::percent_mul(
+            user_total_debt, close_factor
+        );
+
+        let actual_debt_to_liquidate =
+            if (params.debt_to_cover > max_liquidatable_debt) {
+                max_liquidatable_debt
+            } else {
+                params.debt_to_cover
+            };
+
+        (user_variable_debt, user_total_debt, actual_debt_to_liquidate)
+    }
+
+    /// @notice Returns the configuration data for the debt and the collateral reserves.
+    /// @param collateral_reserve The data of the collateral reserve
+    /// @param params The additional parameters needed to execute the liquidation function
+    /// @return The collateral aToken
+    /// @return The address to use as price source for the collateral
+    /// @return The address to use as price source for the debt
+    /// @return The liquidation bonus to apply to the collateral
+    fun get_configuration_data(
+        collateral_reserve: &ReserveData, params: &ExecuteLiquidationCallParams
+    ): (address, address, address, u256) {
+        let collateral_a_token = pool::get_reserve_a_token_address(collateral_reserve);
+        let collateral_config_map =
+            pool::get_reserve_configuration_by_reserve_data(collateral_reserve);
+        let liquidation_bonus =
+            reserve_config::get_liquidation_bonus(&collateral_config_map);
+
+        let collateral_price_source = params.collateral_asset;
+        let debt_price_source = params.debt_asset;
+
+        if (params.user_emode_category != 0) {
+            let emode_category_data =
+                emode_logic::get_emode_category_data(params.user_emode_category);
+            let emode_price_source =
+                emode_logic::get_emode_category_price_source(&emode_category_data);
+
+            if (emode_logic::is_in_emode_category(
+                (params.user_emode_category as u256),
+                reserve_config::get_emode_category(&collateral_config_map)
+            )) {
+                liquidation_bonus = (
+                    emode_logic::get_emode_category_liquidation_bonus(
+                        &emode_category_data
+                    ) as u256
+                );
+                if (emode_price_source != @0x0) {
+                    collateral_price_source = emode_price_source;
+                };
+            };
+
+            // when in eMode, debt will always be in the same eMode category, can skip matching category check
+            if (emode_price_source != @0x0) {
+                debt_price_source = emode_price_source;
+            };
+        };
+        (
+            collateral_a_token,
+            collateral_price_source,
+            debt_price_source,
+            liquidation_bonus
+        )
+    }
+
+    struct AvailableCollateralToLiquidateLocalVars has drop {
+        collateral_price: u256,
+        debt_asset_price: u256,
+        max_collateral_to_liquidate: u256,
+        base_collateral: u256,
+        bonus_collateral: u256,
+        debt_asset_decimals: u256,
+        collateral_decimals: u256,
+        collateral_asset_unit: u256,
+        debt_asset_unit: u256,
+        collateral_amount: u256,
+        debt_amount_needed: u256,
+        liquidation_protocol_fee_percentage: u256,
+        liquidation_protocol_fee: u256
+    }
+
+    fun create_available_collateral_to_liquidate_local_vars():
+        AvailableCollateralToLiquidateLocalVars {
+        AvailableCollateralToLiquidateLocalVars {
+            collateral_price: 0,
+            debt_asset_price: 0,
+            max_collateral_to_liquidate: 0,
+            base_collateral: 0,
+            bonus_collateral: 0,
+            debt_asset_decimals: 0,
+            collateral_decimals: 0,
+            collateral_asset_unit: 0,
+            debt_asset_unit: 0,
+            collateral_amount: 0,
+            debt_amount_needed: 0,
+            liquidation_protocol_fee_percentage: 0,
+            liquidation_protocol_fee: 0
+        }
+    }
+
+    /// @notice Calculates how much of a specific collateral can be liquidated, given
+    /// a certain amount of debt asset.
+    /// @dev This function needs to be called after all the checks to validate the liquidation have been performed,
+    /// otherwise it might fail.
+    /// @param collateral_reserve The data of the collateral reserve
+    /// @param debt_reserve_cache The data of the debt reserve cache
+    /// @param collateral_asset The address of the underlying asset used as collateral, to receive as result of the liquidation
+    /// @param debt_asset The address of the underlying borrowed asset to be repaid with the liquidation
+    /// @param debt_to_cover The debt amount of borrowed `asset` the liquidator wants to cover
+    /// @param user_collateral_balance The collateral balance for the specific `collateralAsset` of the user being liquidated
+    /// @param liquidation_bonus The collateral bonus percentage to receive as result of the liquidation
+    /// @return The maximum amount that is possible to liquidate given all the liquidation constraints (user balance, close factor)
+    /// @return The amount to repay with the liquidation
+    /// @return The fee taken from the liquidation bonus amount to be paid to the protocol
+    fun calculate_available_collateral_to_liquidate(
+        collateral_reserve: &ReserveData,
+        debt_reserve_cache: &ReserveCache,
+        collateral_asset: address,
+        debt_asset: address,
+        debt_to_cover: u256,
+        user_collateral_balance: u256,
+        liquidation_bonus: u256
+    ): (u256, u256, u256) {
+        let vars = create_available_collateral_to_liquidate_local_vars();
+        // TODO Waiting for Chainlink oracle functionality
+        vars.collateral_price = oracle::get_asset_price(collateral_asset);
+        vars.debt_asset_price = oracle::get_asset_price(debt_asset);
+
+        let collateral_reserve_config =
+            pool::get_reserve_configuration_by_reserve_data(collateral_reserve);
+        vars.collateral_decimals = reserve_config::get_decimals(
+            &collateral_reserve_config
+        );
+
+        let debt_reserve_config =
+            pool::get_reserve_cache_configuration(debt_reserve_cache);
+        vars.debt_asset_decimals = reserve_config::get_decimals(&debt_reserve_config);
+
+        vars.collateral_asset_unit = math_utils::pow(10, vars.collateral_decimals);
+        vars.debt_asset_unit = math_utils::pow(10, vars.debt_asset_decimals);
+
+        vars.liquidation_protocol_fee_percentage = reserve_config::get_liquidation_protocol_fee(
+            &collateral_reserve_config
+        );
+
+        // This is the base collateral to liquidate based on the given debt to cover
+        vars.base_collateral = (
+            vars.debt_asset_price * debt_to_cover * vars.collateral_asset_unit
+        ) / (vars.collateral_price * vars.debt_asset_unit);
+
+        vars.max_collateral_to_liquidate = math_utils::percent_mul(
+            vars.base_collateral, liquidation_bonus
+        );
+
+        if (vars.max_collateral_to_liquidate > user_collateral_balance) {
+            vars.collateral_amount = user_collateral_balance;
+            vars.debt_amount_needed = math_utils::percent_div(
+                ((vars.collateral_price * vars.collateral_amount * vars.debt_asset_unit)
+                    / (vars.debt_asset_price * vars.collateral_asset_unit)),
+                liquidation_bonus
+            );
+        } else {
+            vars.collateral_amount = vars.max_collateral_to_liquidate;
+            vars.debt_amount_needed = debt_to_cover;
+        };
+
+        if (vars.liquidation_protocol_fee_percentage != 0) {
+            vars.bonus_collateral = vars.collateral_amount
+                - math_utils::percent_div(vars.collateral_amount, liquidation_bonus);
+
+            vars.liquidation_protocol_fee = math_utils::percent_mul(
+                vars.bonus_collateral,
+                vars.liquidation_protocol_fee_percentage
+            );
+
+            (
+                vars.collateral_amount - vars.liquidation_protocol_fee,
+                vars.debt_amount_needed,
+                vars.liquidation_protocol_fee
+            )
+        } else {
+            (vars.collateral_amount, vars.debt_amount_needed, 0)
+        }
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/supply_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/supply_logic.move
@@ -1,0 +1,394 @@
+module aave_pool::supply_logic {
+    use std::signer;
+    use aptos_framework::event;
+
+    use aave_config::error_config;
+    use aave_config::user_config;
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::emode_logic;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::pool;
+    use aave_pool::validation_logic;
+
+    friend aave_pool::user_logic;
+
+    #[event]
+    /// @dev Emitted on supply()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address initiating the supply
+    /// @param on_behalf_of The beneficiary of the supply, receiving the aTokens
+    /// @param amount The amount supplied
+    /// @param referral_code The referral code used
+    struct Supply has drop, copy, store {
+        reserve: address,
+        user: address,
+        on_behalf_of: address,
+        amount: u256,
+        referral_code: u16
+    }
+
+    #[event]
+    /// @dev Emitted on withdraw()
+    /// @param reserve The address of the underlying asset being withdrawn
+    /// @param user The address initiating the withdrawal, owner of aTokens
+    /// @param to The address that will receive the underlying
+    /// @param amount The amount to be withdrawn
+    struct Withdraw has drop, store {
+        reserve: address,
+        user: address,
+        to: address,
+        amount: u256
+    }
+
+    #[event]
+    /// @dev Emitted on supply(), finalize_transfer(), set_user_use_reserve_as_collateral()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address of the user enabling the usage as collateral
+    struct ReserveUsedAsCollateralEnabled has store, drop {
+        reserve: address,
+        user: address
+    }
+
+    #[event]
+    /// @dev Emitted on withdraw(), finalize_transfer(), set_user_use_reserve_as_collateral()
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param user The address of the user disabling the usage as collateral
+    struct ReserveUsedAsCollateralDisabled has store, drop {
+        reserve: address,
+        user: address
+    }
+
+    /// @notice Supplies an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+    /// - E.g. User supplies 100 USDC and gets in return 100 aUSDC
+    /// @param account The account signer that will supply the asset
+    /// @param asset The address of the underlying asset to supply
+    /// @param amount The amount to be supplied
+    /// @param on_behalf_of The address that will receive the aTokens, same as account address if the user
+    /// wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+    /// is a different wallet
+    /// @param referral_code Code used to register the integrator originating the operation, for potential rewards.
+    /// 0 if the action is executed directly by the user, without any middle-man
+    public entry fun supply(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        on_behalf_of: address,
+        referral_code: u16
+    ) {
+        let account_address = signer::address_of(account);
+        let reserve_data = pool::get_reserve_data(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        // update pool state
+        pool::update_state(asset, &mut reserve_data, &mut reserve_cache);
+
+        // validate supply
+        validation_logic::validate_supply(&reserve_cache, &reserve_data, amount);
+
+        // update interest rates
+        pool::update_interest_rates(
+            &mut reserve_data,
+            &reserve_cache,
+            asset,
+            amount,
+            0
+        );
+
+        let token_a_address = pool::get_a_token_address(&reserve_cache);
+        let a_token_resource_account =
+            a_token_factory::get_token_account_address(token_a_address);
+        // transfer the asset to the a_token address
+        fungible_asset_manager::transfer(
+            account,
+            a_token_resource_account,
+            (amount as u64),
+            asset
+        );
+
+        let is_first_supply =
+            a_token_factory::scaled_balance_of(on_behalf_of, token_a_address) == 0;
+        a_token_factory::mint(
+            account_address,
+            on_behalf_of,
+            amount,
+            pool::get_next_liquidity_index(&reserve_cache),
+            token_a_address
+        );
+
+        if (is_first_supply) {
+            let user_config_map = pool::get_user_configuration(on_behalf_of);
+            let reserve_config_map =
+                pool::get_reserve_cache_configuration(&reserve_cache);
+            if (validation_logic::validate_automatic_use_as_collateral(
+                account_address,
+                &user_config_map,
+                &reserve_config_map
+            )) {
+                user_config::set_using_as_collateral(
+                    &mut user_config_map,
+                    (pool::get_reserve_id(&reserve_data) as u256),
+                    true
+                );
+                pool::set_user_configuration(on_behalf_of, user_config_map);
+                event::emit(
+                    ReserveUsedAsCollateralEnabled { reserve: asset, user: on_behalf_of }
+                );
+            }
+        };
+        // Emit a supply event
+        event::emit(
+            Supply {
+                reserve: asset,
+                user: account_address,
+                on_behalf_of,
+                amount,
+                referral_code
+            }
+        );
+    }
+
+    /// @notice Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
+    /// E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
+    /// @param account The account signer that will withdraw the asset
+    /// @param asset The address of the underlying asset to withdraw
+    /// @param amount The underlying amount to be withdrawn
+    ///   - Send the value type(uint256).max in order to withdraw the whole aToken balance
+    /// @param to The address that will receive the underlying, same as account address if the user
+    ///   wants to receive it on his own wallet, or a different address if the beneficiary is a
+    ///   different wallet
+    public entry fun withdraw(
+        account: &signer,
+        asset: address,
+        amount: u256,
+        to: address
+    ) {
+        let account_address = signer::address_of(account);
+        let (reserve_data, reserves_count) =
+            pool::get_reserve_data_and_reserves_count(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+        // update pool state
+        pool::update_state(asset, &mut reserve_data, &mut reserve_cache);
+
+        let a_token_address = pool::get_a_token_address(&reserve_cache);
+        let user_balance =
+            wad_ray_math::ray_mul(
+                a_token_factory::scaled_balance_of(account_address, a_token_address),
+                pool::get_next_liquidity_index(&reserve_cache)
+            );
+        let amount_to_withdraw = amount;
+        if (amount == math_utils::u256_max()) {
+            amount_to_withdraw = user_balance;
+        };
+
+        // validate withdraw
+        validation_logic::validate_withdraw(
+            &reserve_cache, amount_to_withdraw, user_balance
+        );
+
+        // update interest rates
+        pool::update_interest_rates(
+            &mut reserve_data,
+            &reserve_cache,
+            asset,
+            0,
+            amount_to_withdraw
+        );
+
+        let user_config_map = pool::get_user_configuration(account_address);
+        let reserve_id = pool::get_reserve_id(&reserve_data);
+        let is_collateral =
+            user_config::is_using_as_collateral(&user_config_map, (reserve_id as u256));
+
+        if (is_collateral && amount_to_withdraw == user_balance) {
+            user_config::set_using_as_collateral(
+                &mut user_config_map,
+                (reserve_id as u256),
+                false
+            );
+            pool::set_user_configuration(account_address, user_config_map);
+
+            event::emit(
+                ReserveUsedAsCollateralDisabled { reserve: asset, user: account_address }
+            );
+        };
+
+        // burn a token
+        a_token_factory::burn(
+            account_address,
+            to,
+            amount_to_withdraw,
+            pool::get_next_liquidity_index(&reserve_cache),
+            a_token_address
+        );
+
+        if (is_collateral && user_config::is_borrowing_any(&user_config_map)) {
+            let user_emode_category = (emode_logic::get_user_emode(account_address) as u8);
+            let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+                emode_logic::get_emode_configuration(user_emode_category);
+            // validate health factor and ltv
+            validation_logic::validate_hf_and_ltv(
+                &user_config_map,
+                asset,
+                account_address,
+                reserves_count,
+                user_emode_category,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+        };
+        // Emit a withdraw event
+        event::emit(
+            Withdraw {
+                reserve: asset,
+                user: account_address,
+                to,
+                amount: amount_to_withdraw
+            }
+        );
+    }
+
+    /// @notice Validates and finalizes an aToken transfer
+    /// @dev Only callable by the overlying user_logic module of the `asset`
+    /// @param account The account signer that will finalize the transfer
+    /// @param asset The address of the underlying asset of the aToken
+    /// @param from The user from which the aTokens are transferred
+    /// @param to The user receiving the aTokens
+    /// @param amount The amount being transferred/withdrawn
+    /// @param balance_from_before The aToken balance of the `from` user before the transfer
+    /// @param balance_to_before The aToken balance of the `to` user before the transfer
+    public(friend) fun finalize_transfer(
+        account: &signer,
+        asset: address,
+        from: address,
+        to: address,
+        amount: u256,
+        balance_from_before: u256,
+        balance_to_before: u256
+    ) {
+        let account_address = signer::address_of(account);
+        let (reserve_data, reserves_count) =
+            pool::get_reserve_data_and_reserves_count(asset);
+        // validate transfer
+        validation_logic::validate_transfer(&reserve_data);
+
+        let reserve_id = (pool::get_reserve_id(&reserve_data) as u256);
+        if (from != to && amount != 0) {
+            let from_config = pool::get_user_configuration(from);
+            if (user_config::is_using_as_collateral(&from_config, reserve_id)) {
+                if (user_config::is_borrowing_any(&from_config)) {
+                    let user_emode_category = (emode_logic::get_user_emode(from) as u8);
+                    let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+                        emode_logic::get_emode_configuration(user_emode_category);
+
+                    validation_logic::validate_hf_and_ltv(
+                        &from_config,
+                        asset,
+                        from,
+                        reserves_count,
+                        user_emode_category,
+                        emode_ltv,
+                        emode_liq_threshold,
+                        emode_asset_price
+                    );
+                };
+
+                if (balance_from_before == amount) {
+                    user_config::set_using_as_collateral(
+                        &mut from_config, reserve_id, false
+                    );
+                    pool::set_user_configuration(from, from_config);
+                    event::emit(
+                        ReserveUsedAsCollateralDisabled { reserve: asset, user: from }
+                    );
+                }
+            };
+
+            if (balance_to_before == 0) {
+                let to_config = pool::get_user_configuration(to);
+                let reserve_config_map =
+                    pool::get_reserve_configuration_by_reserve_data(&reserve_data);
+                if (validation_logic::validate_automatic_use_as_collateral(
+                    account_address,
+                    &to_config,
+                    &reserve_config_map
+                )) {
+                    user_config::set_using_as_collateral(&mut to_config, reserve_id, true);
+                    pool::set_user_configuration(to, to_config);
+                    event::emit(
+                        ReserveUsedAsCollateralEnabled { reserve: asset, user: to }
+                    );
+                }
+            }
+        }
+    }
+
+    /// @notice Allows suppliers to enable/disable a specific supplied asset as collateral
+    /// @dev Emits the `ReserveUsedAsCollateralEnabled()` event if the asset can be activated as collateral.
+    /// @dev In case the asset is being deactivated as collateral, `ReserveUsedAsCollateralDisabled()` is emitted.
+    /// @param account The account signer that will enable/disable the usage of the asset as collateral
+    /// @param asset The address of the underlying asset supplied
+    /// @param use_as_collateral True if the user wants to use the supply as collateral, false otherwise
+    public entry fun set_user_use_reserve_as_collateral(
+        account: &signer, asset: address, use_as_collateral: bool
+    ) {
+        let account_address = signer::address_of(account);
+        let (reserve_data, reserves_count) =
+            pool::get_reserve_data_and_reserves_count(asset);
+        let reserve_cache = pool::cache(&reserve_data);
+
+        let user_balance =
+            pool::a_token_balance_of(
+                account_address,
+                pool::get_a_token_address(&reserve_cache)
+            );
+        // validate set use reserve as collateral
+        validation_logic::validate_set_use_reserve_as_collateral(
+            &reserve_cache, user_balance
+        );
+
+        let user_config_map = pool::get_user_configuration(account_address);
+        let reserve_id = (pool::get_reserve_id(&reserve_data) as u256);
+        if (use_as_collateral
+            == user_config::is_using_as_collateral(&user_config_map, reserve_id)) { return };
+
+        if (use_as_collateral) {
+            let reserve_config_map =
+                pool::get_reserve_cache_configuration(&reserve_cache);
+            assert!(
+                validation_logic::validate_use_as_collateral(
+                    &user_config_map, &reserve_config_map
+                ),
+                error_config::get_euser_in_isolation_mode_or_ltv_zero()
+            );
+            user_config::set_using_as_collateral(&mut user_config_map, reserve_id, true);
+            pool::set_user_configuration(account_address, user_config_map);
+            event::emit(
+                ReserveUsedAsCollateralEnabled { reserve: asset, user: account_address }
+            );
+        } else {
+            user_config::set_using_as_collateral(&mut user_config_map, reserve_id, false);
+            pool::set_user_configuration(account_address, user_config_map);
+            let user_emode_category = (emode_logic::get_user_emode(account_address) as u8);
+            let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+                emode_logic::get_emode_configuration(user_emode_category);
+
+            validation_logic::validate_hf_and_ltv(
+                &user_config_map,
+                asset,
+                account_address,
+                reserves_count,
+                user_emode_category,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+
+            event::emit(
+                ReserveUsedAsCollateralDisabled { reserve: asset, user: account_address }
+            );
+        }
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/user_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/user_logic.move
@@ -1,0 +1,131 @@
+module aave_pool::user_logic {
+
+    use std::signer;
+    use aptos_framework::event;
+
+    use aave_math::wad_ray_math;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::emode_logic;
+    use aave_pool::generic_logic;
+    use aave_pool::pool;
+    use aave_pool::supply_logic;
+    use aave_pool::token_base;
+
+    #[event]
+    /// @dev Emitted during the transfer action
+    /// @param from The user whose tokens are being transferred
+    /// @param to The recipient
+    /// @param value The scaled amount being transferred
+    /// @param index The next liquidity index of the reserve
+    struct BalanceTransfer has store, drop {
+        from: address,
+        to: address,
+        value: u256,
+        index: u256
+    }
+
+    /// @notice Transfers aTokens from the user to the recipient
+    /// @param account The account signer of the caller
+    /// @param to The recipient of the aTokens
+    /// @param amount The amount of aTokens to transfer
+    /// @param a_token_address The address of the aToken
+    public entry fun transfer_a_token(
+        account: &signer,
+        to: address,
+        amount: u256,
+        a_token_address: address
+    ) {
+        let account_address = signer::address_of(account);
+
+        let underlying_asset =
+            a_token_factory::get_underlying_asset_address(a_token_address);
+        let index = pool::get_reserve_normalized_income(underlying_asset);
+        let from_balance_before =
+            wad_ray_math::ray_mul(
+                a_token_factory::scaled_balance_of(account_address, a_token_address),
+                index
+            );
+        let to_balance_before =
+            wad_ray_math::ray_mul(
+                a_token_factory::scaled_balance_of(to, a_token_address),
+                index
+            );
+        token_base::transfer(
+            account_address,
+            to,
+            amount,
+            index,
+            a_token_address
+        );
+
+        // finalize transfer validate
+        supply_logic::finalize_transfer(
+            account,
+            underlying_asset,
+            account_address,
+            to,
+            amount,
+            from_balance_before,
+            to_balance_before
+        );
+
+        // send balance transfer event
+        event::emit(
+            BalanceTransfer {
+                from: account_address,
+                to,
+                value: wad_ray_math::ray_div(amount, index),
+                index
+            }
+        );
+    }
+
+    #[view]
+    /// @notice Returns the user account data across all the reserves
+    /// @param user The address of the user
+    /// @return total_collateral_base The total collateral of the user in the base currency used by the price feed
+    /// @return total_debt_base The total debt of the user in the base currency used by the price feed
+    /// @return available_borrows_base The borrowing power left of the user in the base currency used by the price feed
+    /// @return current_liquidation_threshold The liquidation threshold of the user
+    /// @return ltv The loan to value of The user
+    /// @return health_factor The current health factor of the user
+    public fun get_user_account_data(user: address): (u256, u256, u256, u256, u256, u256) {
+        let user_config_map = pool::get_user_configuration(user);
+        let reserves_count = pool::get_reserves_count();
+        let user_emode_category = (emode_logic::get_user_emode(user) as u8);
+        let (emode_ltv, emode_liq_threshold, emode_asset_price) =
+            emode_logic::get_emode_configuration(user_emode_category);
+        let (
+            total_collateral_base,
+            total_debt_base,
+            ltv,
+            current_liquidation_threshold,
+            health_factor,
+            _
+        ) =
+            generic_logic::calculate_user_account_data(
+                &user_config_map,
+                reserves_count,
+                user,
+                user_emode_category,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+
+        let available_borrows_base =
+            generic_logic::calculate_available_borrows(
+                total_collateral_base, total_debt_base, ltv
+            );
+
+        (
+            total_collateral_base,
+            total_debt_base,
+            available_borrows_base,
+            current_liquidation_threshold,
+            ltv,
+            health_factor
+        )
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-logic/validation_logic.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-logic/validation_logic.move
@@ -1,0 +1,638 @@
+module aave_pool::validation_logic {
+    use std::string;
+    use std::vector;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_config::reserve_config::{Self, ReserveConfigurationMap};
+    use aave_config::user_config::{Self, UserConfigurationMap};
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+    use aave_oracle::oracle;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::generic_logic;
+    use aave_pool::pool::{Self, ReserveCache, ReserveData};
+
+    /// @notice Validates a flashloan action.
+    /// @param reserves_data The data of all the reserves
+    /// @param assets The assets being flash-borrowed
+    /// @param amounts The amounts for each asset being borrowed
+    public fun validate_flashloan_complex(
+        reserves_data: &vector<ReserveData>,
+        assets: &vector<address>,
+        amounts: &vector<u256>,
+        interest_rate_modes: &vector<u8>
+    ) {
+        assert!(
+            vector::length(assets) == vector::length(amounts)
+                && vector::length(assets) == vector::length(interest_rate_modes),
+            error_config::get_einconsistent_flashloan_params()
+        );
+        for (i in 0..vector::length(assets)) {
+            validate_flashloan_simple(vector::borrow(reserves_data, i));
+        }
+    }
+
+    /// @notice Validates a flashloan action.
+    /// @param reserve_data The reserve data the reserve
+    public fun validate_flashloan_simple(reserve_data: &ReserveData) {
+        let reserve_configuration =
+            pool::get_reserve_configuration_by_reserve_data(reserve_data);
+        let (is_active, _, _, is_paused) =
+            reserve_config::get_flags(&reserve_configuration);
+        assert!(!is_paused, error_config::get_ereserve_paused());
+        assert!(is_active, error_config::get_ereserve_inactive());
+        let is_flashloan_enabled =
+            reserve_config::get_flash_loan_enabled(&reserve_configuration);
+        assert!(is_flashloan_enabled, error_config::get_eflashloan_disabled());
+    }
+
+    /// @notice Validates a supply action.
+    /// @param reserve_cache The reserve cache of the reserve
+    /// @param reserve_data The reserve data of the reserve
+    /// @param amount The amount to be supplied
+    public fun validate_supply(
+        reserve_cache: &ReserveCache, reserve_data: &ReserveData, amount: u256
+    ) {
+        assert!(amount != 0, error_config::get_einvalid_amount());
+
+        let reserve_configuration_map =
+            pool::get_reserve_cache_configuration(reserve_cache);
+        let (is_active, is_frozen, _, is_paused) =
+            reserve_config::get_flags(&reserve_configuration_map);
+
+        assert!(is_active, error_config::get_ereserve_inactive());
+        assert!(!is_paused, error_config::get_ereserve_paused());
+        assert!(!is_frozen, error_config::get_ereserve_frozen());
+
+        let supply_cap = reserve_config::get_supply_cap(&reserve_configuration_map);
+        let a_token_scaled_total_supply =
+            a_token_factory::scaled_total_supply(
+                pool::get_a_token_address(reserve_cache)
+            );
+
+        let total_supply_liquidity =
+            wad_ray_math::ray_mul(
+                (
+                    a_token_scaled_total_supply
+                        + pool::get_reserve_accrued_to_treasury(reserve_data)
+                ),
+                pool::get_next_liquidity_index(reserve_cache)
+            );
+
+        let total_supply = total_supply_liquidity + amount;
+        let max_supply_cap =
+            supply_cap
+                * (
+                    math_utils::pow(
+                        10,
+                        reserve_config::get_decimals(&reserve_configuration_map)
+                    )
+                );
+
+        assert!(
+            supply_cap == 0 || total_supply <= max_supply_cap,
+            error_config::get_esupply_cap_exceeded()
+        );
+    }
+
+    /// @notice Validates a withdraw action.
+    /// @param reserve_cache The reserve cache of the reserve
+    /// @param amount The amount to be withdrawn
+    /// @param user_balance The balance of the user
+    public fun validate_withdraw(
+        reserve_cache: &ReserveCache, amount: u256, user_balance: u256
+    ) {
+        assert!(amount != 0, error_config::get_einvalid_amount());
+        assert!(
+            amount <= user_balance,
+            error_config::get_enot_enough_available_user_balance()
+        );
+
+        let reserve_configuration_map =
+            pool::get_reserve_cache_configuration(reserve_cache);
+        let (is_active, _, _, is_paused) =
+            reserve_config::get_flags(&reserve_configuration_map);
+        assert!(is_active, error_config::get_ereserve_inactive());
+        assert!(!is_paused, error_config::get_ereserve_paused());
+    }
+
+    /// @notice Validates a transfer action.
+    /// @param reserve_data The reserve data the reserve
+    public fun validate_transfer(reserve_data: &ReserveData) {
+        let reserve_config_map =
+            pool::get_reserve_configuration_by_reserve_data(reserve_data);
+        assert!(
+            !reserve_config::get_paused(&reserve_config_map),
+            error_config::get_ereserve_paused()
+        )
+    }
+
+    /// @notice Validates the action of setting an asset as collateral.
+    /// @param reserve_cache The reserve cache of the reserve
+    /// @param user_balance The balance of the user
+    public fun validate_set_use_reserve_as_collateral(
+        reserve_cache: &ReserveCache, user_balance: u256
+    ) {
+        assert!(user_balance != 0, error_config::get_eunderlying_balance_zero());
+        let reserve_configuration_map =
+            pool::get_reserve_cache_configuration(reserve_cache);
+        let (is_active, _, _, is_paused) =
+            reserve_config::get_flags(&reserve_configuration_map);
+        assert!(is_active, error_config::get_ereserve_inactive());
+        assert!(!is_paused, error_config::get_ereserve_paused());
+    }
+
+    /**
+    * ----------------------------
+    * Borrow Validate
+    * ----------------------------
+    */
+    struct ValidateBorrowLocalVars has drop {
+        current_ltv: u256,
+        collateral_needed_in_base_currency: u256,
+        user_collateral_in_base_currency: u256,
+        user_debt_in_base_currency: u256,
+        available_liquidity: u256,
+        health_factor: u256,
+        total_debt: u256,
+        total_supply_variable_debt: u256,
+        reserve_decimals: u256,
+        borrow_cap: u256,
+        amount_in_base_currency: u256,
+        asset_unit: u256,
+        emode_price_source: address,
+        siloed_borrowing_address: address,
+        is_active: bool,
+        is_frozen: bool,
+        is_paused: bool,
+        borrowing_enabled: bool,
+        siloed_borrowing_enabled: bool
+    }
+
+    fun create_validate_borrow_local_vars(): ValidateBorrowLocalVars {
+        ValidateBorrowLocalVars {
+            current_ltv: 0,
+            collateral_needed_in_base_currency: 0,
+            user_collateral_in_base_currency: 0,
+            user_debt_in_base_currency: 0,
+            available_liquidity: 0,
+            health_factor: 0,
+            total_debt: 0,
+            total_supply_variable_debt: 0,
+            reserve_decimals: 0,
+            borrow_cap: 0,
+            amount_in_base_currency: 0,
+            asset_unit: 0,
+            emode_price_source: @0x0,
+            siloed_borrowing_address: @0x0,
+            is_active: false,
+            is_frozen: false,
+            is_paused: false,
+            borrowing_enabled: false,
+            siloed_borrowing_enabled: false
+        }
+    }
+
+    /// @notice Validates a borrow action.
+    /// @param reserve_cache The reserve cache of the reserve
+    /// @param user_config_map The UserConfigurationMap object
+    /// @param asset The address of the asset to be borrowed
+    /// @param user_address The address of the user
+    /// @param amount The amount to be borrowed
+    /// @param interest_rate_mode The interest rate mode
+    /// @param reserves_count The number of reserves
+    /// @param user_emode_category The user's eMode category
+    /// @param emode_ltv The eMode LTV
+    /// @param emode_liq_threshold The eMode liquidation threshold
+    /// @param emode_asset_price The eMode asset price
+    /// @param emode_source_price The eMode price source
+    /// @param isolation_mode_active The isolation mode state
+    /// @param isolation_mode_collateral_address The address of the collateral reserve in isolation mode
+    /// @param isolation_mode_debt_ceiling The debt ceiling in isolation mode
+    public fun validate_borrow(
+        reserve_cache: &ReserveCache,
+        user_config_map: &UserConfigurationMap,
+        asset: address,
+        user_address: address,
+        amount: u256,
+        interest_rate_mode: u8,
+        reserves_count: u256,
+        user_emode_category: u8,
+        emode_ltv: u256,
+        emode_liq_threshold: u256,
+        emode_asset_price: u256,
+        emode_source_price: address,
+        isolation_mode_active: bool,
+        isolation_mode_collateral_address: address,
+        isolation_mode_debt_ceiling: u256
+    ) {
+        assert!(amount != 0, error_config::get_einvalid_amount());
+        let vars = create_validate_borrow_local_vars();
+        let reserve_configuration_map =
+            pool::get_reserve_cache_configuration(reserve_cache);
+
+        let (is_active, is_frozen, borrowing_enabled, is_paused) =
+            reserve_config::get_flags(&reserve_configuration_map);
+
+        assert!(is_active, error_config::get_ereserve_inactive());
+        assert!(!is_paused, error_config::get_ereserve_paused());
+        assert!(!is_frozen, error_config::get_ereserve_frozen());
+        assert!(borrowing_enabled, error_config::get_eborrowing_not_enabled());
+
+        // validate interest rate mode
+        assert!(
+            interest_rate_mode == user_config::get_interest_rate_mode_variable(),
+            error_config::get_einvalid_interest_rate_mode_selected()
+        );
+        vars.reserve_decimals = reserve_config::get_decimals(&reserve_configuration_map);
+        vars.borrow_cap = reserve_config::get_borrow_cap(&reserve_configuration_map);
+        vars.asset_unit = math_utils::pow(10, vars.reserve_decimals);
+        if (vars.borrow_cap != 0) {
+            vars.total_supply_variable_debt = wad_ray_math::ray_mul(
+                pool::get_curr_scaled_variable_debt(reserve_cache),
+                pool::get_next_variable_borrow_index(reserve_cache)
+            );
+            vars.total_debt = vars.total_supply_variable_debt + amount;
+            assert!(
+                vars.total_debt <= vars.borrow_cap * vars.asset_unit,
+                error_config::get_eborrow_cap_exceeded()
+            );
+        };
+
+        if (isolation_mode_active) {
+            // check that the asset being borrowed is borrowable in isolation mode AND
+            // the total exposure is no bigger than the collateral debt ceiling
+            assert!(
+                reserve_config::get_borrowable_in_isolation(&reserve_configuration_map),
+                error_config::get_easset_not_borrowable_in_isolation()
+            );
+
+            let mode_collateral_reserve_data =
+                pool::get_reserve_data(isolation_mode_collateral_address);
+            let isolation_mode_total_debt =
+                (
+                    pool::get_reserve_isolation_mode_total_debt(
+                        &mode_collateral_reserve_data
+                    ) as u256
+                );
+            let total_debt =
+                isolation_mode_total_debt
+                    + (
+                        amount
+                            / math_utils::pow(
+                                10,
+                                (
+                                    vars.reserve_decimals
+                                        - reserve_config::get_debt_ceiling_decimals()
+                                )
+                            )
+                    );
+            assert!(
+                total_debt <= isolation_mode_debt_ceiling,
+                error_config::get_edebt_ceiling_exceeded()
+            );
+        };
+
+        if (user_emode_category != 0) {
+            assert!(
+                reserve_config::get_emode_category(&reserve_configuration_map)
+                    == (user_emode_category as u256),
+                error_config::get_einconsistent_emode_category()
+            );
+            vars.emode_price_source = emode_source_price;
+        };
+
+        let (
+            user_collateral_in_base_currency,
+            user_debt_in_base_currency,
+            current_ltv,
+            _,
+            health_factor,
+            _
+        ) =
+            generic_logic::calculate_user_account_data(
+                user_config_map,
+                reserves_count,
+                user_address,
+                user_emode_category,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+
+        vars.user_collateral_in_base_currency = user_collateral_in_base_currency;
+        vars.user_debt_in_base_currency = user_debt_in_base_currency;
+        vars.current_ltv = current_ltv;
+        vars.health_factor = health_factor;
+
+        assert!(
+            vars.user_collateral_in_base_currency != 0,
+            error_config::get_ecollateral_balance_is_zero()
+        );
+        assert!(vars.current_ltv != 0, error_config::get_eltv_validation_failed());
+        assert!(
+            vars.health_factor > user_config::get_health_factor_liquidation_threshold(),
+            error_config::get_ehealth_factor_lower_than_liquidation_threshold()
+        );
+
+        // Currently, custom oracle is not supported. Only a unified oracle is used. Therefore, the price is obtained by calling the oracle directly with the asset.
+        let asset_address =
+            if (vars.emode_price_source != @0x0) {
+                vars.emode_price_source
+            } else { asset };
+        vars.amount_in_base_currency = oracle::get_asset_price(asset_address) * amount;
+        vars.amount_in_base_currency = vars.amount_in_base_currency / vars.asset_unit;
+
+        //add the current already borrowed amount to the amount requested to calculate the total collateral needed.
+        vars.collateral_needed_in_base_currency = math_utils::percent_div(
+            (vars.user_debt_in_base_currency + vars.amount_in_base_currency),
+            vars.current_ltv //LTV is calculated in percentage
+        );
+
+        assert!(
+            vars.collateral_needed_in_base_currency
+                <= vars.user_collateral_in_base_currency,
+            error_config::get_ecollateral_cannot_cover_new_borrow()
+        );
+
+        if (user_config::is_borrowing_any(user_config_map)) {
+            let (siloed_borrowing_enabled, siloed_borrowing_address) =
+                pool::get_siloed_borrowing_state(user_address);
+
+            vars.siloed_borrowing_enabled = siloed_borrowing_enabled;
+            vars.siloed_borrowing_address = siloed_borrowing_address;
+
+            if (vars.siloed_borrowing_enabled) {
+                assert!(
+                    vars.siloed_borrowing_address == asset,
+                    error_config::get_esiloed_borrowing_violation()
+                )
+            } else {
+                assert!(
+                    !reserve_config::get_siloed_borrowing(&reserve_configuration_map),
+                    error_config::get_esiloed_borrowing_violation()
+                )
+            }
+        }
+    }
+
+    /// @notice Validates a repay action.
+    /// @param account_address The address of the user repaying the debt
+    /// @param reserve_cache The reserve cache of the reserve
+    /// @param amount_sent The amount sent for the repayment. Can be an actual value or uint(-1)
+    /// @param interest_rate_mode The interest rate mode of the debt being repaid
+    /// @param on_behalf_of The address of the user account_address is repaying for
+    /// @param variable_debt The borrow balance of the user
+    public fun validate_repay(
+        account_address: address,
+        reserve_cache: &ReserveCache,
+        amount_sent: u256,
+        interest_rate_mode: u8,
+        on_behalf_of: address,
+        variable_debt: u256
+    ) {
+        assert!(amount_sent != 0, error_config::get_einvalid_amount());
+        assert!(
+            amount_sent != math_utils::u256_max() || account_address == on_behalf_of,
+            error_config::get_eno_explicit_amount_to_repay_on_behalf()
+        );
+        let reserve_configuration = pool::get_reserve_cache_configuration(
+            reserve_cache
+        );
+        let (is_active, _, _, is_paused) =
+            reserve_config::get_flags(&reserve_configuration);
+        assert!(is_active, error_config::get_ereserve_inactive());
+        assert!(!is_paused, error_config::get_ereserve_paused());
+
+        assert!(
+            variable_debt != 0
+                && interest_rate_mode == user_config::get_interest_rate_mode_variable(),
+            error_config::get_eno_debt_of_selected_type()
+        );
+    }
+
+    /// @notice Validates the liquidation action.
+    /// @param user_config_map The user configuration mapping
+    /// @param collateral_reserve The reserve data of the collateral
+    /// @param debt_reserve_cache The reserve cache of the debt reserve
+    /// @param total_debt The total debt of the user
+    /// @param health_factor The health factor of the user
+    public fun validate_liquidation_call(
+        user_config_map: &UserConfigurationMap,
+        collateral_reserve: &ReserveData,
+        debt_reserve_cache: &ReserveCache,
+        total_debt: u256,
+        health_factor: u256
+    ) {
+        let collateral_reserve_config =
+            pool::get_reserve_configuration_by_reserve_data(collateral_reserve);
+        let (collateral_reserve_active, _, _, collateral_reserve_paused) =
+            reserve_config::get_flags(&collateral_reserve_config);
+
+        let debt_reserve_config =
+            pool::get_reserve_cache_configuration(debt_reserve_cache);
+        let (principal_reserve_active, _, _, principal_reserve_paused) =
+            reserve_config::get_flags(&debt_reserve_config);
+
+        assert!(
+            collateral_reserve_active && principal_reserve_active,
+            error_config::get_ereserve_inactive()
+        );
+        assert!(
+            !collateral_reserve_paused && !principal_reserve_paused,
+            error_config::get_ereserve_paused()
+        );
+
+        assert!(
+            health_factor
+                < user_config::get_minimum_health_factor_liquidation_threshold(),
+            error_config::get_ehealth_factor_lower_than_liquidation_threshold()
+        );
+
+        assert!(
+            health_factor < user_config::get_health_factor_liquidation_threshold(),
+            error_config::get_ehealth_factor_not_below_threshold()
+        );
+
+        let collateral_reserve_id = pool::get_reserve_id(collateral_reserve);
+        let is_collateral_enabled =
+            reserve_config::get_liquidation_threshold(&collateral_reserve_config) != 0
+                && user_config::is_using_as_collateral(
+                    user_config_map, (collateral_reserve_id as u256)
+                );
+
+        //if collateral isn't enabled as collateral by user, it cannot be liquidated
+        assert!(
+            is_collateral_enabled,
+            error_config::get_ecollateral_cannot_be_liquidated()
+        );
+        assert!(
+            total_debt != 0,
+            error_config::get_especified_currency_not_borrowed_by_user()
+        );
+    }
+
+    /// @notice Validates the health factor of a user and the ltv of the asset being withdrawn.
+    /// @param user_config_map the user configuration map
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param from The user from which the aTokens are being transferred
+    /// @param reserves_count The number of available reserves
+    /// @param user_emode_category The users active efficiency mode category
+    /// @param emode_ltv The ltv of the efficiency mode category
+    /// @param emode_liq_threshold The liquidation threshold of the efficiency mode category
+    /// @param emode_asset_price The price of the efficiency mode category
+    public fun validate_hf_and_ltv(
+        user_config_map: &UserConfigurationMap,
+        asset: address,
+        from: address,
+        reserves_count: u256,
+        user_emode_category: u8,
+        emode_ltv: u256,
+        emode_liq_threshold: u256,
+        emode_asset_price: u256
+    ) {
+        let reserve_data = pool::get_reserve_data(asset);
+        let (_, has_zero_ltv_collateral) =
+            validate_health_factor(
+                user_config_map,
+                from,
+                user_emode_category,
+                reserves_count,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+        let reserve_configuration_map =
+            pool::get_reserve_configuration_by_reserve_data(&reserve_data);
+        assert!(
+            !has_zero_ltv_collateral
+                || reserve_config::get_ltv(&reserve_configuration_map) == 0,
+            error_config::get_eltv_validation_failed()
+        );
+    }
+
+    /// @notice Validates if an asset should be automatically activated as collateral in the following actions: supply,
+    /// transfer, mint unbacked, and liquidate
+    /// @dev This is used to ensure that isolated assets are not enabled as collateral automatically
+    /// @param user_config_map the user configuration map
+    /// @param reserve_config_map The reserve configuration map
+    /// @return True if the asset can be activated as collateral, false otherwise
+    public fun validate_automatic_use_as_collateral(
+        account_address: address,
+        user_config_map: &UserConfigurationMap,
+        reserve_config_map: &ReserveConfigurationMap
+    ): bool {
+        if (reserve_config::get_debt_ceiling(reserve_config_map) != 0) {
+            // ensures only the ISOLATED_COLLATERAL_SUPPLIER_ROLE can enable collateral as side-effect of an action
+            if (!acl_manage::has_role(
+                string::utf8(user_config::get_isolated_collateral_supplier_role()),
+                account_address
+            )) {
+                return false
+            };
+        };
+
+        return validate_use_as_collateral(user_config_map, reserve_config_map)
+    }
+
+    /// @notice Validates the action of activating the asset as collateral.
+    /// @dev Only possible if the asset has non-zero LTV and the user is not in isolation mode
+    /// @param user_config_map the user configuration map
+    /// @param reserve_config_map The reserve configuration map
+    /// @return True if the asset can be activated as collateral, false otherwise
+    public fun validate_use_as_collateral(
+        user_config_map: &UserConfigurationMap,
+        reserve_config_map: &ReserveConfigurationMap
+    ): bool {
+        if (reserve_config::get_ltv(reserve_config_map) == 0) {
+            return false
+        };
+        if (!user_config::is_using_as_collateral_any(user_config_map)) {
+            return true
+        };
+
+        let (isolation_mode_active, _, _) =
+            pool::get_isolation_mode_state(user_config_map);
+
+        (
+            !isolation_mode_active
+                && reserve_config::get_debt_ceiling(reserve_config_map) == 0
+        )
+    }
+
+    /// @notice Validates the health factor of a user.
+    /// @param user_config_map the user configuration map
+    /// @param user The user to validate health factor of
+    /// @param user_emode_category The users active efficiency mode category
+    /// @param reserves_count The number of available reserves
+    /// @param emode_ltv The ltv of the efficiency mode category
+    /// @param emode_liq_threshold The liquidation threshold of the efficiency mode category
+    /// @param emode_asset_price The price of the efficiency mode category
+    public fun validate_health_factor(
+        user_config_map: &UserConfigurationMap,
+        user: address,
+        user_emode_category: u8,
+        reserves_count: u256,
+        emode_ltv: u256,
+        emode_liq_threshold: u256,
+        emode_asset_price: u256
+    ): (u256, bool) {
+        let (_, _, _, _, health_factor, has_zero_ltv_collateral) =
+            generic_logic::calculate_user_account_data(
+                user_config_map,
+                reserves_count,
+                user,
+                user_emode_category,
+                emode_ltv,
+                emode_liq_threshold,
+                emode_asset_price
+            );
+
+        assert!(
+            health_factor >= user_config::get_health_factor_liquidation_threshold(),
+            error_config::get_ehealth_factor_lower_than_liquidation_threshold()
+        );
+
+        (health_factor, has_zero_ltv_collateral)
+    }
+
+    /// @notice Validates the action of setting efficiency mode.
+    /// @param user_config_map the user configuration map
+    /// @param reserves_count The total number of valid reserves
+    /// @param category_id The id of the category
+    /// @param liquidation_threshold The liquidation threshold
+    public fun validate_set_user_emode(
+        user_config_map: &UserConfigurationMap,
+        reserves_count: u256,
+        category_id: u8,
+        liquidation_threshold: u16
+    ) {
+        // category is invalid if the liq threshold is not set
+        assert!(
+            category_id == 0 || liquidation_threshold != 0,
+            error_config::get_einconsistent_emode_category()
+        );
+
+        // eMode can always be enabled if the user hasn't supplied anything
+        if (!user_config::is_empty(user_config_map)) {
+            // if user is trying to set another category than default we require that
+            // either the user is not borrowing, or it's borrowing assets of category_id
+            if (category_id != 0) {
+                for (i in 0..reserves_count) {
+                    if (user_config::is_borrowing(user_config_map, i)) {
+                        let reserve_address = pool::get_reserve_address_by_id(i);
+                        let reserve_configuration =
+                            pool::get_reserve_configuration(reserve_address);
+                        assert!(
+                            reserve_config::get_emode_category(&reserve_configuration)
+                                == (category_id as u256),
+                            error_config::get_einconsistent_emode_category()
+                        );
+                    };
+                }
+            }
+        }
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-mocks/mock_underlying_token_factory.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-mocks/mock_underlying_token_factory.move
@@ -1,0 +1,250 @@
+module aave_pool::mock_underlying_token_factory {
+    use std::error;
+    use std::option::{Self, Option};
+    use std::signer;
+    use std::string::{Self, String};
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::fungible_asset::{Self, BurnRef, Metadata, MintRef, TransferRef};
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+
+    use aave_pool::token_base;
+
+    friend aave_pool::a_token_factory;
+    friend aave_pool::pool;
+    friend aave_pool::supply_logic;
+    friend aave_pool::borrow_logic;
+    friend aave_pool::liquidation_logic;
+    friend aave_pool::bridge_logic;
+    friend aave_pool::flashloan_logic;
+    friend aave_pool::transfer_strategy;
+    friend aave_pool::ecosystem_reserve_v2;
+
+    #[test_only]
+    friend aave_pool::mock_underlying_token_factory_tests;
+
+    /// Only fungible asset metadata owner can make changes.
+    const ENOT_OWNER: u64 = 1;
+    const E_TOKEN_ALREADY_EXISTS: u64 = 2;
+    const E_ACCOUNT_NOT_EXISTS: u64 = 3;
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Hold refs to control the minting, transfer and burning of fungible assets.
+    struct ManagedFungibleAsset has key {
+        mint_ref: MintRef,
+        transfer_ref: TransferRef,
+        burn_ref: BurnRef
+    }
+
+    /// mapping (underlying token address => bool)
+    struct CoinList has key {
+        value: SmartTable<address, bool>
+    }
+
+    fun init_module(signer: &signer) {
+        token_base::only_token_admin(signer);
+        move_to(signer, CoinList { value: smart_table::new() })
+    }
+
+    /// @notice Creates a new underlying token.
+    /// @param signer The signer of the transaction
+    /// @param name The name of the underlying token
+    /// @param symbol The symbol of the underlying token
+    /// @param decimals The decimals of the underlying token
+    /// @param icon_uri The icon URI of the underlying token
+    /// @param project_uri The project URI of the underlying token
+    public entry fun create_token(
+        signer: &signer,
+        maximum_supply: u128,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String
+    ) acquires CoinList {
+        only_token_admin(signer);
+        let token_metadata_address =
+            object::create_object_address(
+                &signer::address_of(signer),
+                *string::bytes(&symbol)
+            );
+        let coin_list = borrow_global_mut<CoinList>(@aave_pool);
+
+        assert!(
+            !smart_table::contains(&coin_list.value, token_metadata_address),
+            E_TOKEN_ALREADY_EXISTS
+        );
+
+        smart_table::add(&mut coin_list.value, token_metadata_address, true);
+
+        let max_supply =
+            if (maximum_supply != 0) {
+                option::some(maximum_supply)
+            } else {
+                option::none()
+            };
+
+        let constructor_ref =
+            &object::create_named_object(signer, *string::bytes(&symbol));
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor_ref,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            project_uri
+        );
+
+        // Create mint/burn/transfer refs to allow creator to manage the fungible asset.
+        let mint_ref = fungible_asset::generate_mint_ref(constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(constructor_ref);
+        let transfer_ref = fungible_asset::generate_transfer_ref(constructor_ref);
+        let metadata_object_signer = object::generate_signer(constructor_ref);
+
+        move_to(
+            &metadata_object_signer,
+            ManagedFungibleAsset { mint_ref, transfer_ref, burn_ref }
+        );
+    }
+
+    public fun assert_token_exists(token_metadata_address: address) acquires CoinList {
+        let coin_list = borrow_global<CoinList>(@aave_pool);
+        assert!(
+            smart_table::contains(&coin_list.value, token_metadata_address),
+            E_TOKEN_ALREADY_EXISTS
+        );
+    }
+
+    #[view]
+    public fun get_metadata_by_symbol(symbol: String): Object<Metadata> {
+        let metadata_address =
+            object::create_object_address(&@underlying_tokens, *string::bytes(&symbol));
+        object::address_to_object<Metadata>(metadata_address)
+    }
+
+    #[view]
+    public fun get_token_account_address(): address {
+        @underlying_tokens
+    }
+
+    /// Return the address of the managed fungible asset that's created when this module is deployed.
+    inline fun get_metadata(metadata_address: address): Object<Metadata> {
+        object::address_to_object<Metadata>(metadata_address)
+    }
+
+    /// Mint as the owner of metadata object.
+    public entry fun mint(
+        admin: &signer,
+        to: address,
+        amount: u64,
+        metadata_address: address
+    ) acquires ManagedFungibleAsset {
+        let asset = get_metadata(metadata_address);
+        let managed_fungible_asset = authorized_borrow_refs(admin, asset);
+        let to_wallet = primary_fungible_store::ensure_primary_store_exists(to, asset);
+        let fa = fungible_asset::mint(&managed_fungible_asset.mint_ref, amount);
+        fungible_asset::deposit_with_ref(
+            &managed_fungible_asset.transfer_ref, to_wallet, fa
+        );
+    }
+
+    // <:!:mint
+    public(friend) fun transfer_from(
+        from: address,
+        to: address,
+        amount: u64,
+        metadata_address: address
+    ) acquires ManagedFungibleAsset {
+        let asset = get_metadata(metadata_address);
+        let transfer_ref = &authorized_borrow_refs_without_permission(asset).transfer_ref;
+        let from_wallet = primary_fungible_store::primary_store(from, asset);
+        let to_wallet = primary_fungible_store::ensure_primary_store_exists(to, asset);
+        fungible_asset::transfer_with_ref(transfer_ref, from_wallet, to_wallet, amount);
+    }
+
+    /// Burn fungible assets as the owner of metadata object.
+    public(friend) fun burn(
+        from: address, amount: u64, metadata_address: address
+    ) acquires ManagedFungibleAsset {
+        let asset = get_metadata(metadata_address);
+        let burn_ref = &authorized_borrow_refs_without_permission(asset).burn_ref;
+        let from_wallet = primary_fungible_store::primary_store(from, asset);
+        fungible_asset::burn_from(burn_ref, from_wallet, amount);
+    }
+
+    #[view]
+    /// Get the current supply from the `metadata` object.
+    public fun supply(metadata_address: address): Option<u128> {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::supply(asset)
+    }
+
+    #[view]
+    /// Get the maximum supply from the `metadata` object.
+    public fun maximum(metadata_address: address): Option<u128> {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::maximum(asset)
+    }
+
+    #[view]
+    /// Get the name of the fungible asset from the `metadata` object.
+    public fun name(metadata_address: address): String {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::name(asset)
+    }
+
+    #[view]
+    /// Get the symbol of the fungible asset from the `metadata` object.
+    public fun symbol(metadata_address: address): String {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::symbol(asset)
+    }
+
+    #[view]
+    /// Get the decimals from the `metadata` object.
+    public fun decimals(metadata_address: address): u8 {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::decimals(asset)
+    }
+
+    #[view]
+    /// Get the balance of a given store.
+    public fun balance_of(owner: address, metadata_address: address): u64 {
+        let metadata = get_metadata(metadata_address);
+        primary_fungible_store::balance(owner, metadata)
+    }
+
+    #[view]
+    public fun token_address(symbol: String): address {
+        object::create_object_address(&@underlying_tokens, *string::bytes(&symbol))
+    }
+
+    /// Borrow the immutable reference of the refs of `metadata`.
+    /// This validates that the signer is the metadata object's owner.
+    inline fun authorized_borrow_refs(
+        owner: &signer, asset: Object<Metadata>
+    ): &ManagedFungibleAsset acquires ManagedFungibleAsset {
+        assert!(
+            object::is_owner(asset, signer::address_of(owner)),
+            error::permission_denied(ENOT_OWNER)
+        );
+
+        borrow_global<ManagedFungibleAsset>(object::object_address(&asset))
+    }
+
+    inline fun authorized_borrow_refs_without_permission(
+        asset: Object<Metadata>
+    ): &ManagedFungibleAsset acquires ManagedFungibleAsset {
+        borrow_global<ManagedFungibleAsset>(object::object_address(&asset))
+    }
+
+    fun only_token_admin(account: &signer) {
+        assert!(signer::address_of(account) == @underlying_tokens, ENOT_OWNER)
+    }
+
+    #[test_only]
+    public fun test_init_module(signer: &signer) {
+        init_module(signer);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/admin_controlled_ecosystem_reserve.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/admin_controlled_ecosystem_reserve.move
@@ -1,0 +1,321 @@
+module aave_pool::admin_controlled_ecosystem_reserve {
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aave_acl::acl_manage::{Self};
+    use aptos_framework::fungible_asset::{Self, Metadata, FungibleStore};
+    use aptos_framework::primary_fungible_store;
+    use std::signer;
+    use aptos_framework::object::{
+        Self,
+        Object,
+        ExtendRef as ObjExtendRef,
+        TransferRef as ObjectTransferRef
+    };
+    use aptos_framework::event;
+
+    const NOT_FUNDS_ADMIN: u64 = 1;
+
+    const REVISION: u256 = 2;
+
+    const ONLY_BY_FUNDS_ADMIN: u64 = 3;
+
+    const ADMIN_CONTROLLED_ECOSYSTEM_RESERVE: vector<u8> = b"ADMIN_CONTROLLED_ECOSYSTEM_RESERVE";
+
+    #[event]
+    struct NewFundsAdmin has store, drop {
+        funds_admin: address
+    }
+
+    struct AdminControlledEcosystemReserveData has key {
+        fungible_assets: SmartTable<Object<Metadata>, Object<FungibleStore>>,
+        extend_ref: ObjExtendRef,
+        transfer_ref: ObjectTransferRef,
+        funds_admin: address
+    }
+
+    public fun initialize(sender: &signer) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, ADMIN_CONTROLLED_ECOSYSTEM_RESERVE);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        move_to(
+            state_object_signer,
+            AdminControlledEcosystemReserveData {
+                fungible_assets: smart_table::new<Object<Metadata>, Object<FungibleStore>>(),
+                transfer_ref: object::generate_transfer_ref(state_object_constructor_ref),
+                extend_ref: object::generate_extend_ref(state_object_constructor_ref),
+                funds_admin: signer::address_of(sender)
+            }
+        );
+    }
+
+    public fun check_is_funds_admin(account: address) {
+        assert!(
+            acl_manage::is_admin_controlled_ecosystem_reserve_funds_admin(account),
+            NOT_FUNDS_ADMIN
+        );
+    }
+
+    public fun get_revision(): u256 {
+        REVISION
+    }
+
+    public fun get_funds_admin(): address acquires AdminControlledEcosystemReserveData {
+        let admin_controlled_ecosystem_reserve_data =
+            borrow_global_mut<AdminControlledEcosystemReserveData>(
+                admin_controlled_ecosystem_reserve_address()
+            );
+        let account = admin_controlled_ecosystem_reserve_data.funds_admin;
+        check_is_funds_admin(account);
+        account
+    }
+
+    #[view]
+    public fun admin_controlled_ecosystem_reserve_address(): address {
+        object::create_object_address(&@aave_pool, ADMIN_CONTROLLED_ECOSYSTEM_RESERVE)
+    }
+
+    #[view]
+    public fun admin_controlled_ecosystem_reserve_object():
+        Object<AdminControlledEcosystemReserveData> {
+        object::address_to_object<AdminControlledEcosystemReserveData>(
+            admin_controlled_ecosystem_reserve_address()
+        )
+    }
+
+    fun set_funds_admin_internal(
+        admin: &signer, account: address
+    ) acquires AdminControlledEcosystemReserveData {
+        let admin_controlled_ecosystem_reserve_data =
+            borrow_global_mut<AdminControlledEcosystemReserveData>(
+                admin_controlled_ecosystem_reserve_address()
+            );
+        acl_manage::remove_admin_controlled_ecosystem_reserve_funds_admin(
+            admin, admin_controlled_ecosystem_reserve_data.funds_admin
+        );
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(admin, account);
+        admin_controlled_ecosystem_reserve_data.funds_admin = account;
+
+        event::emit(NewFundsAdmin { funds_admin: account });
+    }
+
+    public fun transfer_out(
+        sender: &signer,
+        asset_metadata: Object<Metadata>,
+        receiver: address,
+        amount: u64
+    ) acquires AdminControlledEcosystemReserveData {
+        check_is_funds_admin(signer::address_of(sender));
+
+        let admin_controlled_ecosystem_reserve_data =
+            borrow_global_mut<AdminControlledEcosystemReserveData>(
+                admin_controlled_ecosystem_reserve_address()
+            );
+
+        if (smart_table::contains(
+            &admin_controlled_ecosystem_reserve_data.fungible_assets, asset_metadata
+        )) {
+            let collector_fungible_store =
+                smart_table::borrow(
+                    &admin_controlled_ecosystem_reserve_data.fungible_assets,
+                    asset_metadata
+                );
+            let collector_fungible_store_signer =
+                object::generate_signer_for_extending(
+                    &admin_controlled_ecosystem_reserve_data.extend_ref
+                );
+            let receiver_fungible_store =
+                primary_fungible_store::ensure_primary_store_exists(
+                    receiver, asset_metadata
+                );
+
+            fungible_asset::transfer(
+                &collector_fungible_store_signer,
+                *collector_fungible_store,
+                receiver_fungible_store,
+                amount
+            );
+        }
+    }
+
+    #[test_only]
+    use aave_pool::standard_token::{Self};
+    #[test_only]
+    use std::string::utf8;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test_only]
+    fun create_test_fa(creator: &signer): Object<Metadata> {
+        let test_symbol = b"TEST";
+        standard_token::initialize(
+            creator,
+            0,
+            utf8(b"Test Token"),
+            utf8(test_symbol),
+            8,
+            utf8(b"http://example.com/favicon.ico"),
+            utf8(b"http://example.com"),
+            vector[true, true, true],
+            @0x1,
+            false
+        );
+        let metadata_address =
+            object::create_object_address(&signer::address_of(creator), test_symbol);
+        object::address_to_object<Metadata>(metadata_address)
+    }
+
+    #[
+        test(
+            fa_creator = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222
+        )
+    ]
+    fun test_basic_flow(
+        fa_creator: &signer,
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer
+    ) acquires AdminControlledEcosystemReserveData {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        check_is_funds_admin(signer::address_of(acl_fund_admin));
+
+        // create test token
+        let metadata = create_test_fa(fa_creator);
+
+        // mint coins to user
+        let _creator_address = signer::address_of(fa_creator);
+        let user_address = signer::address_of(user_account);
+        standard_token::mint_to_primary_stores(
+            fa_creator,
+            metadata,
+            vector[user_address],
+            vector[100]
+        );
+        assert!(
+            primary_fungible_store::balance(user_address, metadata) == 100, TEST_SUCCESS
+        );
+
+        // user withdraws all fas he has
+        let fa =
+            standard_token::withdraw_from_primary_stores(
+                fa_creator,
+                metadata,
+                vector[user_address],
+                vector[100]
+            );
+        assert!(fungible_asset::amount(&fa) == 100, TEST_SUCCESS);
+
+        initialize(periphery_account);
+
+        let asset_metadata = fungible_asset::metadata_from_asset(&fa);
+
+        let admin_controlled_ecosystem_reserve_data =
+            borrow_global_mut<AdminControlledEcosystemReserveData>(
+                admin_controlled_ecosystem_reserve_address()
+            );
+
+        let asset_object_constructor_ref =
+            object::create_object(admin_controlled_ecosystem_reserve_address());
+        let collector_fungible_store =
+            fungible_asset::create_store(&asset_object_constructor_ref, asset_metadata);
+
+        fungible_asset::deposit(collector_fungible_store, fa);
+
+        smart_table::upsert(
+            &mut admin_controlled_ecosystem_reserve_data.fungible_assets,
+            asset_metadata,
+            collector_fungible_store
+        );
+
+        transfer_out(acl_fund_admin, metadata, user_address, 50);
+    }
+
+    #[
+        test(
+            fa_creator = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222
+        )
+    ]
+    fun test_set_funds_admin_internal(
+        fa_creator: &signer,
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer
+    ) acquires AdminControlledEcosystemReserveData {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        check_is_funds_admin(signer::address_of(acl_fund_admin));
+
+        // create test token
+        let metadata = create_test_fa(fa_creator);
+
+        // mint coins to user
+        let _creator_address = signer::address_of(fa_creator);
+        let user_address = signer::address_of(user_account);
+        standard_token::mint_to_primary_stores(
+            fa_creator,
+            metadata,
+            vector[user_address],
+            vector[100]
+        );
+        assert!(
+            primary_fungible_store::balance(user_address, metadata) == 100, TEST_SUCCESS
+        );
+
+        // user withdraws all fas he has
+        let fa =
+            standard_token::withdraw_from_primary_stores(
+                fa_creator,
+                metadata,
+                vector[user_address],
+                vector[100]
+            );
+        assert!(fungible_asset::amount(&fa) == 100, TEST_SUCCESS);
+
+        initialize(periphery_account);
+
+        let asset_metadata = fungible_asset::metadata_from_asset(&fa);
+
+        let admin_controlled_ecosystem_reserve_data =
+            borrow_global_mut<AdminControlledEcosystemReserveData>(
+                admin_controlled_ecosystem_reserve_address()
+            );
+
+        let asset_object_constructor_ref =
+            object::create_object(admin_controlled_ecosystem_reserve_address());
+        let collector_fungible_store =
+            fungible_asset::create_store(&asset_object_constructor_ref, asset_metadata);
+
+        fungible_asset::deposit(collector_fungible_store, fa);
+
+        smart_table::upsert(
+            &mut admin_controlled_ecosystem_reserve_data.fungible_assets,
+            asset_metadata,
+            collector_fungible_store
+        );
+
+        transfer_out(acl_fund_admin, metadata, user_address, 50);
+
+        set_funds_admin_internal(aave_role_super_admin, user_address);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/coin_migrator.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/coin_migrator.move
@@ -1,0 +1,107 @@
+module aave_pool::coin_migrator {
+    use std::signer;
+    use std::option;
+    use std::string::String;
+    use aptos_std::type_info::Self;
+    use aptos_framework::fungible_asset::Self;
+    use aptos_framework::primary_fungible_store;
+    use aptos_framework::object;
+    use aptos_framework::coin::{Self};
+    use aptos_framework::event;
+    use aave_config::error_config;
+
+    #[event]
+    struct CointToFaConvertion has store, drop {
+        user: address,
+        amount: u64,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        coin_address: address,
+        fa_address: address
+    }
+
+    #[event]
+    struct FaToCointConvertion has store, drop {
+        user: address,
+        amount: u64,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        coin_address: address,
+        fa_address: address
+    }
+
+    public entry fun coin_to_fa<CoinType>(account: &signer, amount: u64) {
+        assert!(
+            coin::balance<CoinType>(signer::address_of(account)) >= amount,
+            error_config::get_einsufficient_coins_to_wrap()
+        );
+        let coin_type = type_info::type_of<CoinType>();
+        let coin_to_wrap = coin::withdraw<CoinType>(account, amount);
+        let wrapped_fa = coin::coin_to_fungible_asset<CoinType>(coin_to_wrap);
+        let wrapped_fa_meta = fungible_asset::metadata_from_asset(&wrapped_fa);
+        let wrapped_fa_address = object::object_address(&wrapped_fa_meta);
+        let account_wallet =
+            primary_fungible_store::ensure_primary_store_exists(
+                signer::address_of(account), wrapped_fa_meta
+            );
+        fungible_asset::deposit(account_wallet, wrapped_fa);
+
+        event::emit(
+            CointToFaConvertion {
+                user: signer::address_of(account),
+                amount,
+                name: fungible_asset::name(wrapped_fa_meta),
+                symbol: fungible_asset::symbol(wrapped_fa_meta),
+                decimals: fungible_asset::decimals(wrapped_fa_meta),
+                coin_address: type_info::account_address(&coin_type),
+                fa_address: wrapped_fa_address
+            }
+        );
+    }
+
+    public entry fun fa_to_coin<CoinType>(user: &signer, amount: u64) {
+        let coin_type = type_info::type_of<CoinType>();
+        let wrapped_fa_meta = coin::paired_metadata<CoinType>();
+        assert!(
+            option::is_some(&wrapped_fa_meta),
+            error_config::get_eunmapped_coin_to_fa()
+        );
+        let wrapped_fa_meta = option::destroy_some(wrapped_fa_meta);
+        let user_fa_store =
+            primary_fungible_store::ensure_primary_store_exists(
+                signer::address_of(user), wrapped_fa_meta
+            );
+        assert!(
+            fungible_asset::balance(user_fa_store) >= amount,
+            error_config::get_einsufficient_fas_to_unwrap()
+        );
+        let wrapped_fa_address = object::object_address(&wrapped_fa_meta);
+        let withdrawn_coins = coin::withdraw<CoinType>(user, amount);
+        coin::deposit<CoinType>(signer::address_of(user), withdrawn_coins);
+
+        event::emit(
+            FaToCointConvertion {
+                user: signer::address_of(user),
+                amount,
+                name: fungible_asset::name(wrapped_fa_meta),
+                symbol: fungible_asset::symbol(wrapped_fa_meta),
+                decimals: fungible_asset::decimals(wrapped_fa_meta),
+                coin_address: type_info::account_address(&coin_type),
+                fa_address: wrapped_fa_address
+            }
+        );
+    }
+
+    #[view]
+    public fun get_fa_address<CoinType>(): address {
+        let wrapped_fa_meta = coin::paired_metadata<CoinType>();
+        assert!(
+            option::is_some(&wrapped_fa_meta),
+            error_config::get_eunmapped_coin_to_fa()
+        );
+        let wrapped_fa_meta = option::destroy_some(wrapped_fa_meta);
+        object::object_address(&wrapped_fa_meta)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/coin_wrapper.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/coin_wrapper.move
@@ -1,0 +1,210 @@
+module aave_pool::coin_wrapper {
+    use aptos_framework::account::{Self, SignerCapability};
+    use aptos_framework::aptos_account;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::fungible_asset::{Self, BurnRef, FungibleAsset, Metadata, MintRef};
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_std::string_utils;
+    use aptos_std::type_info;
+    use std::string::{Self, String};
+    use std::option;
+    use std::signer;
+    use aave_pool::package_manager;
+
+    const COIN_WRAPPER_NAME: vector<u8> = b"COIN_WRAPPER";
+
+    /// Stores the refs for a specific fungible asset wrapper for wrapping and unwrapping.
+    struct FungibleAssetData has store {
+        // Used during unwrapping to burn the internal fungible assets.
+        burn_ref: BurnRef,
+        // Reference to the metadata object.
+        metadata: Object<Metadata>,
+        // Used during wrapping to mint the internal fungible assets.
+        mint_ref: MintRef
+    }
+
+    /// The resource stored in the main resource account to track all the fungible asset wrappers.
+    /// This main resource account will also be the one holding all the deposited coins, each of which in a separate
+    /// CoinStore<CoinType> resource. See coin_wrapper.move in the Aptos Framework for more details.
+    struct WrapperAccount has key {
+        // The signer cap used to withdraw deposited coins from the main resource account during unwrapping so the
+        // coins can be returned to the end users.
+        signer_cap: SignerCapability,
+        // Map from an original coin type (represented as strings such as "0x1::aptos_coin::AptosCoin") to the
+        // corresponding fungible asset wrapper.
+        coin_to_fungible_asset: SmartTable<String, FungibleAssetData>,
+        // Map from a fungible asset wrapper to the original coin type.
+        fungible_asset_to_coin: SmartTable<Object<Metadata>, String>
+    }
+
+    /// Create the coin wrapper account to host all the deposited coins.
+    public entry fun initialize() {
+        if (is_initialized()) { return };
+
+        let signer = &package_manager::get_signer();
+        let (coin_wrapper_signer, signer_cap) =
+            account::create_resource_account(signer, COIN_WRAPPER_NAME);
+        package_manager::add_address(
+            string::utf8(COIN_WRAPPER_NAME), signer::address_of(&coin_wrapper_signer)
+        );
+        move_to(
+            &coin_wrapper_signer,
+            WrapperAccount {
+                signer_cap,
+                coin_to_fungible_asset: smart_table::new(),
+                fungible_asset_to_coin: smart_table::new()
+            }
+        );
+    }
+
+    #[view]
+    public fun is_initialized(): bool {
+        package_manager::address_exists(string::utf8(COIN_WRAPPER_NAME))
+    }
+
+    #[view]
+    /// Return the address of the resource account that stores all deposited coins.
+    public fun wrapper_address(): address {
+        package_manager::get_address(string::utf8(COIN_WRAPPER_NAME))
+    }
+
+    #[view]
+    /// Return whether a specific CoinType has a wrapper fungible asset. This is only the case if at least one wrap()
+    /// call has been made for that CoinType.
+    public fun is_supported<CoinType>(): bool acquires WrapperAccount {
+        let coin_type = type_info::type_name<CoinType>();
+        smart_table::contains(&wrapper_account().coin_to_fungible_asset, coin_type)
+    }
+
+    #[view]
+    /// Return true if the given fungible asset is a wrapper fungible asset.
+    public fun is_wrapper(metadata: Object<Metadata>): bool acquires WrapperAccount {
+        smart_table::contains(&wrapper_account().fungible_asset_to_coin, metadata)
+    }
+
+    #[view]
+    /// Return the original CoinType for a specific wrapper fungible asset. This errors out if there's no such wrapper.
+    public fun get_coin_type(metadata: Object<Metadata>): String acquires WrapperAccount {
+        *smart_table::borrow(&wrapper_account().fungible_asset_to_coin, metadata)
+    }
+
+    #[view]
+    /// Return the wrapper fungible asset for a specific CoinType. This errors out if there's no such wrapper.
+    public fun get_wrapper<CoinType>(): Object<Metadata> acquires WrapperAccount {
+        fungible_asset_data<CoinType>().metadata
+    }
+
+    #[view]
+    /// Return the original CoinType if the given fungible asset is a wrapper fungible asset. Otherwise, return the
+    /// given fungible asset itself, which means it's a native fungible asset (not wrapped).
+    /// The return value is a String such as "0x1::aptos_coin::AptosCoin" for an original coin or "0x12345" for a native
+    /// fungible asset.
+    public fun get_original(fungible_asset: Object<Metadata>): String acquires WrapperAccount {
+        if (is_wrapper(fungible_asset)) {
+            get_coin_type(fungible_asset)
+        } else {
+            format_fungible_asset(fungible_asset)
+        }
+    }
+
+    #[view]
+    /// Return the address string of a fungible asset (e.g. "0x1234").
+    public fun format_fungible_asset(fungible_asset: Object<Metadata>): String {
+        let fa_address = object::object_address(&fungible_asset);
+        // This will create "@0x123"
+        let fa_address_str = string_utils::to_string(&fa_address);
+        // We want to strip the prefix "@"
+        string::sub_string(&fa_address_str, 1, string::length(&fa_address_str))
+    }
+
+    /// Wrap the given coins into fungible asset. This will also create the fungible asset wrapper if it doesn't exist
+    /// yet. The coins will be deposited into the main resource account.
+    public(friend) fun wrap<CoinType>(coins: Coin<CoinType>): FungibleAsset acquires WrapperAccount {
+        // Ensure the corresponding fungible asset has already been created.
+        create_fungible_asset<CoinType>();
+
+        // Deposit coins into the main resource account and mint&return the wrapper fungible assets.
+        let amount = coin::value(&coins);
+        aptos_account::deposit_coins(wrapper_address(), coins);
+        let mint_ref = &fungible_asset_data<CoinType>().mint_ref;
+        fungible_asset::mint(mint_ref, amount)
+    }
+
+    /// Unwrap the given fungible asset into coins. This will burn the fungible asset and withdraw&return the coins from
+    /// the main resource account.
+    /// This errors out if the given fungible asset is not a wrapper fungible asset.
+    public(friend) fun unwrap<CoinType>(fa: FungibleAsset): Coin<CoinType> acquires WrapperAccount {
+        let amount = fungible_asset::amount(&fa);
+        let burn_ref = &fungible_asset_data<CoinType>().burn_ref;
+        fungible_asset::burn(burn_ref, fa);
+        let wrapper_signer =
+            &account::create_signer_with_capability(&wrapper_account().signer_cap);
+        coin::withdraw(wrapper_signer, amount)
+    }
+
+    /// Create the fungible asset wrapper for the given CoinType if it doesn't exist yet.
+    public(friend) fun create_fungible_asset<CoinType>(): Object<Metadata> acquires WrapperAccount {
+        let coin_type = type_info::type_name<CoinType>();
+        let wrapper_account = mut_wrapper_account();
+        let coin_to_fungible_asset = &mut wrapper_account.coin_to_fungible_asset;
+        let wrapper_signer =
+            &account::create_signer_with_capability(&wrapper_account.signer_cap);
+        if (!smart_table::contains(coin_to_fungible_asset, coin_type)) {
+            let metadata_constructor_ref =
+                &object::create_named_object(wrapper_signer, *string::bytes(&coin_type));
+            primary_fungible_store::create_primary_store_enabled_fungible_asset(
+                metadata_constructor_ref,
+                option::none(),
+                coin::name<CoinType>(),
+                coin::symbol<CoinType>(),
+                coin::decimals<CoinType>(),
+                string::utf8(b""),
+                string::utf8(b"")
+            );
+
+            let mint_ref = fungible_asset::generate_mint_ref(metadata_constructor_ref);
+            let burn_ref = fungible_asset::generate_burn_ref(metadata_constructor_ref);
+            let metadata =
+                object::object_from_constructor_ref<Metadata>(metadata_constructor_ref);
+            smart_table::add(
+                coin_to_fungible_asset,
+                coin_type,
+                FungibleAssetData { metadata, mint_ref, burn_ref }
+            );
+            smart_table::add(
+                &mut wrapper_account.fungible_asset_to_coin, metadata, coin_type
+            );
+        };
+        smart_table::borrow(coin_to_fungible_asset, coin_type).metadata
+    }
+
+    inline fun fungible_asset_data<CoinType>(): &FungibleAssetData acquires WrapperAccount {
+        let coin_type = type_info::type_name<CoinType>();
+        smart_table::borrow(&wrapper_account().coin_to_fungible_asset, coin_type)
+    }
+
+    inline fun wrapper_account(): &WrapperAccount acquires WrapperAccount {
+        borrow_global<WrapperAccount>(wrapper_address())
+    }
+
+    inline fun mut_wrapper_account(): &mut WrapperAccount acquires WrapperAccount {
+        borrow_global_mut<WrapperAccount>(wrapper_address())
+    }
+
+    #[test_only]
+    public fun test_wrap<CoinType>(coins: Coin<CoinType>): FungibleAsset acquires WrapperAccount {
+        wrap(coins)
+    }
+
+    #[test_only]
+    public fun test_unwrap<CoinType>(fa: FungibleAsset): Coin<CoinType> acquires WrapperAccount {
+        unwrap(fa)
+    }
+
+    #[test_only]
+    public fun test_get_original(fungible_asset: Object<Metadata>): String acquires WrapperAccount {
+        get_original(fungible_asset)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/collector.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/collector.move
@@ -1,0 +1,167 @@
+module aave_pool::collector {
+    use aptos_framework::fungible_asset::{Self, Metadata, FungibleStore, FungibleAsset};
+    use aptos_framework::object::{
+        Self,
+        Object,
+        ObjectGroup,
+        ExtendRef as ObjExtendRef,
+        TransferRef as ObjectTransferRef
+    };
+    use aptos_framework::primary_fungible_store;
+    use aave_acl::acl_manage::{Self};
+    use aptos_std::smart_table::{Self, SmartTable};
+    use std::signer;
+
+    // Not an asset listing or a pool admin error
+    const NOT_FUNDS_ADMIN: u64 = 1;
+    /// Only fungible asset metadata owner can make changes.
+    const ERR_NOT_OWNER: u64 = 1;
+    /// Contract revision
+    const REVISION: u64 = 1;
+    /// Collector name
+    const COLLECTOR_NAME: vector<u8> = b"AAVE_COLLECTOR";
+
+    // mapping between metadata address - secondary fungible store for that asset
+    #[resource_group_member(group = ObjectGroup)]
+    struct CollectorData has key {
+        // this smart table only keeps track of objects references (does not store them)
+        fungible_assets: SmartTable<Object<Metadata>, Object<FungibleStore>>,
+        extend_ref: ObjExtendRef,
+        transfer_ref: ObjectTransferRef
+    }
+
+    fun is_funds_admin(account: address) {
+        assert!(check_is_funds_admin(account), NOT_FUNDS_ADMIN);
+    }
+
+    #[view]
+    public fun check_is_funds_admin(account: address): bool {
+        acl_manage::is_funds_admin(account)
+    }
+
+    /// Initialize metadata object and store the refs specified by `ref_flags`.
+    fun init_module(sender: &signer) {
+        // 1, create the object and a generate a signer
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, COLLECTOR_NAME);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        // 2. move the resources into it, incl. the references
+        move_to(
+            state_object_signer,
+            CollectorData {
+                fungible_assets: smart_table::new<Object<Metadata>, Object<FungibleStore>>(),
+                transfer_ref: object::generate_transfer_ref(state_object_constructor_ref),
+                extend_ref: object::generate_extend_ref(state_object_constructor_ref)
+            }
+        );
+    }
+
+    #[test_only]
+    public fun init_module_test(sender: &signer) {
+        init_module(sender);
+    }
+
+    #[view]
+    /// Return the revision of the aave token implementation
+    public fun get_revision(): u64 {
+        REVISION
+    }
+
+    #[view]
+    public fun collector_address(): address {
+        object::create_object_address(&@aave_pool, COLLECTOR_NAME)
+    }
+
+    #[view]
+    public fun collector_object(): Object<CollectorData> {
+        object::address_to_object<CollectorData>(collector_address())
+    }
+
+    fun generate_secondary_collector_fungible_store(
+        asset_metadata: Object<Metadata>
+    ): Object<FungibleStore> {
+        let asset_object_constructor_ref = object::create_object(collector_address()); // make the collector address be the owner
+        let collector_fungible_store =
+            fungible_asset::create_store(&asset_object_constructor_ref, asset_metadata);
+        collector_fungible_store
+    }
+
+    public fun deposit(sender: &signer, fa: FungibleAsset) acquires CollectorData {
+        // check sender is the fund admin
+        is_funds_admin(signer::address_of(sender));
+
+        let asset_metadata = fungible_asset::metadata_from_asset(&fa);
+        // get mutably the resource CollectorData stored inside the named object
+        let collector_data = borrow_global_mut<CollectorData>(collector_address());
+
+        if (!smart_table::contains(&collector_data.fungible_assets, asset_metadata)) {
+            // create fungible store (object) with the collector being its address(owner)
+            let collector_fungible_store =
+                generate_secondary_collector_fungible_store(asset_metadata);
+
+            // deposit the fa
+            fungible_asset::deposit(collector_fungible_store, fa);
+
+            // update the resource
+            smart_table::upsert(
+                &mut collector_data.fungible_assets,
+                asset_metadata,
+                collector_fungible_store
+            );
+        } else {
+            let collector_fungible_store =
+                smart_table::borrow(&collector_data.fungible_assets, asset_metadata);
+            fungible_asset::deposit(*collector_fungible_store, fa);
+        }
+    }
+
+    public fun withdraw(
+        sender: &signer,
+        asset_metadata: Object<Metadata>,
+        receiver: address,
+        amount: u64
+    ) acquires CollectorData {
+        // check sender is the fund admin
+        is_funds_admin(signer::address_of(sender));
+
+        // borrow the global collector data
+        let collector_data = borrow_global_mut<CollectorData>(collector_address());
+
+        // check if we have a secondary fungible store for the asset, if now, throw an error
+        if (smart_table::contains(&collector_data.fungible_assets, asset_metadata)) {
+            let collector_fungible_store =
+                smart_table::borrow(&collector_data.fungible_assets, asset_metadata);
+            let collector_fungible_store_signer =
+                object::generate_signer_for_extending(&collector_data.extend_ref);
+            let receiver_fungible_store =
+                primary_fungible_store::ensure_primary_store_exists(
+                    receiver, asset_metadata
+                );
+
+            // transfer the amount from the collector's sec store to the receiver's store using the collectors signer which is also the owner of the sec.store
+            fungible_asset::transfer(
+                &collector_fungible_store_signer,
+                *collector_fungible_store,
+                receiver_fungible_store,
+                amount
+            );
+        }
+    }
+
+    #[view]
+    public fun get_collected_fees(asset_metadata: Object<Metadata>): u64 acquires CollectorData {
+        // get mutably the resource CollectorData stored inside the named object
+        let collector_data = borrow_global<CollectorData>(collector_address());
+        if (smart_table::contains(&collector_data.fungible_assets, asset_metadata)) {
+            let collector_fungible_store =
+                smart_table::borrow(&collector_data.fungible_assets, asset_metadata);
+            fungible_asset::balance<FungibleStore>(*collector_fungible_store)
+        } else { 0 }
+    }
+
+    #[test_only]
+    public fun get_collector_name(): vector<u8> {
+        COLLECTOR_NAME
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/eac_aggregator_proxy.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/eac_aggregator_proxy.move
@@ -1,0 +1,93 @@
+module aave_pool::eac_aggregator_proxy {
+    struct MockEacAggregatorProxy has key, drop, store, copy {}
+
+    #[event]
+    struct AnswerUpdated has store, drop {
+        current: u256,
+        round_id: u256,
+        timestamp: u256
+    }
+
+    #[event]
+    struct NewRound has store, drop {
+        round_id: u256,
+        started_by: address
+    }
+
+    public fun decimals(): u8 {
+        0
+    }
+
+    public fun latest_answer(): u256 {
+        0
+    }
+
+    fun latest_timestamp(): u256 {
+        0
+    }
+
+    fun latest_round(): u256 {
+        0
+    }
+
+    fun get_answer(_round_id: u256): u256 {
+        0
+    }
+
+    fun get_timestamp(_round_id: u256): u256 {
+        0
+    }
+
+    public fun create_eac_aggregator_proxy(): MockEacAggregatorProxy {
+        MockEacAggregatorProxy {}
+    }
+
+    #[test_only]
+    const TEST_SUCCESS: u64 = 1;
+    #[test_only]
+    const TEST_FAILED: u64 = 2;
+
+    #[test()]
+    fun test_decimals() {
+        // check the decimals which should now be 0
+        assert!(decimals() == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_latest_answer() {
+        // check the latest_answer which should now be 0
+        assert!(latest_answer() == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_latest_timestamp() {
+        // check the latest_timestamp which should now be 0
+        assert!(latest_timestamp() == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_latest_round() {
+        // check the latest_round which should now be 0
+        assert!(latest_round() == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_get_answer() {
+        let round_id = 0;
+        // check the get_answer which should now be 0
+        assert!(get_answer(round_id) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_get_timestamp() {
+        let round_id = 0;
+        // check the get_timestamp which should now be 0
+        assert!(get_timestamp(round_id) == 0, TEST_SUCCESS);
+    }
+
+    #[test()]
+    fun test_create_eac_aggregator_proxy() {
+        // check the create_eac_aggregator_proxy which should now return MockEacAggregatorProxy {}
+        assert!(create_eac_aggregator_proxy() == MockEacAggregatorProxy {}, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/ecosystem_reserve_v2.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/ecosystem_reserve_v2.move
@@ -1,0 +1,909 @@
+module aave_pool::ecosystem_reserve_v2 {
+    use std::signer;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::event;
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::timestamp;
+
+    use aave_acl::acl_manage::Self;
+
+    use aave_pool::admin_controlled_ecosystem_reserve::check_is_funds_admin;
+    use aave_pool::stream::{Self, Stream};
+
+    #[test_only]
+    use aptos_framework::timestamp::fast_forward_seconds;
+    #[test_only]
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    const EROLE_NOT_EXISTS: u64 = 1;
+    const ESTREAM_NOT_EXISTS: u64 = 2;
+    const NOT_FUNDS_ADMIN: u64 = 3;
+    const ESTREAM_TO_THE_CONTRACT_ITSELF: u64 = 4;
+    const ESTREAM_TO_THE_CALLER: u64 = 5;
+    const EDEPOSIT_IS_ZERO: u64 = 6;
+    const ESTART_TIME_BEFORE_BLOCK_TIMESTAMP: u64 = 7;
+    const ESTOP_TIME_BEFORE_THE_START_TIME: u64 = 8;
+    const EDEPOSIT_SMALLER_THAN_TIME_DELTA: u64 = 9;
+    const EDEPOSIT_NOT_MULTIPLE_OF_TIME_DELTA: u64 = 10;
+    const EAMOUNT_IS_ZERO: u64 = 11;
+    const EAMOUNT_EXCEEDS_THE_AVAILABLE_BALANCE: u64 = 12;
+
+    const ECOSYSTEM_RESERVE_V2_NAME: vector<u8> = b"AAVE_ECOSYSTEM_RESERVE_V2";
+
+    struct EcosystemReserveV2Data has key {
+        next_stream_id: u256,
+        streams: SmartTable<u256, Stream>
+    }
+
+    #[event]
+    struct CreateStream has store, drop {
+        stream_id: u256,
+        sender: address,
+        recipient: address,
+        deposit: u256,
+        token_address: address,
+        start_time: u256,
+        stop_time: u256
+    }
+
+    #[event]
+    struct WithdrawFromStream has store, drop {
+        stream_id: u256,
+        recipient: address,
+        amount: u256
+    }
+
+    #[event]
+    struct CancelStream has store, drop {
+        stream_id: u256,
+        sender: address,
+        recipient: address,
+        sender_balance: u256,
+        recipient_balance: u256
+    }
+
+    fun only_admin_or_recipient(account: address, stream_id: u256) acquires EcosystemReserveV2Data {
+        assert!(
+            acl_manage::is_funds_admin(account) || is_recipient(account, stream_id),
+            NOT_FUNDS_ADMIN
+        );
+    }
+
+    fun is_recipient(account: address, stream_id: u256): bool acquires EcosystemReserveV2Data {
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+
+        if (!smart_table::contains(&ecosystem_reserve_v2_data.streams, stream_id)) {
+            return false
+        };
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+        let recipient = stream::recipient(stream_item);
+
+        recipient != account
+    }
+
+    fun stream_exists(stream_id: u256) acquires EcosystemReserveV2Data {
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+
+        assert!(
+            smart_table::contains(&ecosystem_reserve_v2_data.streams, stream_id),
+            ESTREAM_NOT_EXISTS
+        );
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+        assert!(stream::is_entity(stream_item), ESTREAM_NOT_EXISTS);
+    }
+
+    fun get_next_stream_id(): u256 acquires EcosystemReserveV2Data {
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+        ecosystem_reserve_v2_data.next_stream_id
+    }
+
+    public fun initialize(sender: &signer) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, ECOSYSTEM_RESERVE_V2_NAME);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        move_to(
+            state_object_signer,
+            EcosystemReserveV2Data {
+                streams: smart_table::new<u256, Stream>(),
+                next_stream_id: 1
+            }
+        );
+    }
+
+    #[view]
+    public fun ecosystem_reserve_v2_data_address(): address {
+        object::create_object_address(&@aave_pool, ECOSYSTEM_RESERVE_V2_NAME)
+    }
+
+    #[view]
+    public fun ecosystem_reserve_v2_data_object(): Object<EcosystemReserveV2Data> {
+        object::address_to_object<EcosystemReserveV2Data>(
+            ecosystem_reserve_v2_data_address()
+        )
+    }
+
+    fun get_stream(
+        stream_id: u256
+    ): (address, address, u256, address, u256, u256, u256, u256) acquires EcosystemReserveV2Data {
+        stream_exists(stream_id);
+
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+        stream::get_stream(stream_item)
+    }
+
+    #[view]
+    public fun delta_of(stream_id: u256): u256 acquires EcosystemReserveV2Data {
+        stream_exists(stream_id);
+
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+
+        let (_, _, _, _, start_time, stop_time, _, _) = stream::get_stream(stream_item);
+
+        let now = (timestamp::now_seconds() as u256);
+
+        if (now <= start_time) {
+            return 0
+        };
+
+        if (now < stop_time) {
+            return now - start_time
+        };
+        stop_time - start_time
+    }
+
+    public fun balance_of(stream_id: u256, who: address): u256 acquires EcosystemReserveV2Data {
+        stream_exists(stream_id);
+
+        let delta = delta_of(stream_id);
+
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+
+        let (sender, recipient, deposit, _, _, _, remaining_balance, rate_per_second) =
+            stream::get_stream(stream_item);
+
+        let recipient_balance = delta * rate_per_second;
+
+        if (deposit > remaining_balance) {
+            let withdrawal_amount = deposit - remaining_balance;
+            recipient_balance = recipient_balance - withdrawal_amount;
+        };
+
+        if (who == recipient) {
+            return recipient_balance
+        };
+
+        if (who == sender) {
+            let sender_balance = remaining_balance - recipient_balance;
+            return sender_balance
+        };
+        0
+    }
+
+    fun create_stream(
+        sender: &signer,
+        recipient: address,
+        deposit: u256,
+        token_address: address,
+        start_time: u256,
+        stop_time: u256
+    ): u256 acquires EcosystemReserveV2Data {
+        check_is_funds_admin(signer::address_of(sender));
+
+        assert!(
+            recipient != ecosystem_reserve_v2_data_address(),
+            ESTREAM_TO_THE_CONTRACT_ITSELF
+        );
+        assert!(recipient != signer::address_of(sender), ESTREAM_TO_THE_CALLER);
+        assert!(deposit > 0, EDEPOSIT_IS_ZERO);
+        let now = (timestamp::now_seconds() as u256);
+        assert!(start_time >= now, ESTART_TIME_BEFORE_BLOCK_TIMESTAMP);
+        assert!(stop_time > start_time, ESTOP_TIME_BEFORE_THE_START_TIME);
+
+        let duration = stop_time - start_time;
+
+        assert!(deposit >= duration, EDEPOSIT_SMALLER_THAN_TIME_DELTA);
+
+        assert!(
+            deposit % duration == 0,
+            EDEPOSIT_NOT_MULTIPLE_OF_TIME_DELTA
+        );
+
+        let rate_per_second = deposit / duration;
+
+        let stream_id = get_next_stream_id();
+
+        let ecosystem_reserve_v2_data =
+            borrow_global_mut<EcosystemReserveV2Data>(
+                ecosystem_reserve_v2_data_address()
+            );
+        let stream_item =
+            stream::create_stream(
+                deposit,
+                rate_per_second,
+                deposit,
+                start_time,
+                stop_time,
+                recipient,
+                signer::address_of(sender),
+                token_address,
+                true
+            );
+
+        smart_table::upsert(
+            &mut ecosystem_reserve_v2_data.streams, stream_id, stream_item
+        );
+
+        ecosystem_reserve_v2_data.next_stream_id = ecosystem_reserve_v2_data.next_stream_id
+            + 1;
+
+        event::emit(
+            CreateStream {
+                stream_id,
+                sender: signer::address_of(sender),
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            }
+        );
+
+        stream_id
+    }
+
+    fun withdraw_from_stream(
+        sender: &signer, stream_id: u256, amount: u256
+    ): bool acquires EcosystemReserveV2Data {
+        stream_exists(stream_id);
+        check_is_funds_admin(signer::address_of(sender));
+
+        assert!(amount > 0, EAMOUNT_IS_ZERO);
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+
+        let (_, recipient, _, _, _, _, remaining_balance, _) =
+            stream::get_stream(stream_item);
+
+        let balance = balance_of(stream_id, recipient);
+        assert!(balance >= amount, EAMOUNT_EXCEEDS_THE_AVAILABLE_BALANCE);
+
+        let ecosystem_reserve_v2_data =
+            borrow_global_mut<EcosystemReserveV2Data>(
+                ecosystem_reserve_v2_data_address()
+            );
+        let stream_item =
+            smart_table::borrow_mut(&mut ecosystem_reserve_v2_data.streams, stream_id);
+
+        stream::set_remaining_balance(stream_item, remaining_balance - amount);
+
+        let (_, recipient, _, _, _, _, remaining_balance, _) =
+            stream::get_stream(stream_item);
+
+        if (remaining_balance == 0) {
+            smart_table::remove(&mut ecosystem_reserve_v2_data.streams, stream_id);
+        };
+
+        event::emit(WithdrawFromStream { stream_id, recipient, amount });
+        true
+    }
+
+    fun cancel_stream(sender: &signer, stream_id: u256): bool acquires EcosystemReserveV2Data {
+        stream_exists(stream_id);
+        check_is_funds_admin(signer::address_of(sender));
+
+        let ecosystem_reserve_v2_data =
+            borrow_global<EcosystemReserveV2Data>(ecosystem_reserve_v2_data_address());
+        let stream_item =
+            smart_table::borrow(&ecosystem_reserve_v2_data.streams, stream_id);
+
+        let (stream_sender, recipient, _, _token_address, _, _, _, _) =
+            stream::get_stream(stream_item);
+
+        let sender_balance = balance_of(stream_id, stream_sender);
+        let recipient_balance = balance_of(stream_id, recipient);
+
+        let ecosystem_reserve_v2_data =
+            borrow_global_mut<EcosystemReserveV2Data>(
+                ecosystem_reserve_v2_data_address()
+            );
+
+        smart_table::remove(&mut ecosystem_reserve_v2_data.streams, stream_id);
+
+        if (recipient_balance > 0) {
+            // mock_underlying_token_factory::transfer_from(
+            //     stream_sender,
+            //     recipient,
+            //     (recipient_balance as u64),
+            //     token_address
+            // );
+        };
+
+        event::emit(
+            CancelStream {
+                stream_id,
+                sender: stream_sender,
+                recipient,
+                sender_balance,
+                recipient_balance
+            }
+        );
+
+        true
+    }
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_basic_flow(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_only_admin_or_recipient(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, TEST_SUCCESS);
+
+        only_admin_or_recipient(token_address, 1);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_cancel_stream(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, 1);
+
+        cancel_stream(periphery_account, stream_id);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_balance_of(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, 1);
+
+        fast_forward_seconds(one_hour_in_secs);
+
+        let res = balance_of(stream_id, signer::address_of(periphery_account));
+        assert!(res == 7200, 1);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_withdraw_from_stream(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, 1);
+
+        let amount = 1;
+
+        fast_forward_seconds(2 * one_hour_in_secs);
+
+        let res = withdraw_from_stream(periphery_account, stream_id, amount);
+        assert!(res == true, 1);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_get_stream(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, 1);
+
+        let (
+            stream_sender,
+            stream_recipient,
+            stream_deposit,
+            stream_token_address,
+            stream_start_time,
+            stream_stop_time,
+            stream_remaining_balance,
+            stream_rate_per_second
+        ) = get_stream(stream_id);
+
+        assert!(stream_sender == sender, 1);
+        assert!(stream_recipient == recipient, 1);
+        assert!(stream_deposit == deposit, 1);
+        assert!(stream_token_address == token_address, 1);
+        assert!(stream_start_time == start_time, 1);
+        assert!(stream_stop_time == stop_time, 1);
+        assert!(stream_remaining_balance == 7200, 1);
+        assert!(stream_rate_per_second == 2, 1);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_delta_of(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, 1);
+
+        let _amount = 1;
+
+        fast_forward_seconds(2 * one_hour_in_secs);
+
+        let res = delta_of(stream_id);
+
+        assert!(res == 3600, 1);
+    }
+
+    #[
+        test(
+            aave_role_super_admin = @aave_acl,
+            periphery_account = @aave_pool,
+            acl_fund_admin = @0x111,
+            user_account = @0x222,
+            creator = @0x1
+        )
+    ]
+    fun test_get_next_stream_id(
+        aave_role_super_admin: &signer,
+        periphery_account: &signer,
+        acl_fund_admin: &signer,
+        user_account: &signer,
+        creator: &signer
+    ) acquires EcosystemReserveV2Data {
+        // init acl
+        acl_manage::test_init_module(aave_role_super_admin);
+
+        set_time_has_started_for_testing(creator);
+
+        let one_hour_in_secs = 1 * 60 * 60;
+
+        fast_forward_seconds(one_hour_in_secs);
+        // get the ts for one hour ago
+        let _ts_one_hour_ago = timestamp::now_seconds() - one_hour_in_secs;
+
+        // set fund admin
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(acl_fund_admin)
+        );
+        // assert role is granted
+        acl_manage::is_funds_admin(signer::address_of(acl_fund_admin));
+
+        acl_manage::add_admin_controlled_ecosystem_reserve_funds_admin(
+            aave_role_super_admin, signer::address_of(periphery_account)
+        );
+
+        initialize(periphery_account);
+
+        let _rate_per_second = 1;
+        let _remaining_balance = 1;
+        let start_time = (one_hour_in_secs as u256) * 2;
+        let stop_time = (one_hour_in_secs as u256) * 3;
+        let deposit = (one_hour_in_secs as u256) * 2;
+        let recipient = signer::address_of(user_account);
+        let _sender = signer::address_of(periphery_account);
+        let token_address = signer::address_of(periphery_account);
+        let _is_entity = true;
+
+        let stream_id =
+            create_stream(
+                periphery_account,
+                recipient,
+                deposit,
+                token_address,
+                start_time,
+                stop_time
+            );
+
+        assert!(stream_id == 1, 1);
+
+        let _amount = 1;
+
+        fast_forward_seconds(2 * one_hour_in_secs);
+
+        let res = get_next_stream_id();
+
+        assert!(res == 2, 1);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/emission_manager.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/emission_manager.move
@@ -1,0 +1,237 @@
+module aave_pool::emission_manager {
+    use std::signer;
+    use std::vector;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::event;
+    use aptos_framework::object::{
+        Self,
+        ExtendRef as ObjExtendRef,
+        Object,
+        ObjectGroup,
+        TransferRef as ObjectTransferRef
+    };
+    use aave_oracle::reward_oracle::RewardOracle;
+    use aave_pool::rewards_controller::Self;
+    use aave_pool::transfer_strategy::{
+        check_is_emission_admin,
+        get_reward,
+        PullRewardsTransferStrategy,
+        RewardsConfigInput,
+        StakedTokenTransferStrategy
+    };
+
+    const ENOT_MANAGEMENT: u64 = 1;
+    const NOT_EMISSION_ADMIN: u64 = 2;
+    const ONLY_EMISSION_ADMIN: u64 = 3;
+
+    const EMISSION_MANAGER_NAME: vector<u8> = b"EMISSION_MANAGER";
+
+    #[resource_group_member(group = ObjectGroup)]
+    struct EmissionManagerData has key {
+        emission_admins: SmartTable<address, address>,
+        extend_ref: ObjExtendRef,
+        transfer_ref: ObjectTransferRef,
+        rewards_controller: address
+    }
+
+    #[event]
+    struct EmissionAdminUpdated has store, drop {
+        reward: address,
+        old_admin: address,
+        new_admin: address
+    }
+
+    fun check_admin(account: address) {
+        assert!(account == @aave_acl, ENOT_MANAGEMENT);
+    }
+
+    public fun initialize(sender: &signer, rewards_controller: address) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, EMISSION_MANAGER_NAME);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        move_to(
+            state_object_signer,
+            EmissionManagerData {
+                emission_admins: smart_table::new<address, address>(),
+                transfer_ref: object::generate_transfer_ref(state_object_constructor_ref),
+                extend_ref: object::generate_extend_ref(state_object_constructor_ref),
+                rewards_controller
+            }
+        );
+    }
+
+    #[view]
+    public fun emission_manager_address(): address {
+        object::create_object_address(&@aave_pool, EMISSION_MANAGER_NAME)
+    }
+
+    #[view]
+    public fun emission_manager_object(): Object<EmissionManagerData> {
+        object::address_to_object<EmissionManagerData>(emission_manager_address())
+    }
+
+    public fun configure_assets(
+        account: &signer, config: vector<RewardsConfigInput>
+    ) acquires EmissionManagerData {
+        let emission_manager_data =
+            borrow_global_mut<EmissionManagerData>(emission_manager_address());
+
+        for (i in 0..vector::length(&config)) {
+            let reward = get_reward(vector::borrow(&config, i));
+            assert!(
+                *smart_table::borrow(&emission_manager_data.emission_admins, reward)
+                    == signer::address_of(account),
+                ONLY_EMISSION_ADMIN
+            );
+        };
+        rewards_controller::configure_assets(
+            account, config, emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_pull_rewards_transfer_strategy(
+        caller: &signer,
+        reward: address,
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ) acquires EmissionManagerData {
+        check_is_emission_admin(reward);
+
+        let emission_manager_data =
+            borrow_global_mut<EmissionManagerData>(emission_manager_address());
+        rewards_controller::set_pull_rewards_transfer_strategy(
+            caller,
+            reward,
+            pull_rewards_transfer_strategy,
+            emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_staked_token_transfer_strategy(
+        caller: &signer,
+        reward: address,
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ) acquires EmissionManagerData {
+        check_is_emission_admin(reward);
+
+        let emission_manager_data =
+            borrow_global_mut<EmissionManagerData>(emission_manager_address());
+        rewards_controller::set_staked_token_transfer_strategy(
+            caller,
+            reward,
+            staked_token_transfer_strategy,
+            emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_reward_oracle(
+        caller: &signer, reward: address, reward_oracle: RewardOracle
+    ) acquires EmissionManagerData {
+        check_is_emission_admin(reward);
+        let emission_manager_data =
+            borrow_global<EmissionManagerData>(emission_manager_address());
+        rewards_controller::set_reward_oracle(
+            caller,
+            reward,
+            reward_oracle,
+            emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_distribution_end(
+        caller: &signer,
+        asset: address,
+        reward: address,
+        new_distribution_end: u32
+    ) acquires EmissionManagerData {
+        check_is_emission_admin(reward);
+
+        let emission_manager_data =
+            borrow_global<EmissionManagerData>(emission_manager_address());
+        rewards_controller::set_distribution_end(
+            caller,
+            asset,
+            reward,
+            new_distribution_end,
+            emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_emission_per_second(
+        caller: &signer,
+        asset: address,
+        rewards: vector<address>,
+        new_emissions_per_second: vector<u128>
+    ) acquires EmissionManagerData {
+        let emission_manager_data =
+            borrow_global_mut<EmissionManagerData>(emission_manager_address());
+        for (i in 0..vector::length(&rewards)) {
+            assert!(
+                *smart_table::borrow(
+                    &emission_manager_data.emission_admins,
+                    *vector::borrow(&rewards, i)
+                ) == signer::address_of(caller),
+                ONLY_EMISSION_ADMIN
+            );
+        };
+        rewards_controller::set_emission_per_second(
+            caller,
+            asset,
+            rewards,
+            new_emissions_per_second,
+            emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_claimer(
+        account: &signer, user: address, claimer: address
+    ) acquires EmissionManagerData {
+        check_admin(signer::address_of(account));
+        let emission_manager_data =
+            borrow_global<EmissionManagerData>(emission_manager_address());
+        rewards_controller::set_claimer(
+            user, claimer, emission_manager_data.rewards_controller
+        );
+    }
+
+    public fun set_emission_admin(
+        account: &signer, reward: address, new_admin: address
+    ) acquires EmissionManagerData {
+        check_admin(signer::address_of(account));
+
+        let emission_manager_data =
+            borrow_global_mut<EmissionManagerData>(emission_manager_address());
+
+        let old_admin =
+            *smart_table::borrow_with_default(
+                &emission_manager_data.emission_admins, reward, &new_admin
+            );
+        smart_table::upsert(
+            &mut emission_manager_data.emission_admins, reward, new_admin
+        );
+        event::emit(EmissionAdminUpdated { reward, old_admin, new_admin });
+    }
+
+    public fun set_rewards_controller(
+        account: &signer, controller: address
+    ) acquires EmissionManagerData {
+        check_admin(signer::address_of(account));
+        let emission_manager_data =
+            borrow_global_mut<EmissionManagerData>(emission_manager_address());
+        emission_manager_data.rewards_controller = controller;
+    }
+
+    public fun get_rewards_controller(): address acquires EmissionManagerData {
+        let emission_manager_data =
+            borrow_global<EmissionManagerData>(emission_manager_address());
+        emission_manager_data.rewards_controller
+    }
+
+    public fun get_emission_admin(reward: address): address acquires EmissionManagerData {
+        let emission_manager_data =
+            borrow_global<EmissionManagerData>(emission_manager_address());
+        let emission_admin =
+            smart_table::borrow(&emission_manager_data.emission_admins, reward);
+        *emission_admin
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/package-manager.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/package-manager.move
@@ -1,0 +1,107 @@
+module aave_pool::package_manager {
+    use aptos_framework::account::{Self, SignerCapability};
+    use std::string::{Self, String};
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::object::Self;
+
+    friend aave_pool::coin_wrapper;
+
+    const PACKAGE_MANAGER: vector<u8> = b"PACKAGE_MANAGER";
+
+    /// Stores permission config such as SignerCapability for controlling the resource account.
+    struct PermissionConfig has key {
+        /// Required to obtain the resource account signer.
+        signer_cap: SignerCapability,
+        /// Track the addresses created by the modules in this package.
+        addresses: SmartTable<String, address>
+    }
+
+    /// Initialize PermissionConfig to establish control over the resource account.
+    /// This function is invoked only when this package is deployed the first time.
+    fun initialize(sender: &signer) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, PACKAGE_MANAGER);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+        let seed = *string::bytes(&string::utf8(PACKAGE_MANAGER));
+        let (_resource_signer, signer_cap) =
+            account::create_resource_account(sender, seed);
+
+        initialize_helper(state_object_signer, signer_cap);
+    }
+
+    #[view]
+    public fun package_manager_address(): address {
+        object::create_object_address(&@aave_pool, PACKAGE_MANAGER)
+    }
+
+    fun get_resource_account_signer(): signer acquires PermissionConfig {
+        let oracle_data = borrow_global<PermissionConfig>(package_manager_address());
+        account::create_signer_with_capability(&oracle_data.signer_cap)
+    }
+
+    fun initialize_helper(sender: &signer, signer_cap: SignerCapability) {
+        move_to(
+            sender,
+            PermissionConfig {
+                addresses: smart_table::new<String, address>(),
+                signer_cap
+            }
+        );
+    }
+
+    /// Can be called by friended modules to obtain the resource account signer.
+    public(friend) fun get_signer(): signer acquires PermissionConfig {
+        let signer_cap =
+            &borrow_global<PermissionConfig>(package_manager_address()).signer_cap;
+        account::create_signer_with_capability(signer_cap)
+    }
+
+    #[test_only]
+    public fun get_signer_test(): signer acquires PermissionConfig {
+        get_signer()
+    }
+
+    /// Can be called by friended modules to keep track of a system address.
+    public(friend) fun add_address(name: String, object: address) acquires PermissionConfig {
+        let addresses =
+            &mut borrow_global_mut<PermissionConfig>(package_manager_address()).addresses;
+        smart_table::add(addresses, name, object);
+    }
+
+    #[test_only]
+    public fun add_address_test(name: String, object: address) acquires PermissionConfig {
+        add_address(name, object)
+    }
+
+    public(friend) fun address_exists(name: String): bool acquires PermissionConfig {
+        smart_table::contains(&safe_permission_config().addresses, name)
+    }
+
+    public(friend) fun get_address(name: String): address acquires PermissionConfig {
+        let addresses =
+            &borrow_global<PermissionConfig>(package_manager_address()).addresses;
+        *smart_table::borrow(addresses, name)
+    }
+
+    #[test_only]
+    public fun get_address_test(name: String): address acquires PermissionConfig {
+        get_address(name)
+    }
+
+    inline fun safe_permission_config(): &PermissionConfig acquires PermissionConfig {
+        borrow_global<PermissionConfig>(package_manager_address())
+    }
+
+    #[test_only]
+    public fun initialize_for_test(deployer: &signer) {
+        let deployer_addr = std::signer::address_of(deployer);
+        if (!exists<PermissionConfig>(deployer_addr)) {
+            aptos_framework::timestamp::set_time_has_started_for_testing(
+                &account::create_signer_for_test(@0x1)
+            );
+
+            account::create_account_for_test(deployer_addr);
+            initialize_helper(deployer, account::create_test_signer_cap(deployer_addr));
+        };
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/rewards_controller.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/rewards_controller.move
@@ -1,0 +1,1510 @@
+module aave_pool::rewards_controller {
+    use std::signer;
+    use std::simple_map::{Self, SimpleMap};
+    use std::vector;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::event;
+    use aptos_framework::object::{Self, Object, ObjectGroup};
+    use aptos_framework::timestamp;
+
+    use aave_acl::acl_manage::Self;
+    use aave_math::math_utils;
+    use aave_oracle::reward_oracle::{Self, RewardOracle};
+
+    use aave_pool::a_token_factory;
+    use aave_pool::transfer_strategy::check_is_emission_admin;
+    use aave_pool::transfer_strategy::{
+        get_asset,
+        get_emission_per_second,
+        get_reward,
+        get_total_supply,
+        has_pull_rewards_transfer_strategy,
+        pull_rewards_transfer_strategy_get_strategy,
+        PullRewardsTransferStrategy,
+        RewardsConfigInput,
+        set_total_supply,
+        staked_token_transfer_strategy_get_strategy,
+        StakedTokenTransferStrategy,
+        validate_rewards_config_input
+    };
+
+    const REVISION: u64 = 1;
+
+    const CLAIMER_UNAUTHORIZED: u64 = 1;
+    const INDEX_OVERFLOW: u64 = 2;
+    const ONLY_EMISSION_MANAGER: u64 = 3;
+    const INVALID_INPUT: u64 = 4;
+    const DISTRIBUTION_DOES_NOT_EXIST: u64 = 5;
+    const ORACLE_MUST_RETURN_PRICE: u64 = 6;
+    const TRANSFER_ERROR: u64 = 7;
+
+    const NOT_REWARDS_CONTROLLER_ADMIN: u64 = 8;
+
+    const REWARDS_CONTROLLER_NAME: vector<u8> = b"REWARDS_CONTROLLER_NAME";
+
+    #[resource_group_member(group = ObjectGroup)]
+    struct RewardsControllerData has key {
+        authorized_claimers: SmartTable<address, address>,
+        pull_rewards_transfer_strategy_table: SmartTable<address, PullRewardsTransferStrategy>,
+        staked_token_transfer_strategy_table: SmartTable<address, StakedTokenTransferStrategy>,
+        reward_oracle: SmartTable<address, RewardOracle>,
+        emission_manager: address,
+        assets: SmartTable<address, AssetData>,
+        is_reward_enabled: SmartTable<address, bool>,
+        rewards_list: vector<address>,
+        assets_list: vector<address>
+    }
+
+    fun assert_access(account: address) {
+        assert!(
+            acl_manage::is_rewards_controller_admin(account),
+            NOT_REWARDS_CONTROLLER_ADMIN
+        );
+    }
+
+    public fun initialize(sender: &signer, emission_manager: address) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, REWARDS_CONTROLLER_NAME);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        move_to(
+            state_object_signer,
+            RewardsControllerData {
+                authorized_claimers: smart_table::new<address, address>(),
+                pull_rewards_transfer_strategy_table: smart_table::new<address, PullRewardsTransferStrategy>(),
+                staked_token_transfer_strategy_table: smart_table::new<address, StakedTokenTransferStrategy>(),
+                reward_oracle: smart_table::new<address, RewardOracle>(),
+                emission_manager,
+                assets: smart_table::new<address, AssetData>(),
+                is_reward_enabled: smart_table::new<address, bool>(),
+                rewards_list: vector[],
+                assets_list: vector[]
+            }
+        );
+    }
+
+    struct AssetData has key, store, drop {
+        rewards: std::simple_map::SimpleMap<address, RewardData>,
+        available_rewards: std::simple_map::SimpleMap<u128, address>,
+        available_rewards_count: u128,
+        decimals: u8
+    }
+
+    public fun create_asset_data(
+        rewards: SimpleMap<address, RewardData>,
+        available_rewards: SimpleMap<u128, address>,
+        available_rewards_count: u128,
+        decimals: u8
+    ): AssetData {
+        AssetData { rewards, available_rewards, available_rewards_count, decimals }
+    }
+
+    struct RewardData has key, store, drop, copy {
+        index: u128,
+        emission_per_second: u128,
+        last_update_timestamp: u32,
+        distribution_end: u32,
+        users_data: std::simple_map::SimpleMap<address, UserData>
+    }
+
+    public fun create_reward_data(
+        index: u128,
+        emission_per_second: u128,
+        last_update_timestamp: u32,
+        distribution_end: u32,
+        users_data: std::simple_map::SimpleMap<address, UserData>
+    ): RewardData {
+        RewardData {
+            index,
+            emission_per_second,
+            last_update_timestamp,
+            distribution_end,
+            users_data
+        }
+    }
+
+    struct UserData has key, store, copy, drop {
+        index: u128,
+        accrued: u128
+    }
+
+    #[test_only]
+    public fun create_user_data(index: u128, accrued: u128): UserData {
+        UserData { index, accrued }
+    }
+
+    struct UserAssetBalance has store, drop, copy {
+        asset: address,
+        user_balance: u256,
+        total_supply: u256
+    }
+
+    #[event]
+    struct ClaimerSet has store, drop {
+        user: address,
+        claimer: address
+    }
+
+    #[event]
+    struct Accrued has store, drop {
+        asset: address,
+        reward: address,
+        user: address,
+        asset_index: u256,
+        user_index: u256,
+        rewards_accrued: u256
+    }
+
+    #[event]
+    struct AssetConfigUpdated has store, drop {
+        asset: address,
+        reward: address,
+        old_emission: u256,
+        new_emission: u256,
+        old_distribution_end: u256,
+        new_distribution_end: u256,
+        asset_index: u256
+    }
+
+    #[event]
+    struct RewardsClaimed has store, drop {
+        user: address,
+        reward: address,
+        to: address,
+        claimer: address,
+        amount: u256
+    }
+
+    #[event]
+    struct RewardOracleUpdated has store, drop {
+        reward: address,
+        reward_oracle: RewardOracle
+    }
+
+    #[event]
+    struct PullRewardsTransferStrategyInstalled has store, drop {
+        reward: address,
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    }
+
+    #[event]
+    struct StakedTokenTransferStrategyInstalled has store, drop {
+        reward: address,
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    }
+
+    #[view]
+    public fun rewards_controller_address(): address {
+        object::create_object_address(&@aave_pool, REWARDS_CONTROLLER_NAME)
+    }
+
+    #[view]
+    public fun rewards_controller_object(): Object<RewardsControllerData> {
+        object::address_to_object<RewardsControllerData>(rewards_controller_address())
+    }
+
+    fun only_authorized_claimers(
+        claimer: address, user: address, rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        assert!(
+            get_claimer(user, rewards_controller_address) == claimer,
+            CLAIMER_UNAUTHORIZED
+        );
+    }
+
+    #[test_only]
+    public fun add_asset(
+        rewards_controller_address: address, asset_addr: address, asset: AssetData
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        smart_table::add(&mut rewards_controller_data.assets, asset_addr, asset);
+    }
+
+    #[test_only]
+    public fun enable_reward(
+        rewards_controller_address: address, reward: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        smart_table::add(&mut rewards_controller_data.is_reward_enabled, reward, true);
+    }
+
+    #[view]
+    public fun get_claimer(
+        user: address, rewards_controller_address: address
+    ): address acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let claimer =
+            smart_table::borrow(&rewards_controller_data.authorized_claimers, user);
+        *claimer
+    }
+
+    #[view]
+    public fun get_revision(): u64 {
+        REVISION
+    }
+
+    #[view]
+    public fun get_reward_oracle(
+        reward: address, rewards_controller_address: address
+    ): RewardOracle acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        *smart_table::borrow(&rewards_controller_data.reward_oracle, reward)
+    }
+
+    public fun get_pull_rewards_transfer_strategy(
+        reward: address, rewards_controller_address: address
+    ): PullRewardsTransferStrategy acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        *smart_table::borrow(
+            &rewards_controller_data.pull_rewards_transfer_strategy_table, reward
+        )
+    }
+
+    public fun get_staked_token_transfer_strategy(
+        reward: address, rewards_controller_address: address
+    ): StakedTokenTransferStrategy acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        *smart_table::borrow(
+            &rewards_controller_data.staked_token_transfer_strategy_table, reward
+        )
+    }
+
+    public fun configure_assets(
+        caller: &signer,
+        config: vector<RewardsConfigInput>,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        only_emission_manager(caller, rewards_controller_address);
+        for (i in 0..vector::length(&config)) {
+            let config_el = vector::borrow_mut(&mut config, i);
+
+            validate_rewards_config_input(config_el);
+
+            let asset = get_asset(config_el);
+            set_total_supply(config_el, a_token_factory::scaled_total_supply(asset));
+
+            let reward = aave_pool::transfer_strategy::get_reward(config_el);
+
+            if (has_pull_rewards_transfer_strategy(config_el)) {
+                install_pull_rewards_transfer_strategy(
+                    reward,
+                    pull_rewards_transfer_strategy_get_strategy(config_el),
+                    rewards_controller_address
+                );
+            } else {
+                install_staked_token_transfer_strategy(
+                    reward,
+                    staked_token_transfer_strategy_get_strategy(config_el),
+                    rewards_controller_address
+                );
+            };
+
+            set_reward_oracle(
+                caller,
+                reward,
+                aave_pool::transfer_strategy::get_reward_oracle(
+                    vector::borrow(&config, i)
+                ),
+                rewards_controller_address
+            );
+        };
+        configure_assets_internal(config, rewards_controller_address);
+    }
+
+    public fun set_pull_rewards_transfer_strategy(
+        caller: &signer,
+        reward: address,
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        only_emission_manager(caller, rewards_controller_address);
+        install_pull_rewards_transfer_strategy(
+            reward, pull_rewards_transfer_strategy, rewards_controller_address
+        );
+    }
+
+    public fun set_staked_token_transfer_strategy(
+        caller: &signer,
+        reward: address,
+        staked_token_transfer_strategy: StakedTokenTransferStrategy,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        only_emission_manager(caller, rewards_controller_address);
+        install_staked_token_transfer_strategy(
+            reward, staked_token_transfer_strategy, rewards_controller_address
+        );
+    }
+
+    public fun set_reward_oracle(
+        caller: &signer,
+        reward: address,
+        reward_oracle: RewardOracle,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        assert_access(signer::address_of(caller));
+        only_emission_manager(caller, rewards_controller_address);
+        set_reward_oracle_internal(reward, reward_oracle);
+    }
+
+    #[test_only]
+    public fun test_handle_action(
+        caller: &signer,
+        user: address,
+        total_supply: u256,
+        user_balance: u256,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        handle_action(
+            caller,
+            user,
+            total_supply,
+            user_balance,
+            rewards_controller_address
+        )
+    }
+
+    fun handle_action(
+        caller: &signer,
+        user: address,
+        total_supply: u256,
+        user_balance: u256,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+        update_data(
+            addr,
+            user,
+            user_balance,
+            total_supply,
+            rewards_controller_address
+        );
+    }
+
+    public fun claim_rewards(
+        caller: &signer,
+        assets: vector<address>,
+        amount: u256,
+        to: address,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+        claim_rewards_internal(
+            caller,
+            assets,
+            amount,
+            addr,
+            addr,
+            to,
+            reward,
+            rewards_controller_address
+        )
+    }
+
+    #[test_only]
+    public fun test_claim_rewards_on_behalf(
+        caller: &signer,
+        assets: vector<address>,
+        amount: u256,
+        user: address,
+        to: address,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        claim_rewards_on_behalf(
+            caller,
+            assets,
+            amount,
+            user,
+            to,
+            reward,
+            rewards_controller_address
+        )
+    }
+
+    fun claim_rewards_on_behalf(
+        caller: &signer,
+        assets: vector<address>,
+        amount: u256,
+        user: address,
+        to: address,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+
+        only_authorized_claimers(addr, user, rewards_controller_address);
+        claim_rewards_internal(
+            caller,
+            assets,
+            amount,
+            addr,
+            user,
+            to,
+            reward,
+            rewards_controller_address
+        )
+    }
+
+    #[test_only]
+    public fun test_claim_rewards_to_self(
+        caller: &signer,
+        assets: vector<address>,
+        amount: u256,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        claim_rewards_to_self(
+            caller,
+            assets,
+            amount,
+            reward,
+            rewards_controller_address
+        )
+    }
+
+    fun claim_rewards_to_self(
+        caller: &signer,
+        assets: vector<address>,
+        amount: u256,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+        claim_rewards_internal(
+            caller,
+            assets,
+            amount,
+            addr,
+            addr,
+            addr,
+            reward,
+            rewards_controller_address
+        )
+    }
+
+    public fun claim_all_rewards(
+        caller: &signer,
+        assets: vector<address>,
+        to: address,
+        rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+        claim_all_rewards_internal(
+            caller,
+            assets,
+            addr,
+            addr,
+            to,
+            rewards_controller_address
+        )
+    }
+
+    #[test_only]
+    public fun test_claim_all_rewards_on_behalf(
+        caller: &signer,
+        assets: vector<address>,
+        user: address,
+        to: address,
+        rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        claim_all_rewards_on_behalf(
+            caller,
+            assets,
+            user,
+            to,
+            rewards_controller_address
+        )
+    }
+
+    fun claim_all_rewards_on_behalf(
+        caller: &signer,
+        assets: vector<address>,
+        user: address,
+        to: address,
+        rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+
+        only_authorized_claimers(addr, user, rewards_controller_address);
+        claim_all_rewards_internal(
+            caller,
+            assets,
+            addr,
+            user,
+            to,
+            rewards_controller_address
+        )
+    }
+
+    #[test_only]
+    public fun test_claim_all_rewards_to_self(
+        caller: &signer, assets: vector<address>, rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        claim_all_rewards_to_self(caller, assets, rewards_controller_address)
+    }
+
+    fun claim_all_rewards_to_self(
+        caller: &signer, assets: vector<address>, rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        let addr = signer::address_of(caller);
+        claim_all_rewards_internal(
+            caller,
+            assets,
+            addr,
+            addr,
+            addr,
+            rewards_controller_address
+        )
+    }
+
+    public fun set_claimer(
+        user: address, claimer: address, rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        check_is_emission_admin(user);
+
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        smart_table::upsert(
+            &mut rewards_controller_data.authorized_claimers, user, claimer
+        );
+        event::emit(ClaimerSet { user, claimer });
+    }
+
+    fun get_user_asset_balances(assets: vector<address>, user: address):
+        vector<UserAssetBalance> {
+        let user_asset_balances = vector[];
+        for (i in 0..vector::length(&assets)) {
+            let asset = *vector::borrow(&assets, i);
+            let user_balance = a_token_factory::scaled_balance_of(user, asset);
+            let total_supply = a_token_factory::scaled_total_supply(asset);
+
+            vector::push_back(
+                &mut user_asset_balances,
+                UserAssetBalance { asset, user_balance, total_supply }
+            );
+        };
+        user_asset_balances
+    }
+
+    fun claim_rewards_internal(
+        caller: &signer,
+        assets: vector<address>,
+        amount: u256,
+        claimer: address,
+        user: address,
+        to: address,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        if (amount == 0) {
+            return 0
+        };
+        let total_rewards = 0;
+
+        update_data_multiple(
+            user,
+            get_user_asset_balances(assets, user),
+            rewards_controller_address
+        );
+
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+
+        for (i in 0..vector::length(&assets)) {
+            let asset = *vector::borrow(&assets, i);
+
+            let asset_el =
+                smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+            let reward_data: &mut RewardData =
+                simple_map::borrow_mut(&mut asset_el.rewards, &reward);
+            let user_data: &mut UserData =
+                simple_map::borrow_mut(&mut reward_data.users_data, &user);
+            total_rewards = total_rewards + (user_data.accrued as u256);
+
+            if (total_rewards <= amount) {
+                user_data.accrued = 0;
+            } else {
+                let difference = total_rewards - amount;
+                total_rewards = total_rewards - difference;
+                user_data.accrued = (difference as u128);
+                break
+            };
+        };
+
+        if (total_rewards == 0) {
+            return 0
+        };
+
+        if (smart_table::contains(
+            &rewards_controller_data.pull_rewards_transfer_strategy_table, reward
+        )) {
+            transfer_pull_rewards_transfer_strategy_rewards(
+                caller,
+                to,
+                reward,
+                total_rewards,
+                rewards_controller_data
+            )
+        } else if (smart_table::contains(
+            &rewards_controller_data.pull_rewards_transfer_strategy_table, reward
+        )) {
+            transfer_staked_token_transfer_strategy_rewards(
+                caller,
+                to,
+                reward,
+                total_rewards,
+                rewards_controller_data
+            )
+        };
+        event::emit(
+            RewardsClaimed { user, reward: claimer, to, claimer, amount: total_rewards }
+        );
+
+        total_rewards
+    }
+
+    fun claim_all_rewards_internal(
+        caller: &signer,
+        assets: vector<address>,
+        claimer: address,
+        user: address,
+        to: address,
+        rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        update_data_multiple(
+            user,
+            get_user_asset_balances(assets, user),
+            rewards_controller_address
+        );
+
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        let rewards_list_length = vector::length(&rewards_controller_data.rewards_list);
+
+        let rewards_list = rewards_controller_data.rewards_list;
+        let claimed_amounts = vector[];
+
+        for (i in 0..vector::length(&assets)) {
+            let asset = *vector::borrow(&assets, i);
+            let asset_el =
+                smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+
+            for (j in 0..rewards_list_length) {
+                let reward_data: &mut RewardData =
+                    simple_map::borrow_mut(
+                        &mut asset_el.rewards, vector::borrow(&rewards_list, j)
+                    );
+                let user_data: &mut UserData =
+                    simple_map::borrow_mut(&mut reward_data.users_data, &user);
+
+                let reward_amount = (user_data.accrued as u256);
+                if (reward_amount != 0) {
+                    if (vector::length(&claimed_amounts) > 0) {
+                        let claimed_amounts_j =
+                            *vector::borrow_mut(&mut claimed_amounts, j);
+                        vector::insert(
+                            &mut claimed_amounts, j, claimed_amounts_j + reward_amount
+                        );
+                    } else {
+                        vector::insert(&mut claimed_amounts, j, reward_amount);
+                    };
+                    user_data.accrued = 0;
+                };
+            };
+        };
+
+        for (i in 0..rewards_list_length) {
+            if (smart_table::contains(
+                &rewards_controller_data.pull_rewards_transfer_strategy_table,
+                *vector::borrow(&rewards_list, i)
+            )) {
+                transfer_pull_rewards_transfer_strategy_rewards(
+                    caller,
+                    to,
+                    *vector::borrow(&rewards_list, i),
+                    *vector::borrow(&claimed_amounts, i),
+                    rewards_controller_data
+                )
+            } else if (smart_table::contains(
+                &rewards_controller_data.pull_rewards_transfer_strategy_table,
+                *vector::borrow(&rewards_list, i)
+            )) {
+                transfer_staked_token_transfer_strategy_rewards(
+                    caller,
+                    to,
+                    *vector::borrow(&rewards_list, i),
+                    *vector::borrow(&claimed_amounts, i),
+                    rewards_controller_data
+                )
+            };
+            event::emit(
+                RewardsClaimed {
+                    user,
+                    reward: *vector::borrow(&rewards_list, i),
+                    to,
+                    claimer,
+                    amount: *vector::borrow(&claimed_amounts, i)
+                }
+            );
+        };
+        (rewards_list, claimed_amounts)
+    }
+
+    fun transfer_pull_rewards_transfer_strategy_rewards(
+        caller: &signer,
+        to: address,
+        reward: address,
+        amount: u256,
+        rewards_controller_data: &mut RewardsControllerData
+    ) {
+        let pull_rewards_transfer_strategy =
+            *smart_table::borrow(
+                &rewards_controller_data.pull_rewards_transfer_strategy_table, reward
+            );
+        let success =
+            aave_pool::transfer_strategy::pull_rewards_transfer_strategy_perform_transfer(
+                caller,
+                to,
+                reward,
+                amount,
+                pull_rewards_transfer_strategy
+            );
+
+        assert!(success, TRANSFER_ERROR);
+    }
+
+    fun transfer_staked_token_transfer_strategy_rewards(
+        caller: &signer,
+        to: address,
+        reward: address,
+        amount: u256,
+        rewards_controller_data: &mut RewardsControllerData
+    ) {
+        let staked_token_transfer_strategy =
+            *smart_table::borrow(
+                &rewards_controller_data.staked_token_transfer_strategy_table, reward
+            );
+        let success =
+            aave_pool::transfer_strategy::staked_token_transfer_strategy_perform_transfer(
+                caller,
+                to,
+                reward,
+                amount,
+                staked_token_transfer_strategy
+            );
+
+        assert!(success, TRANSFER_ERROR);
+    }
+
+    fun install_pull_rewards_transfer_strategy(
+        reward: address,
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        smart_table::upsert(
+            &mut rewards_controller_data.pull_rewards_transfer_strategy_table,
+            reward,
+            pull_rewards_transfer_strategy
+        );
+
+        event::emit(
+            PullRewardsTransferStrategyInstalled { reward, pull_rewards_transfer_strategy }
+        );
+    }
+
+    fun install_staked_token_transfer_strategy(
+        reward: address,
+        staked_token_transfer_strategy: StakedTokenTransferStrategy,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        smart_table::upsert(
+            &mut rewards_controller_data.staked_token_transfer_strategy_table,
+            reward,
+            staked_token_transfer_strategy
+        );
+
+        event::emit(
+            StakedTokenTransferStrategyInstalled { reward, staked_token_transfer_strategy }
+        );
+    }
+
+    public fun set_reward_oracle_internal(
+        reward: address, reward_oracle: RewardOracle
+    ) acquires RewardsControllerData {
+        assert!(
+            reward_oracle::latest_answer(reward_oracle) > 0, ORACLE_MUST_RETURN_PRICE
+        );
+
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address());
+        smart_table::upsert(
+            &mut rewards_controller_data.reward_oracle, reward, reward_oracle
+        );
+
+        event::emit(RewardOracleUpdated { reward, reward_oracle });
+    }
+
+    fun only_emission_manager(
+        sender: &signer, rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        assert!(
+            signer::address_of(sender) == rewards_controller_data.emission_manager,
+            ONLY_EMISSION_MANAGER
+        );
+    }
+
+    #[view]
+    public fun get_rewards_data(
+        asset: address, reward: address, rewards_controller_address: address
+    ): (u256, u256, u256, u256) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow(&rewards_controller_data.assets, asset);
+        let rewards_data: &RewardData = simple_map::borrow(&asset.rewards, &reward);
+        (
+            (rewards_data.index as u256),
+            (rewards_data.emission_per_second as u256),
+            (rewards_data.last_update_timestamp as u256),
+            (rewards_data.distribution_end as u256)
+        )
+    }
+
+    #[test_only]
+    public fun add_rewards_data(
+        asset: address,
+        reward: address,
+        rewards_controller_address: address,
+        reward_data: RewardData
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+        simple_map::upsert(&mut asset.rewards, reward, reward_data);
+    }
+
+    #[view]
+    public fun get_asset_index(
+        asset: address, reward: address, rewards_controller_address: address
+    ): (u256, u256) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let asset_el = smart_table::borrow(&rewards_controller_data.assets, asset);
+        let rewards_data: &RewardData = simple_map::borrow(&asset_el.rewards, &reward);
+        get_asset_index_internal(
+            rewards_data,
+            a_token_factory::scaled_total_supply(asset),
+            math_utils::pow(10, (asset_el.decimals as u256))
+        )
+    }
+
+    #[view]
+    public fun get_distribution_end(
+        asset: address, reward: address, rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow(&rewards_controller_data.assets, asset);
+        let reward_data: &RewardData = simple_map::borrow(&asset.rewards, &reward);
+        (reward_data.distribution_end as u256)
+    }
+
+    #[view]
+    public fun get_rewards_by_asset(
+        asset: address, rewards_controller_address: address
+    ): vector<address> acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow(&rewards_controller_data.assets, asset);
+
+        let rewards_count = asset.available_rewards_count;
+        let available_rewards: vector<address> = vector[];
+
+        for (i in 0..rewards_count) {
+            let el = simple_map::borrow(&asset.available_rewards, &i);
+            vector::push_back(&mut available_rewards, *el);
+        };
+        available_rewards
+    }
+
+    #[test_only]
+    public fun add_rewards_by_asset(
+        asset: address,
+        rewards_controller_address: address,
+        i: u128,
+        addr: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+        // asset.available_rewards_count = asset.available_rewards_count + 1;
+
+        simple_map::upsert(&mut asset.available_rewards, i, addr);
+    }
+
+    #[view]
+    public fun get_rewards_list(
+        rewards_controller_address: address
+    ): vector<address> acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        rewards_controller_data.rewards_list
+    }
+
+    #[view]
+    public fun get_user_asset_index(
+        user: address,
+        asset: address,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow(&rewards_controller_data.assets, asset);
+        let reward_data: &RewardData = simple_map::borrow(&asset.rewards, &reward);
+        let user_data: &UserData = simple_map::borrow(&reward_data.users_data, &user);
+        (user_data.index as u256)
+    }
+
+    public fun add_user_asset_index(
+        user: address,
+        asset: address,
+        reward: address,
+        rewards_controller_address: address,
+        user_data: UserData
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+        let reward_data: &mut RewardData =
+            simple_map::borrow_mut(&mut asset.rewards, &reward);
+        simple_map::upsert(&mut reward_data.users_data, user, user_data);
+    }
+
+    #[view]
+    public fun get_user_accrued_rewards(
+        user: address, reward: address, rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let total_accrued = 0;
+
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+
+        let assets_list = rewards_controller_data.assets_list;
+
+        for (i in 0..vector::length(&assets_list)) {
+            let asset =
+                smart_table::borrow(
+                    &rewards_controller_data.assets,
+                    *vector::borrow(&assets_list, i)
+                );
+            let reward_data: &RewardData = simple_map::borrow(&asset.rewards, &reward);
+            let user_data: &UserData = simple_map::borrow(
+                &reward_data.users_data, &user
+            );
+
+            total_accrued = total_accrued + (user_data.accrued as u256);
+        };
+
+        total_accrued
+    }
+
+    #[view]
+    public fun get_user_rewards(
+        assets: vector<address>,
+        user: address,
+        reward: address,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        get_user_reward(
+            user,
+            reward,
+            get_user_asset_balances(assets, user),
+            rewards_controller_address
+        )
+    }
+
+    #[test_only]
+    public fun add_to_rewards_list(
+        reward: address, rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        vector::push_back(
+            &mut rewards_controller_data.rewards_list,
+            reward
+        );
+    }
+
+    #[test_only]
+    public fun add_to_assets_list(
+        asset: address, rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        vector::push_back(
+            &mut rewards_controller_data.assets_list,
+            asset
+        );
+    }
+
+    #[view]
+    public fun get_all_user_rewards(
+        assets: vector<address>, user: address, rewards_controller_address: address
+    ): (vector<address>, vector<u256>) acquires RewardsControllerData {
+        let user_asset_balances = get_user_asset_balances(assets, user);
+        let rewards_list = vector[];
+        let unclaimed_amounts = vector[];
+
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let rewards_list_len = vector::length(&rewards_controller_data.rewards_list);
+
+        for (i in 0..rewards_list_len) {
+            for (r in 0..rewards_list_len) {
+                vector::push_back(
+                    &mut rewards_list,
+                    *vector::borrow(&rewards_controller_data.rewards_list, r)
+                );
+                let asset_el =
+                    smart_table::borrow(
+                        &rewards_controller_data.assets,
+                        vector::borrow(&user_asset_balances, r).asset
+                    );
+                let rewards_el =
+                    simple_map::borrow(
+                        &asset_el.rewards, vector::borrow(&rewards_list, r)
+                    );
+                let user_data = simple_map::borrow(&rewards_el.users_data, &user);
+                vector::push_back(&mut unclaimed_amounts, (user_data.accrued as u256));
+
+                if (vector::borrow(&user_asset_balances, i).user_balance == 0) {
+                    continue
+                };
+                let prev = vector::pop_back(&mut unclaimed_amounts);
+                vector::push_back(
+                    &mut unclaimed_amounts,
+                    prev
+                        + get_pending_rewards(
+                            user,
+                            *vector::borrow(&rewards_list, r),
+                            vector::borrow(&user_asset_balances, i),
+                            rewards_controller_data
+                        )
+                );
+            };
+        };
+        (rewards_list, unclaimed_amounts)
+    }
+
+    public fun set_distribution_end(
+        caller: &signer,
+        asset: address,
+        reward: address,
+        new_distribution_end: u32,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        only_emission_manager(caller, rewards_controller_address);
+
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        let asset_el: &mut AssetData =
+            smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+        let reward_data: &mut RewardData =
+            simple_map::borrow_mut(&mut asset_el.rewards, &reward);
+
+        let old_distribution_end = (reward_data.distribution_end as u256);
+        reward_data.distribution_end = new_distribution_end;
+
+        event::emit(
+            AssetConfigUpdated {
+                asset,
+                reward,
+                old_emission: (reward_data.emission_per_second as u256),
+                new_emission: (reward_data.emission_per_second as u256),
+                old_distribution_end,
+                new_distribution_end: (new_distribution_end as u256),
+                asset_index: (reward_data.index as u256)
+            }
+        );
+    }
+
+    public fun set_emission_per_second(
+        caller: &signer,
+        asset: address,
+        rewards: vector<address>,
+        new_emissions_per_second: vector<u128>,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        only_emission_manager(caller, rewards_controller_address);
+
+        let rewards_len = vector::length(&rewards);
+
+        assert!(rewards_len == vector::length(&new_emissions_per_second), INVALID_INPUT);
+
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+
+        for (i in 0..rewards_len) {
+            let asset_config: &mut AssetData =
+                smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+            let reward_config: &mut RewardData =
+                simple_map::borrow_mut(
+                    &mut asset_config.rewards, vector::borrow(&rewards, i)
+                );
+
+            let decimals = asset_config.decimals;
+            assert!(
+                decimals != 0 && reward_config.last_update_timestamp != 0,
+                DISTRIBUTION_DOES_NOT_EXIST
+            );
+
+            let (new_index, _) =
+                update_reward_data(
+                    reward_config,
+                    a_token_factory::scaled_total_supply(asset),
+                    math_utils::pow(10, (decimals as u256))
+                );
+
+            let old_emission_per_second = (reward_config.emission_per_second as u256);
+            reward_config.emission_per_second = *vector::borrow(
+                &new_emissions_per_second, i
+            );
+
+            event::emit(
+                AssetConfigUpdated {
+                    asset,
+                    reward: *vector::borrow(&rewards, i),
+                    old_emission: old_emission_per_second,
+                    new_emission: (*vector::borrow(&new_emissions_per_second, i) as u256),
+                    old_distribution_end: (reward_config.distribution_end as u256),
+                    new_distribution_end: (reward_config.distribution_end as u256),
+                    asset_index: new_index
+                }
+            );
+        }
+    }
+
+    fun configure_assets_internal(
+        rewards_input: vector<RewardsConfigInput>, rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+
+        for (i in 0..vector::length(&rewards_input)) {
+            let reward_input = vector::borrow(&rewards_input, i);
+            let asset = get_asset(reward_input);
+            let asset_el: &mut AssetData =
+                smart_table::borrow_mut(&mut rewards_controller_data.assets, asset);
+            if (asset_el.decimals == 0) {
+                vector::push_back(&mut rewards_controller_data.assets_list, asset);
+            };
+
+            asset_el.decimals = a_token_factory::decimals(asset);
+
+            let decimals = asset_el.decimals;
+
+            let reward = get_reward(reward_input);
+
+            let reward_config = simple_map::borrow_mut(&mut asset_el.rewards, &reward);
+
+            if (reward_config.last_update_timestamp == 0) {
+                //let update_el = *simple_map::borrow_mut(&mut asset_el.available_rewards, &asset_el.available_rewards_count);
+                //update_el = reward;
+                asset_el.available_rewards_count = asset_el.available_rewards_count + 1;
+            };
+
+            let is_reward_enabled_reward =
+                *smart_table::borrow_mut(
+                    &mut rewards_controller_data.is_reward_enabled, reward
+                );
+            if (is_reward_enabled_reward == false) {
+                //is_reward_enabled_reward = true;
+                vector::push_back(&mut rewards_controller_data.rewards_list, reward);
+            };
+
+            let total_supply = get_total_supply(reward_input);
+
+            let (new_index, _) =
+                update_reward_data(
+                    reward_config,
+                    total_supply,
+                    math_utils::pow(10, (decimals as u256))
+                );
+
+            let old_emissions_per_second = reward_config.emission_per_second;
+            let old_distribution_end = reward_config.distribution_end;
+            reward_config.emission_per_second = get_emission_per_second(reward_input);
+            reward_config.distribution_end = aave_pool::transfer_strategy::get_distribution_end(
+                reward_input
+            );
+
+            event::emit(
+                AssetConfigUpdated {
+                    asset,
+                    reward,
+                    old_emission: (old_emissions_per_second as u256),
+                    new_emission: (get_emission_per_second(reward_input) as u256),
+                    old_distribution_end: (old_distribution_end as u256),
+                    new_distribution_end: (reward_config.distribution_end as u256),
+                    asset_index: new_index
+                }
+            );
+        }
+    }
+
+    fun update_reward_data(
+        reward_data: &mut RewardData, total_supply: u256, asset_unit: u256
+    ): (u256, bool) {
+        let (old_index, new_index) =
+            get_asset_index_internal(reward_data, total_supply, asset_unit);
+        let index_updated = false;
+        if (new_index != old_index) {
+            assert!(new_index <= math_utils::pow(2, 104), INDEX_OVERFLOW);
+            index_updated = true;
+
+            reward_data.index = (new_index as u128);
+            reward_data.last_update_timestamp = (timestamp::now_seconds() as u32);
+        } else {
+            reward_data.last_update_timestamp = (timestamp::now_seconds() as u32);
+        };
+
+        (new_index, index_updated)
+    }
+
+    fun update_user_data(
+        reward_data: &mut RewardData,
+        user: address,
+        user_balance: u256,
+        new_asset_index: u256,
+        asset_unit: u256
+    ): (u256, bool) {
+        let user = simple_map::borrow_mut(&mut reward_data.users_data, &user);
+        let user_index = user.index;
+        let rewards_accrued = 0;
+        let data_updated = user_index != (new_asset_index as u128);
+        if (data_updated) {
+            user.index = (new_asset_index as u128);
+            if (user_balance != 0) {
+                rewards_accrued = get_rewards(
+                    user_balance,
+                    new_asset_index,
+                    (user_index as u256),
+                    asset_unit
+                );
+
+                user.accrued = user.accrued + (rewards_accrued as u128);
+            };
+        };
+        (rewards_accrued, data_updated)
+    }
+
+    fun update_data(
+        asset: address,
+        user: address,
+        user_balance: u256,
+        total_supply: u256,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global_mut<RewardsControllerData>(rewards_controller_address);
+        let asset_el = smart_table::borrow_mut(
+            &mut rewards_controller_data.assets, asset
+        );
+        let num_available_rewards = asset_el.available_rewards_count;
+        let asset_unit = math_utils::pow(10, (asset_el.decimals as u256));
+
+        if (num_available_rewards == 0) { return };
+
+        for (r in 0..num_available_rewards) {
+            let reward: address = *simple_map::borrow(
+                &mut asset_el.available_rewards, &r
+            );
+            let reward_data: &mut RewardData =
+                simple_map::borrow_mut(&mut asset_el.rewards, &reward);
+
+            let (new_asset_index, reward_data_updated) =
+                update_reward_data(reward_data, total_supply, asset_unit);
+
+            let (rewards_accrued, user_data_updated) =
+                update_user_data(
+                    reward_data,
+                    user,
+                    user_balance,
+                    new_asset_index,
+                    asset_unit
+                );
+
+            if (reward_data_updated || user_data_updated) {
+                event::emit(
+                    Accrued {
+                        asset,
+                        reward,
+                        user,
+                        asset_index: new_asset_index,
+                        user_index: new_asset_index,
+                        rewards_accrued
+                    }
+                )
+            };
+        };
+    }
+
+    fun update_data_multiple(
+        user: address,
+        user_asset_balances: vector<UserAssetBalance>,
+        rewards_controller_address: address
+    ) acquires RewardsControllerData {
+        for (i in 0..vector::length(&user_asset_balances)) {
+            let user_asset_balances_i = vector::borrow(&user_asset_balances, i);
+            update_data(
+                user_asset_balances_i.asset,
+                user,
+                user_asset_balances_i.user_balance,
+                user_asset_balances_i.total_supply,
+                rewards_controller_address
+            );
+        };
+    }
+
+    fun get_user_reward(
+        user: address,
+        reward: address,
+        user_asset_balances: vector<UserAssetBalance>,
+        rewards_controller_address: address
+    ): u256 acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+
+        let unclaimed_rewards = 0;
+        for (i in 0..vector::length(&user_asset_balances)) {
+            let user_asset_balances_i = vector::borrow(&user_asset_balances, i);
+            let asset =
+                smart_table::borrow(
+                    &rewards_controller_data.assets, user_asset_balances_i.asset
+                );
+            let reward_data: &RewardData = simple_map::borrow(&asset.rewards, &reward);
+            let user_data: &UserData = simple_map::borrow(
+                &reward_data.users_data, &user
+            );
+
+            if (user_asset_balances_i.user_balance == 0) {
+                unclaimed_rewards = unclaimed_rewards + (user_data.accrued as u256);
+            } else {
+                let pending_rewards =
+                    get_pending_rewards(
+                        user,
+                        reward,
+                        user_asset_balances_i,
+                        rewards_controller_data
+                    );
+                unclaimed_rewards = unclaimed_rewards + pending_rewards
+                    + (user_data.accrued as u256);
+            };
+        };
+
+        unclaimed_rewards
+    }
+
+    fun get_pending_rewards(
+        user: address,
+        reward: address,
+        user_asset_balance: &UserAssetBalance,
+        rewards_controller_data: &RewardsControllerData
+    ): u256 {
+        let asset: &AssetData =
+            smart_table::borrow(
+                &rewards_controller_data.assets, user_asset_balance.asset
+            );
+        let reward_data: &RewardData = simple_map::borrow(&asset.rewards, &reward);
+
+        let user_asset =
+            smart_table::borrow(
+                &rewards_controller_data.assets, user_asset_balance.asset
+            );
+
+        let asset_unit = math_utils::pow(10, (user_asset.decimals as u256));
+        let (_, next_index) =
+            get_asset_index_internal(
+                reward_data, user_asset_balance.total_supply, asset_unit
+            );
+
+        let user_data: &UserData = simple_map::borrow(&reward_data.users_data, &user);
+        let index = (user_data.index as u256);
+
+        get_rewards(
+            user_asset_balance.user_balance,
+            next_index,
+            index,
+            asset_unit
+        )
+    }
+
+    fun get_rewards(
+        user_balance: u256,
+        reserve_index: u256,
+        user_index: u256,
+        asset_unit: u256
+    ): u256 {
+        let result = user_balance * (reserve_index - user_index);
+        result / asset_unit
+    }
+
+    fun get_asset_index_internal(
+        reward_data: &RewardData, total_supply: u256, asset_unit: u256
+    ): (u256, u256) {
+        let old_index = (reward_data.index as u256);
+        let distribution_end = (reward_data.distribution_end as u256);
+        let emission_per_second = (reward_data.emission_per_second as u256);
+        let last_update_timestamp = (reward_data.last_update_timestamp as u256);
+
+        if (emission_per_second == 0
+            || total_supply == 0
+            || last_update_timestamp == (timestamp::now_seconds() as u256)
+            || last_update_timestamp >= distribution_end) {
+            return (old_index, old_index)
+        };
+
+        let current_timestamp = (timestamp::now_seconds() as u256);
+
+        if ((timestamp::now_seconds() as u256) > distribution_end) {
+            current_timestamp = distribution_end;
+        };
+
+        let time_delta = current_timestamp - last_update_timestamp;
+        let first_term = emission_per_second * time_delta * asset_unit;
+        first_term = first_term / total_supply;
+        (old_index, (first_term + old_index))
+    }
+
+    #[view]
+    public fun get_asset_decimals(
+        asset: address, rewards_controller_address: address
+    ): u8 acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        let asset = smart_table::borrow(&rewards_controller_data.assets, asset);
+        asset.decimals
+    }
+
+    #[view]
+    public fun get_emission_manager(
+        rewards_controller_address: address
+    ): address acquires RewardsControllerData {
+        let rewards_controller_data =
+            borrow_global<RewardsControllerData>(rewards_controller_address);
+        rewards_controller_data.emission_manager
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/staked_token.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/staked_token.move
@@ -1,0 +1,54 @@
+module aave_pool::staked_token {
+    struct MockStakedToken has key, drop, store, copy {
+        addr: address
+    }
+
+    public fun staked_token(mock_staked_token: &MockStakedToken): address {
+        mock_staked_token.addr
+    }
+
+    public fun stake(
+        _mock_staked_token: &MockStakedToken, _to: address, _amount: u256
+    ) {}
+
+    fun redeem(_to: address, _amount: u256) {}
+
+    fun cooldown() {}
+
+    fun claim_rewards(_to: address, _amount: u256) {}
+
+    public fun create_mock_staked_token(addr: address): MockStakedToken {
+        MockStakedToken { addr }
+    }
+
+    #[test_only]
+    use std::signer;
+
+    #[test(account = @aave_pool)]
+    fun test_create_mock_staked_token(account: &signer) {
+        let addr = signer::address_of(account);
+
+        let mock_staked_token = create_mock_staked_token(addr);
+
+        assert!(mock_staked_token.addr == addr, 0);
+    }
+
+    #[test(_account = @aave_pool)]
+    fun test_cooldown(_account: &signer) {
+        cooldown();
+    }
+
+    #[test(account = @aave_pool)]
+    fun test_redeem(account: &signer) {
+        let to = signer::address_of(account);
+        let amount = 1;
+        redeem(to, amount);
+    }
+
+    #[test(account = @aave_pool)]
+    fun test_claim_rewards(account: &signer) {
+        let to = signer::address_of(account);
+        let amount = 1;
+        claim_rewards(to, amount);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/stream.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/stream.move
@@ -1,0 +1,273 @@
+module aave_pool::stream {
+
+    struct Stream has key, store, drop {
+        deposit: u256,
+        rate_per_second: u256,
+        remaining_balance: u256,
+        start_time: u256,
+        stop_time: u256,
+        recipient: address,
+        sender: address,
+        token_address: address,
+        is_entity: bool
+    }
+
+    public fun recipient(stream: &Stream): address {
+        stream.recipient
+    }
+
+    public fun is_entity(stream: &Stream): bool {
+        stream.is_entity
+    }
+
+    public fun get_stream(stream: &Stream):
+        (
+        address, address, u256, address, u256, u256, u256, u256
+    ) {
+        (
+            stream.sender,
+            stream.recipient,
+            stream.deposit,
+            stream.token_address,
+            stream.start_time,
+            stream.stop_time,
+            stream.remaining_balance,
+            stream.rate_per_second
+        )
+    }
+
+    public fun set_remaining_balance(
+        stream: &mut Stream, remaining_balance: u256
+    ) {
+        stream.remaining_balance = remaining_balance;
+    }
+
+    public fun create_stream(
+        deposit: u256,
+        rate_per_second: u256,
+        remaining_balance: u256,
+        start_time: u256,
+        stop_time: u256,
+        recipient: address,
+        sender: address,
+        token_address: address,
+        is_entity: bool
+    ): Stream {
+        Stream {
+            deposit,
+            rate_per_second,
+            remaining_balance,
+            start_time,
+            stop_time,
+            recipient,
+            sender,
+            token_address,
+            is_entity
+        }
+    }
+
+    #[test_only]
+    use std::signer;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(account = @aave_pool)]
+    fun test_create_stream(account: &signer) {
+        let deposit = 1;
+        let rate_per_second = 1;
+        let remaining_balance = 1;
+        let start_time = 1;
+        let stop_time = 1;
+        let recipient = signer::address_of(account);
+        let sender = signer::address_of(account);
+        let token_address = signer::address_of(account);
+        let is_entity = true;
+
+        let stream =
+            create_stream(
+                deposit,
+                rate_per_second,
+                remaining_balance,
+                start_time,
+                stop_time,
+                recipient,
+                sender,
+                token_address,
+                is_entity
+            );
+
+        assert!(stream.deposit == deposit, TEST_SUCCESS);
+        assert!(stream.rate_per_second == rate_per_second, TEST_SUCCESS);
+        assert!(stream.remaining_balance == remaining_balance, TEST_SUCCESS);
+        assert!(stream.start_time == start_time, TEST_SUCCESS);
+        assert!(stream.stop_time == stop_time, TEST_SUCCESS);
+        assert!(stream.recipient == recipient, TEST_SUCCESS);
+        assert!(stream.sender == sender, TEST_SUCCESS);
+        assert!(stream.token_address == token_address, TEST_SUCCESS);
+        assert!(stream.is_entity == is_entity, TEST_SUCCESS);
+    }
+
+    #[test(account = @aave_pool)]
+    fun test_is_entity(account: &signer) {
+        let deposit = 1;
+        let rate_per_second = 1;
+        let remaining_balance = 1;
+        let start_time = 1;
+        let stop_time = 1;
+        let recipient = signer::address_of(account);
+        let sender = signer::address_of(account);
+        let token_address = signer::address_of(account);
+        let _is_entity = true;
+
+        let stream_true =
+            create_stream(
+                deposit,
+                rate_per_second,
+                remaining_balance,
+                start_time,
+                stop_time,
+                recipient,
+                sender,
+                token_address,
+                true
+            );
+
+        assert!(is_entity(&stream_true) == true, TEST_SUCCESS);
+
+        let stream_false =
+            create_stream(
+                deposit,
+                rate_per_second,
+                remaining_balance,
+                start_time,
+                stop_time,
+                recipient,
+                sender,
+                token_address,
+                false
+            );
+
+        assert!(is_entity(&stream_false) == false, TEST_SUCCESS);
+    }
+
+    #[test(account = @aave_pool)]
+    fun test_recipient(account: &signer) {
+        let deposit = 1;
+        let rate_per_second = 1;
+        let remaining_balance = 1;
+        let start_time = 1;
+        let stop_time = 1;
+        let recipient = signer::address_of(account);
+        let sender = signer::address_of(account);
+        let token_address = signer::address_of(account);
+        let is_entity = true;
+
+        let stream_true =
+            create_stream(
+                deposit,
+                rate_per_second,
+                remaining_balance,
+                start_time,
+                stop_time,
+                recipient,
+                sender,
+                token_address,
+                is_entity
+            );
+
+        assert!(recipient(&stream_true) == recipient, TEST_SUCCESS);
+    }
+
+    #[test(account = @aave_pool)]
+    fun test_get_stream(account: &signer) {
+        let arg_deposit = 1;
+        let arg_rate_per_second = 1;
+        let arg_remaining_balance = 1;
+        let arg_start_time = 1;
+        let arg_stop_time = 1;
+        let arg_recipient = signer::address_of(account);
+        let arg_sender = signer::address_of(account);
+        let arg_token_address = signer::address_of(account);
+        let arg_is_entity = true;
+
+        let stream =
+            create_stream(
+                arg_deposit,
+                arg_rate_per_second,
+                arg_remaining_balance,
+                arg_start_time,
+                arg_stop_time,
+                arg_recipient,
+                arg_sender,
+                arg_token_address,
+                arg_is_entity
+            );
+
+        let (
+            _sender,
+            _recipient,
+            _deposit,
+            _token_address,
+            _start_time,
+            _stop_time,
+            _remaining_balance,
+            _rate_per_second
+        ) = get_stream(&stream);
+
+        assert!(stream.deposit == arg_deposit, TEST_SUCCESS);
+        assert!(stream.rate_per_second == arg_rate_per_second, TEST_SUCCESS);
+        assert!(stream.remaining_balance == arg_remaining_balance, TEST_SUCCESS);
+        assert!(stream.start_time == arg_start_time, TEST_SUCCESS);
+        assert!(stream.stop_time == arg_stop_time, TEST_SUCCESS);
+        assert!(stream.recipient == arg_recipient, TEST_SUCCESS);
+        assert!(stream.sender == arg_sender, TEST_SUCCESS);
+        assert!(stream.token_address == arg_token_address, TEST_SUCCESS);
+        assert!(stream.is_entity == arg_is_entity, TEST_SUCCESS);
+    }
+
+    #[test(account = @aave_pool)]
+    fun test_set_remaining_balance(account: &signer) {
+        let arg_deposit = 1;
+        let arg_rate_per_second = 1;
+        let arg_remaining_balance = 1;
+        let arg_start_time = 1;
+        let arg_stop_time = 1;
+        let arg_recipient = signer::address_of(account);
+        let arg_sender = signer::address_of(account);
+        let arg_token_address = signer::address_of(account);
+        let arg_is_entity = true;
+
+        let stream =
+            create_stream(
+                arg_deposit,
+                arg_rate_per_second,
+                arg_remaining_balance,
+                arg_start_time,
+                arg_stop_time,
+                arg_recipient,
+                arg_sender,
+                arg_token_address,
+                arg_is_entity
+            );
+
+        let (
+            _sender,
+            _recipient,
+            _deposit,
+            _token_address,
+            _start_time,
+            _stop_time,
+            _remaining_balance,
+            _rate_per_second
+        ) = get_stream(&stream);
+
+        assert!(stream.remaining_balance == arg_remaining_balance, TEST_SUCCESS);
+
+        let new_remaining_balance = 10;
+
+        set_remaining_balance(&mut stream, new_remaining_balance);
+
+        assert!(stream.remaining_balance == new_remaining_balance, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/transfer_strategy.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/transfer_strategy.move
@@ -1,0 +1,1312 @@
+module aave_pool::transfer_strategy {
+    use std::option::{Self, Option};
+    use std::signer;
+    use aptos_framework::event;
+
+    use aave_acl::acl_manage::Self;
+    use aave_oracle::reward_oracle::RewardOracle;
+
+    use aave_pool::staked_token::{MockStakedToken, stake, staked_token};
+
+    #[test_only]
+    use std::string::utf8;
+
+    const ONLY_REWARDS_ADMIN: u64 = 1;
+    const CALLER_NOT_INCENTIVES_CONTROLLER: u64 = 2;
+    const REWARD_TOKEN_NOT_STAKE_CONTRACT: u64 = 3;
+    const TOO_MANY_STRATEGIES: u64 = 4;
+    const NOT_EMISSION_ADMIN: u64 = 5;
+
+    const EMISSION_MANAGER_NAME: vector<u8> = b"EMISSION_MANAGER";
+
+    public fun check_is_emission_admin(account: address) {
+        assert!(acl_manage::is_emission_admin(account), NOT_EMISSION_ADMIN);
+    }
+
+    struct PullRewardsTransferStrategy has key, drop, store, copy {
+        rewards_admin: address,
+        incentives_controller: address,
+        rewards_vault: address
+    }
+
+    public fun create_pull_rewards_transfer_strategy(
+        rewards_admin: address, incentives_controller: address, rewards_vault: address
+    ): PullRewardsTransferStrategy {
+        PullRewardsTransferStrategy { rewards_admin, incentives_controller, rewards_vault }
+    }
+
+    public fun pull_rewards_transfer_strategy_perform_transfer(
+        caller: &signer,
+        _to: address,
+        _reward: address,
+        _amount: u256,
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ): bool {
+        pull_rewards_transfer_strategy_only_incentives_controller(
+            caller, &pull_rewards_transfer_strategy
+        );
+
+        // mock_underlying_token_factory::transfer_from(
+        //     pull_rewards_transfer_strategy.rewards_vault,
+        //     to,
+        //     (amount as u64),
+        //     reward
+        // );
+
+        true
+    }
+
+    public fun pull_rewards_transfer_strategy_get_rewards_vault(
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ): address {
+        pull_rewards_transfer_strategy.rewards_vault
+    }
+
+    fun pull_rewards_transfer_strategy_only_rewards_admin(
+        caller: &signer, pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ) {
+        assert!(
+            signer::address_of(caller) == pull_rewards_transfer_strategy.rewards_admin,
+            ONLY_REWARDS_ADMIN
+        );
+    }
+
+    fun pull_rewards_transfer_strategy_only_incentives_controller(
+        caller: &signer, pull_rewards_transfer_strategy: &PullRewardsTransferStrategy
+    ) {
+        assert!(
+            signer::address_of(caller)
+                == pull_rewards_transfer_strategy.incentives_controller,
+            CALLER_NOT_INCENTIVES_CONTROLLER
+        );
+    }
+
+    public fun pull_rewards_transfer_strategy_get_incentives_controller(
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ): address {
+        pull_rewards_transfer_strategy.incentives_controller
+    }
+
+    public fun pull_rewards_transfer_strategy_get_rewards_admin(
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ): address {
+        pull_rewards_transfer_strategy.rewards_admin
+    }
+
+    fun pull_rewards_transfer_strategy_emergency_withdrawal(
+        caller: &signer,
+        token: address,
+        to: address,
+        amount: u256,
+        pull_rewards_transfer_strategy: PullRewardsTransferStrategy
+    ) {
+        pull_rewards_transfer_strategy_only_rewards_admin(
+            caller, pull_rewards_transfer_strategy
+        );
+
+        // mock_underlying_token_factory::transfer_from(
+        //     signer::address_of(caller),
+        //     to,
+        //     (amount as u64),
+        //     token
+        // );
+
+        emit_emergency_withdrawal_event(caller, token, to, amount);
+    }
+
+    struct StakedTokenTransferStrategy has key, drop, store, copy {
+        rewards_admin: address,
+        incentives_controller: address,
+        stake_contract: MockStakedToken,
+        underlying_token: address
+    }
+
+    public fun create_staked_token_transfer_strategy(
+        rewards_admin: address,
+        incentives_controller: address,
+        stake_contract: MockStakedToken,
+        underlying_token: address
+    ): StakedTokenTransferStrategy {
+        StakedTokenTransferStrategy {
+            rewards_admin,
+            incentives_controller,
+            stake_contract,
+            underlying_token
+        }
+    }
+
+    public fun staked_token_transfer_strategy_perform_transfer(
+        caller: &signer,
+        to: address,
+        reward: address,
+        amount: u256,
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ): bool {
+        staked_token_transfer_strategy_only_incentives_controller(
+            caller, &staked_token_transfer_strategy
+        );
+        assert!(
+            reward == staked_token(&staked_token_transfer_strategy.stake_contract),
+            REWARD_TOKEN_NOT_STAKE_CONTRACT
+        );
+
+        stake(&staked_token_transfer_strategy.stake_contract, to, amount);
+
+        true
+    }
+
+    public fun staked_token_transfer_strategy_get_stake_contract(
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ): address {
+        staked_token(&staked_token_transfer_strategy.stake_contract)
+    }
+
+    public fun staked_token_transfer_strategy_get_underlying_token(
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ): address {
+        staked_token_transfer_strategy.underlying_token
+    }
+
+    fun staked_token_transfer_strategy_only_rewards_admin(
+        caller: &signer, staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ) {
+        assert!(
+            signer::address_of(caller) == staked_token_transfer_strategy.rewards_admin,
+            ONLY_REWARDS_ADMIN
+        );
+    }
+
+    fun staked_token_transfer_strategy_only_incentives_controller(
+        caller: &signer, staked_token_transfer_strategy: &StakedTokenTransferStrategy
+    ) {
+        assert!(
+            signer::address_of(caller)
+                == staked_token_transfer_strategy.incentives_controller,
+            CALLER_NOT_INCENTIVES_CONTROLLER
+        );
+    }
+
+    public fun staked_token_transfer_strategy_get_incentives_controller(
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ): address {
+        staked_token_transfer_strategy.incentives_controller
+    }
+
+    public fun staked_token_transfer_strategy_get_rewards_admin(
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ): address {
+        staked_token_transfer_strategy.rewards_admin
+    }
+
+    fun staked_token_transfer_strategy_emergency_withdrawal(
+        caller: &signer,
+        token: address,
+        to: address,
+        amount: u256,
+        staked_token_transfer_strategy: StakedTokenTransferStrategy
+    ) {
+        staked_token_transfer_strategy_only_rewards_admin(
+            caller, staked_token_transfer_strategy
+        );
+
+        // mock_underlying_token_factory::transfer_from(
+        //     signer::address_of(caller),
+        //     to,
+        //     (amount as u64),
+        //     token
+        // );
+
+        emit_emergency_withdrawal_event(caller, token, to, amount);
+    }
+
+    struct RewardsConfigInput has store, drop {
+        emission_per_second: u128,
+        total_supply: u256,
+        distribution_end: u32,
+        asset: address,
+        reward: address,
+        staked_token_transfer_strategy: Option<StakedTokenTransferStrategy>,
+        pull_rewards_transfer_strategy: Option<PullRewardsTransferStrategy>,
+        reward_oracle: RewardOracle
+    }
+
+    public fun create_rewards_config_input(
+        emission_per_second: u128,
+        total_supply: u256,
+        distribution_end: u32,
+        asset: address,
+        reward: address,
+        staked_token_transfer_strategy: Option<StakedTokenTransferStrategy>,
+        pull_rewards_transfer_strategy: Option<PullRewardsTransferStrategy>,
+        reward_oracle: RewardOracle
+    ): RewardsConfigInput {
+        RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        }
+    }
+
+    public fun get_reward(rewards_config_input: &RewardsConfigInput): address {
+        rewards_config_input.reward
+    }
+
+    public fun get_reward_oracle(
+        rewards_config_input: &RewardsConfigInput
+    ): RewardOracle {
+        rewards_config_input.reward_oracle
+    }
+
+    public fun get_asset(rewards_config_input: &RewardsConfigInput): address {
+        rewards_config_input.asset
+    }
+
+    public fun get_total_supply(rewards_config_input: &RewardsConfigInput): u256 {
+        rewards_config_input.total_supply
+    }
+
+    public fun get_emission_per_second(
+        rewards_config_input: &RewardsConfigInput
+    ): u128 {
+        rewards_config_input.emission_per_second
+    }
+
+    public fun get_distribution_end(
+        rewards_config_input: &RewardsConfigInput
+    ): u32 {
+        rewards_config_input.distribution_end
+    }
+
+    public fun set_total_supply(
+        rewards_config_input: &mut RewardsConfigInput, total_supply: u256
+    ) {
+        rewards_config_input.total_supply = total_supply;
+    }
+
+    public fun pull_rewards_transfer_strategy_get_strategy(
+        rewards_config_input: &RewardsConfigInput
+    ): PullRewardsTransferStrategy {
+        *option::borrow(&rewards_config_input.pull_rewards_transfer_strategy)
+    }
+
+    public fun staked_token_transfer_strategy_get_strategy(
+        rewards_config_input: &RewardsConfigInput
+    ): StakedTokenTransferStrategy {
+        *option::borrow(&rewards_config_input.staked_token_transfer_strategy)
+    }
+
+    public fun validate_rewards_config_input(
+        rewards_config_input: &RewardsConfigInput
+    ) {
+        assert!(
+            (
+                option::is_some(&rewards_config_input.staked_token_transfer_strategy)
+                    && !option::is_some(
+                        &rewards_config_input.pull_rewards_transfer_strategy
+                    )
+            )
+                || (
+                    !option::is_some(&rewards_config_input.staked_token_transfer_strategy)
+                        && option::is_some(
+                            &rewards_config_input.pull_rewards_transfer_strategy
+                        )
+                ),
+            TOO_MANY_STRATEGIES
+        );
+    }
+
+    public fun has_pull_rewards_transfer_strategy(
+        rewards_config_input: &RewardsConfigInput
+    ): bool {
+        option::is_some(&rewards_config_input.pull_rewards_transfer_strategy)
+    }
+
+    #[event]
+    struct EmergencyWithdrawal has store, drop {
+        caller: address,
+        token: address,
+        to: address,
+        amount: u256
+    }
+
+    public fun emit_emergency_withdrawal_event(
+        caller: &signer,
+        token: address,
+        to: address,
+        amount: u256
+    ) {
+        event::emit(
+            EmergencyWithdrawal { caller: signer::address_of(caller), token, to, amount }
+        );
+    }
+
+    #[test_only]
+    const TEST_SUCCESS: u64 = 1;
+    #[test_only]
+    const TEST_FAILED: u64 = 2;
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_get_reward(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        assert!(
+            get_reward(&rewards_config_input) == rewards_admin,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_get_reward_oracle(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        assert!(
+            get_reward_oracle(&rewards_config_input) == reward_oracle,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_get_asset(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        assert!(
+            get_asset(&rewards_config_input) == asset,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_get_total_supply(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        assert!(
+            get_total_supply(&rewards_config_input) == total_supply,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_get_emission_per_second(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        assert!(
+            get_emission_per_second(&rewards_config_input) == emission_per_second,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_get_distribution_end(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        assert!(
+            get_distribution_end(&rewards_config_input) == distribution_end,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_validate_rewards_config_input(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let _stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy = option::none();
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        validate_rewards_config_input(&rewards_config_input);
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_set_total_supply(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let pull_rewards_transfer_strategy =
+            option::some(
+                create_pull_rewards_transfer_strategy(
+                    rewards_admin, incentives_controller, rewards_vault
+                )
+            );
+        let staked_token_transfer_strategy =
+            option::some(
+                create_staked_token_transfer_strategy(
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                )
+            );
+
+        let emission_per_second = 0;
+        let total_supply = 0;
+        let distribution_end = 0;
+        let asset = underlying_token;
+        let reward = underlying_token;
+
+        let id = 1;
+        let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+
+        let rewards_config_input = RewardsConfigInput {
+            emission_per_second,
+            total_supply,
+            distribution_end,
+            asset,
+            reward,
+            staked_token_transfer_strategy,
+            pull_rewards_transfer_strategy,
+            reward_oracle
+        };
+
+        let new_total_supply = 10;
+
+        set_total_supply(&mut rewards_config_input, new_total_supply);
+
+        assert!(
+            rewards_config_input.total_supply == new_total_supply,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            _aave_role_super_admin = @aave_acl,
+            _periphery_account = @aave_pool,
+            _acl_fund_admin = @0x111,
+            _user_account = @0x222,
+            _creator = @0x1,
+            underlying_tokens_admin = @underlying_tokens,
+            _aave_pool = @aave_pool
+        )
+    ]
+    fun test_pull_rewards_transfer_strategy_perform_transfer(
+        _aave_role_super_admin: &signer,
+        _periphery_account: &signer,
+        _acl_fund_admin: &signer,
+        _user_account: &signer,
+        _creator: &signer,
+        underlying_tokens_admin: &signer,
+        _aave_pool: &signer
+    ) {
+        let pull_rewards_transfer_strategy = PullRewardsTransferStrategy {
+            rewards_admin: signer::address_of(underlying_tokens_admin),
+            incentives_controller: signer::address_of(underlying_tokens_admin),
+            rewards_vault: signer::address_of(underlying_tokens_admin)
+        };
+
+        // mock_underlying_token_factory::test_init_module(aave_pool);
+        // let underlying_token_name = utf8(b"TOKEN_1");
+        // let underlying_token_symbol = utf8(b"T1");
+        // let underlying_token_decimals = 3;
+        // let underlying_token_max_supply = 10000;
+        //
+        // mock_underlying_token_factory::create_token(
+        //     underlying_tokens_admin,
+        //     underlying_token_max_supply,
+        //     underlying_token_name,
+        //     underlying_token_symbol,
+        //     underlying_token_decimals,
+        //     utf8(b""),
+        //     utf8(b"")
+        // );
+        // let underlying_token_address =
+        //     mock_underlying_token_factory::token_address(underlying_token_symbol);
+        //
+        // mock_underlying_token_factory::mint(
+        //     underlying_tokens_admin,
+        //     signer::address_of(underlying_tokens_admin),
+        //     100,
+        //     underlying_token_address
+        // );
+
+        let caller: &signer = underlying_tokens_admin;
+        let to: address = signer::address_of(underlying_tokens_admin);
+        let reward: address = @0x0;
+        let amount: u256 = 1;
+
+        pull_rewards_transfer_strategy_perform_transfer(
+            caller,
+            to,
+            reward,
+            amount,
+            pull_rewards_transfer_strategy
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_pull_rewards_transfer_strategy_get_rewards_vault(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let pull_rewards_transfer_strategy =
+            create_pull_rewards_transfer_strategy(
+                rewards_admin, incentives_controller, rewards_vault
+            );
+
+        assert!(
+            pull_rewards_transfer_strategy
+                == PullRewardsTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    rewards_vault
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            pull_rewards_transfer_strategy_get_rewards_vault(
+                pull_rewards_transfer_strategy
+            ) == rewards_vault,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_pull_rewards_transfer_strategy_get_incentives_controller(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let pull_rewards_transfer_strategy =
+            create_pull_rewards_transfer_strategy(
+                rewards_admin, incentives_controller, rewards_vault
+            );
+
+        assert!(
+            pull_rewards_transfer_strategy
+                == PullRewardsTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    rewards_vault
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            pull_rewards_transfer_strategy_get_incentives_controller(
+                pull_rewards_transfer_strategy
+            ) == incentives_controller,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_pull_rewards_transfer_strategy_get_rewards_admin(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let rewards_vault = signer::address_of(underlying_tokens_admin);
+
+        let pull_rewards_transfer_strategy =
+            create_pull_rewards_transfer_strategy(
+                rewards_admin, incentives_controller, rewards_vault
+            );
+
+        assert!(
+            pull_rewards_transfer_strategy
+                == PullRewardsTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    rewards_vault
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            pull_rewards_transfer_strategy_get_rewards_admin(
+                pull_rewards_transfer_strategy
+            ) == rewards_admin,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_staked_token_transfer_strategy_get_rewards_admin(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let staked_token_transfer_strategy =
+            create_staked_token_transfer_strategy(
+                rewards_admin,
+                incentives_controller,
+                stake_contract,
+                underlying_token
+            );
+
+        assert!(
+            staked_token_transfer_strategy
+                == StakedTokenTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            staked_token_transfer_strategy_get_rewards_admin(
+                staked_token_transfer_strategy
+            ) == rewards_admin,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_staked_token_transfer_strategy_get_incentives_controller(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let staked_token_transfer_strategy =
+            create_staked_token_transfer_strategy(
+                rewards_admin,
+                incentives_controller,
+                stake_contract,
+                underlying_token
+            );
+
+        assert!(
+            staked_token_transfer_strategy
+                == StakedTokenTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            staked_token_transfer_strategy_get_incentives_controller(
+                staked_token_transfer_strategy
+            ) == incentives_controller,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_staked_token_transfer_strategy_get_underlying_token(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let staked_token_transfer_strategy =
+            create_staked_token_transfer_strategy(
+                rewards_admin,
+                incentives_controller,
+                stake_contract,
+                underlying_token
+            );
+
+        assert!(
+            staked_token_transfer_strategy
+                == StakedTokenTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            staked_token_transfer_strategy_get_underlying_token(
+                staked_token_transfer_strategy
+            ) == underlying_token,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(underlying_tokens_admin = @underlying_tokens, _aave_pool = @aave_pool)]
+    fun test_staked_token_transfer_strategy_get_stake_contract(
+        underlying_tokens_admin: &signer, _aave_pool: &signer
+    ) {
+        let rewards_admin = signer::address_of(underlying_tokens_admin);
+        let incentives_controller = signer::address_of(underlying_tokens_admin);
+        let underlying_token = signer::address_of(underlying_tokens_admin);
+
+        let stake_contract =
+            aave_pool::staked_token::create_mock_staked_token(underlying_token);
+
+        let staked_token_transfer_strategy =
+            create_staked_token_transfer_strategy(
+                rewards_admin,
+                incentives_controller,
+                stake_contract,
+                underlying_token
+            );
+
+        assert!(
+            staked_token_transfer_strategy
+                == StakedTokenTransferStrategy {
+                    rewards_admin,
+                    incentives_controller,
+                    stake_contract,
+                    underlying_token
+                },
+            TEST_SUCCESS
+        );
+
+        assert!(
+            staked_token_transfer_strategy_get_stake_contract(
+                staked_token_transfer_strategy
+            ) == staked_token(&staked_token_transfer_strategy.stake_contract),
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            _aave_role_super_admin = @aave_acl,
+            _periphery_account = @aave_pool,
+            _acl_fund_admin = @0x111,
+            _user_account = @0x222,
+            _creator = @0x1,
+            underlying_tokens_admin = @underlying_tokens,
+            _aave_pool = @aave_pool
+        )
+    ]
+    fun test_pull_rewards_transfer_strategy_emergency_withdrawal(
+        _aave_role_super_admin: &signer,
+        _periphery_account: &signer,
+        _acl_fund_admin: &signer,
+        _user_account: &signer,
+        _creator: &signer,
+        underlying_tokens_admin: &signer,
+        _aave_pool: &signer
+    ) {
+        let pull_rewards_transfer_strategy = PullRewardsTransferStrategy {
+            rewards_admin: signer::address_of(underlying_tokens_admin),
+            incentives_controller: signer::address_of(underlying_tokens_admin),
+            rewards_vault: signer::address_of(underlying_tokens_admin)
+        };
+
+        // mock_underlying_token_factory::test_init_module(aave_pool);
+        let _underlying_token_name = utf8(b"TOKEN_1");
+        let _underlying_token_symbol = utf8(b"T1");
+        let _underlying_token_decimals = 3;
+        let _underlying_token_max_supply = 10000;
+
+        // mock_underlying_token_factory::create_token(
+        //     underlying_tokens_admin,
+        //     underlying_token_max_supply,
+        //     underlying_token_name,
+        //     underlying_token_symbol,
+        //     underlying_token_decimals,
+        //     utf8(b""),
+        //     utf8(b"")
+        // );
+        // let underlying_token_address =
+        //     mock_underlying_token_factory::token_address(underlying_token_symbol);
+        //
+        // mock_underlying_token_factory::mint(
+        //     underlying_tokens_admin,
+        //     signer::address_of(underlying_tokens_admin),
+        //     100,
+        //     underlying_token_address
+        // );
+
+        let caller: &signer = underlying_tokens_admin;
+        let to: address = signer::address_of(underlying_tokens_admin);
+        let reward: address = @0x0;
+        let amount: u256 = 1;
+
+        pull_rewards_transfer_strategy_perform_transfer(
+            caller,
+            to,
+            reward,
+            amount,
+            pull_rewards_transfer_strategy
+        );
+
+        pull_rewards_transfer_strategy_emergency_withdrawal(
+            caller,
+            @0x0,
+            to,
+            amount,
+            pull_rewards_transfer_strategy
+        );
+    }
+
+    #[
+        test(
+            _aave_role_super_admin = @aave_acl,
+            _periphery_account = @aave_pool,
+            _acl_fund_admin = @0x111,
+            _user_account = @0x222,
+            _creator = @0x1,
+            underlying_tokens_admin = @underlying_tokens,
+            _aave_pool = @aave_pool
+        )
+    ]
+    fun test_staked_token_transfer_strategy_perform_transfer(
+        _aave_role_super_admin: &signer,
+        _periphery_account: &signer,
+        _acl_fund_admin: &signer,
+        _user_account: &signer,
+        _creator: &signer,
+        underlying_tokens_admin: &signer,
+        _aave_pool: &signer
+    ) {
+        // mock_underlying_token_factory::test_init_module(aave_pool);
+        // let underlying_token_name = utf8(b"TOKEN_1");
+        // let underlying_token_symbol = utf8(b"T1");
+        // let underlying_token_decimals = 3;
+        // let underlying_token_max_supply = 10000;
+        //
+        // mock_underlying_token_factory::create_token(
+        //     underlying_tokens_admin,
+        //     underlying_token_max_supply,
+        //     underlying_token_name,
+        //     underlying_token_symbol,
+        //     underlying_token_decimals,
+        //     utf8(b""),
+        //     utf8(b"")
+        // );
+        // let underlying_token_address =
+        //     mock_underlying_token_factory::token_address(underlying_token_symbol);
+        //
+        // mock_underlying_token_factory::mint(
+        //     underlying_tokens_admin,
+        //     signer::address_of(underlying_tokens_admin),
+        //     100,
+        //     underlying_token_address
+        // );
+
+        let staked_token_transfer_strategy = StakedTokenTransferStrategy {
+            rewards_admin: signer::address_of(underlying_tokens_admin),
+            incentives_controller: signer::address_of(underlying_tokens_admin),
+            stake_contract: aave_pool::staked_token::create_mock_staked_token(
+                signer::address_of(underlying_tokens_admin)
+            ),
+            underlying_token: @0x0
+        };
+
+        let caller: &signer = underlying_tokens_admin;
+        let to: address = signer::address_of(underlying_tokens_admin);
+        let reward: address = signer::address_of(underlying_tokens_admin);
+        let amount: u256 = 1;
+
+        staked_token_transfer_strategy_perform_transfer(
+            caller,
+            to,
+            reward,
+            amount,
+            staked_token_transfer_strategy
+        );
+    }
+
+    #[
+        test(
+            _aave_role_super_admin = @aave_acl,
+            _periphery_account = @aave_pool,
+            _acl_fund_admin = @0x111,
+            _user_account = @0x222,
+            _creator = @0x1,
+            underlying_tokens_admin = @underlying_tokens,
+            _aave_pool = @aave_pool
+        )
+    ]
+    fun test_staked_token_transfer_strategy_emergency_withdrawal(
+        _aave_role_super_admin: &signer,
+        _periphery_account: &signer,
+        _acl_fund_admin: &signer,
+        _user_account: &signer,
+        _creator: &signer,
+        underlying_tokens_admin: &signer,
+        _aave_pool: &signer
+    ) {
+        // mock_underlying_token_factory::test_init_module(aave_pool);
+        let _underlying_token_name = utf8(b"TOKEN_1");
+        let _underlying_token_symbol = utf8(b"T1");
+        let _underlying_token_decimals = 3;
+        let _underlying_token_max_supply = 10000;
+
+        // mock_underlying_token_factory::create_token(
+        //     underlying_tokens_admin,
+        //     underlying_token_max_supply,
+        //     underlying_token_name,
+        //     underlying_token_symbol,
+        //     underlying_token_decimals,
+        //     utf8(b""),
+        //     utf8(b"")
+        // );
+        // let underlying_token_address =
+        //     mock_underlying_token_factory::token_address(underlying_token_symbol);
+        //
+        // mock_underlying_token_factory::mint(
+        //     underlying_tokens_admin,
+        //     signer::address_of(underlying_tokens_admin),
+        //     100,
+        //     underlying_token_address
+        // );
+
+        let staked_token_transfer_strategy = StakedTokenTransferStrategy {
+            rewards_admin: signer::address_of(underlying_tokens_admin),
+            incentives_controller: signer::address_of(underlying_tokens_admin),
+            stake_contract: aave_pool::staked_token::create_mock_staked_token(
+                signer::address_of(underlying_tokens_admin)
+            ),
+            underlying_token: @0x0
+        };
+
+        let caller: &signer = underlying_tokens_admin;
+        let to: address = signer::address_of(underlying_tokens_admin);
+        let reward: address = signer::address_of(underlying_tokens_admin);
+        let amount: u256 = 1;
+
+        staked_token_transfer_strategy_perform_transfer(
+            caller,
+            to,
+            reward,
+            amount,
+            staked_token_transfer_strategy
+        );
+
+        staked_token_transfer_strategy_emergency_withdrawal(
+            caller,
+            @0x0,
+            to,
+            amount,
+            staked_token_transfer_strategy
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/ui_incentive_data_provider_v3.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/ui_incentive_data_provider_v3.move
@@ -1,0 +1,683 @@
+module aave_pool::ui_incentive_data_provider_v3 {
+    use std::string::String;
+    use std::vector;
+    use aptos_framework::object::{Self, Object};
+    use aave_pool::rewards_controller::Self;
+    use aave_pool::eac_aggregator_proxy::Self;
+    use aave_pool::pool::{Self};
+    use aave_pool::a_token_factory::Self;
+
+    const EMPTY_ADDRESS: address = @0x0;
+
+    const UI_INCENTIVE_DATA_PROVIDER_V3_NAME: vector<u8> = b"AAVE_UI_INCENTIVE_DATA_PROVIDER_V3";
+
+    struct UiIncentiveDataProviderV3Data has key {}
+
+    struct AggregatedReserveIncentiveData has store, drop {
+        underlying_asset: address,
+        a_incentive_data: IncentiveData,
+        v_incentive_data: IncentiveData
+    }
+
+    struct IncentiveData has store, drop {
+        token_address: address,
+        incentive_controller_address: address,
+        rewards_token_information: vector<RewardInfo>
+    }
+
+    struct RewardInfo has store, drop {
+        reward_token_symbol: String,
+        reward_token_address: address,
+        reward_oracle_address: address,
+        emission_per_second: u256,
+        incentives_last_update_timestamp: u256,
+        token_incentives_index: u256,
+        emission_end_timestamp: u256,
+        reward_price_feed: u256,
+        reward_token_decimals: u8,
+        precision: u8,
+        price_feed_decimals: u8
+    }
+
+    struct UserReserveIncentiveData has store, drop {
+        underlying_asset: address,
+        a_token_incentives_user_data: UserIncentiveData,
+        v_token_incentives_user_data: UserIncentiveData
+    }
+
+    struct UserIncentiveData has store, drop {
+        token_address: address,
+        incentive_controller_address: address,
+        user_rewards_information: vector<UserRewardInfo>
+    }
+
+    struct UserRewardInfo has store, drop {
+        reward_token_symbol: String,
+        reward_oracle_address: address,
+        reward_token_address: address,
+        user_unclaimed_rewards: u256,
+        token_incentives_user_index: u256,
+        reward_price_feed: u256,
+        price_feed_decimals: u8,
+        reward_token_decimals: u8
+    }
+
+    fun init_module(sender: &signer) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, UI_INCENTIVE_DATA_PROVIDER_V3_NAME);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        move_to(
+            state_object_signer,
+            UiIncentiveDataProviderV3Data {}
+        );
+    }
+
+    #[test_only]
+    public fun init_module_test(sender: &signer) {
+        init_module(sender);
+    }
+
+    #[view]
+    public fun ui_incentive_data_provider_v3_data_address(): address {
+        object::create_object_address(&@aave_pool, UI_INCENTIVE_DATA_PROVIDER_V3_NAME)
+    }
+
+    #[view]
+    public fun ui_incentive_data_provider_v3_data_object():
+        Object<UiIncentiveDataProviderV3Data> {
+        object::address_to_object<UiIncentiveDataProviderV3Data>(
+            ui_incentive_data_provider_v3_data_address()
+        )
+    }
+
+    #[view]
+    public fun get_full_reserves_incentive_data(
+        user: address
+    ): (vector<AggregatedReserveIncentiveData>, vector<UserReserveIncentiveData>) {
+        (get_reserves_incentives_data(), get_user_reserves_incentives_data(user))
+    }
+
+    #[view]
+    public fun get_reserves_incentives_data(): vector<AggregatedReserveIncentiveData> {
+        let reserves = pool::get_reserves_list();
+        let reserves_incentives_data = vector::empty<AggregatedReserveIncentiveData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let underlying_asset = *vector::borrow(&reserves, i);
+            let base_data = pool::get_reserve_data(underlying_asset);
+            let rewards_controller_address =
+                rewards_controller::rewards_controller_address();
+            // TODO Waiting for Chainlink oracle functionality
+            let reward_oracle_address = @aave_oracle;
+
+            if (rewards_controller_address != EMPTY_ADDRESS) {
+
+                // ===================== a token ====================
+                let a_token_address = pool::get_reserve_a_token_address(&base_data);
+                let a_token_reward_addresses =
+                    rewards_controller::get_rewards_by_asset(
+                        a_token_address, rewards_controller_address
+                    );
+                let reward_information: vector<RewardInfo> = vector[];
+
+                for (j in 0..vector::length(&a_token_reward_addresses)) {
+                    let reward_token_address =
+                        *vector::borrow(&a_token_reward_addresses, j);
+
+                    let (
+                        token_incentives_index,
+                        emission_per_second,
+                        incentives_last_update_timestamp,
+                        emission_end_timestamp
+                    ) =
+                        rewards_controller::get_rewards_data(
+                            a_token_address,
+                            reward_token_address,
+                            rewards_controller_address
+                        );
+
+                    let precision =
+                        rewards_controller::get_asset_decimals(
+                            a_token_address, rewards_controller_address
+                        );
+                    let reward_token_decimals =
+                        a_token_factory::decimals(reward_token_address);
+                    let reward_token_symbol =
+                        a_token_factory::symbol(reward_token_address);
+
+                    let price_feed_decimals = eac_aggregator_proxy::decimals();
+                    let reward_price_feed = eac_aggregator_proxy::latest_answer();
+
+                    vector::push_back(
+                        &mut reward_information,
+                        RewardInfo {
+                            reward_token_symbol,
+                            reward_token_address,
+                            reward_oracle_address,
+                            emission_per_second,
+                            incentives_last_update_timestamp,
+                            token_incentives_index,
+                            emission_end_timestamp,
+                            reward_price_feed,
+                            reward_token_decimals,
+                            precision,
+                            price_feed_decimals
+                        }
+                    );
+                };
+
+                let a_incentive_data = IncentiveData {
+                    token_address: a_token_address,
+                    incentive_controller_address: rewards_controller_address,
+                    rewards_token_information: reward_information
+                };
+
+                // ===================== variable debt token ====================
+                let variable_debt_token_address =
+                    pool::get_reserve_variable_debt_token_address(&base_data);
+                let var_debt_token_reward_addresses =
+                    rewards_controller::get_rewards_by_asset(
+                        variable_debt_token_address,
+                        rewards_controller_address
+                    );
+                let reward_information: vector<RewardInfo> = vector[];
+
+                for (j in 0..vector::length(&var_debt_token_reward_addresses)) {
+                    let reward_token_address =
+                        *vector::borrow(&var_debt_token_reward_addresses, j);
+
+                    let (
+                        token_incentives_index,
+                        emission_per_second,
+                        incentives_last_update_timestamp,
+                        emission_end_timestamp
+                    ) =
+                        rewards_controller::get_rewards_data(
+                            variable_debt_token_address,
+                            reward_token_address,
+                            rewards_controller_address
+                        );
+
+                    let precision =
+                        rewards_controller::get_asset_decimals(
+                            variable_debt_token_address, rewards_controller_address
+                        );
+                    let reward_token_decimals =
+                        a_token_factory::decimals(reward_token_address);
+                    let reward_token_symbol =
+                        a_token_factory::symbol(reward_token_address);
+
+                    let price_feed_decimals = eac_aggregator_proxy::decimals();
+                    let reward_price_feed = eac_aggregator_proxy::latest_answer();
+
+                    vector::push_back(
+                        &mut reward_information,
+                        RewardInfo {
+                            reward_token_symbol,
+                            reward_token_address,
+                            reward_oracle_address,
+                            emission_per_second,
+                            incentives_last_update_timestamp,
+                            token_incentives_index,
+                            emission_end_timestamp,
+                            reward_price_feed,
+                            reward_token_decimals,
+                            precision,
+                            price_feed_decimals
+                        }
+                    );
+                };
+
+                let v_incentive_data = IncentiveData {
+                    token_address: variable_debt_token_address,
+                    incentive_controller_address: rewards_controller_address,
+                    rewards_token_information: reward_information
+                };
+
+                vector::push_back(
+                    &mut reserves_incentives_data,
+                    AggregatedReserveIncentiveData {
+                        underlying_asset,
+                        a_incentive_data,
+                        v_incentive_data
+                    }
+                )
+            };
+        };
+        reserves_incentives_data
+    }
+
+    #[view]
+    public fun get_user_reserves_incentives_data(user: address):
+        vector<UserReserveIncentiveData> {
+        let reserves = pool::get_reserves_list();
+        let user_reserves_incentives_data = vector::empty<UserReserveIncentiveData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let underlying_asset = *vector::borrow(&reserves, i);
+            let base_data = pool::get_reserve_data(underlying_asset);
+            let rewards_controller_address =
+                rewards_controller::rewards_controller_address();
+            // TODO Waiting for Chainlink oracle functionality
+            let reward_oracle_address = @aave_oracle;
+
+            if (rewards_controller_address != EMPTY_ADDRESS) {
+
+                // ===================== a token ====================
+                let a_token_address = pool::get_reserve_a_token_address(&base_data);
+                let a_token_reward_addresses =
+                    rewards_controller::get_rewards_by_asset(
+                        a_token_address, rewards_controller_address
+                    );
+                let user_rewards_information: vector<UserRewardInfo> = vector[];
+
+                for (j in 0..vector::length(&a_token_reward_addresses)) {
+                    let reward_token_address =
+                        *vector::borrow(&a_token_reward_addresses, j);
+
+                    let token_incentives_user_index =
+                        rewards_controller::get_user_asset_index(
+                            user,
+                            a_token_address,
+                            reward_token_address,
+                            rewards_controller_address
+                        );
+
+                    let user_unclaimed_rewards =
+                        rewards_controller::get_user_accrued_rewards(
+                            user, reward_token_address, rewards_controller_address
+                        );
+                    let reward_token_decimals =
+                        a_token_factory::decimals(reward_token_address);
+                    let reward_token_symbol =
+                        a_token_factory::symbol(reward_token_address);
+
+                    let price_feed_decimals = eac_aggregator_proxy::decimals();
+                    let reward_price_feed = eac_aggregator_proxy::latest_answer();
+
+                    vector::push_back(
+                        &mut user_rewards_information,
+                        UserRewardInfo {
+                            reward_token_symbol,
+                            reward_oracle_address,
+                            reward_token_address,
+                            user_unclaimed_rewards,
+                            token_incentives_user_index,
+                            reward_price_feed,
+                            price_feed_decimals,
+                            reward_token_decimals
+                        }
+                    );
+                };
+
+                let a_incentive_data = UserIncentiveData {
+                    token_address: a_token_address,
+                    incentive_controller_address: rewards_controller_address,
+                    user_rewards_information
+                };
+
+                // ===================== variable debt token ====================
+                let variable_debt_token_address =
+                    pool::get_reserve_variable_debt_token_address(&base_data);
+                let var_debt_token_reward_addresses =
+                    rewards_controller::get_rewards_by_asset(
+                        variable_debt_token_address,
+                        rewards_controller_address
+                    );
+                let user_rewards_information: vector<UserRewardInfo> = vector[];
+
+                for (j in 0..vector::length(&var_debt_token_reward_addresses)) {
+                    let reward_token_address =
+                        *vector::borrow(&var_debt_token_reward_addresses, j);
+
+                    let token_incentives_user_index =
+                        rewards_controller::get_user_asset_index(
+                            user,
+                            variable_debt_token_address,
+                            reward_token_address,
+                            rewards_controller_address
+                        );
+
+                    let user_unclaimed_rewards =
+                        rewards_controller::get_user_accrued_rewards(
+                            user, reward_token_address, rewards_controller_address
+                        );
+                    let reward_token_decimals =
+                        a_token_factory::decimals(reward_token_address);
+                    let reward_token_symbol =
+                        a_token_factory::symbol(reward_token_address);
+
+                    let price_feed_decimals = eac_aggregator_proxy::decimals();
+                    let reward_price_feed = eac_aggregator_proxy::latest_answer();
+
+                    vector::push_back(
+                        &mut user_rewards_information,
+                        UserRewardInfo {
+                            reward_token_symbol,
+                            reward_oracle_address,
+                            reward_token_address,
+                            user_unclaimed_rewards,
+                            token_incentives_user_index,
+                            reward_price_feed,
+                            price_feed_decimals,
+                            reward_token_decimals
+                        }
+                    );
+                };
+
+                let v_incentive_data = UserIncentiveData {
+                    token_address: variable_debt_token_address,
+                    incentive_controller_address: rewards_controller_address,
+                    user_rewards_information
+                };
+
+                vector::push_back(
+                    &mut user_reserves_incentives_data,
+                    UserReserveIncentiveData {
+                        underlying_asset,
+                        a_token_incentives_user_data: a_incentive_data,
+                        v_token_incentives_user_data: v_incentive_data
+                    }
+                )
+            };
+        };
+        user_reserves_incentives_data
+    }
+
+    #[test_only]
+    use std::signer;
+    #[test_only]
+    use std::string::{Self, utf8};
+    #[test_only]
+    use aptos_std::string_utils::{Self};
+
+    #[test_only]
+    const TEST_SUCCESS: u64 = 1;
+    #[test_only]
+    const TEST_FAILED: u64 = 2;
+
+    #[test(aave_pool = @aave_pool)]
+    fun test_ui_incentive_data_provider_v3_data_address(
+        aave_pool: &signer
+    ) {
+        init_module_test(aave_pool);
+        assert!(
+            ui_incentive_data_provider_v3_data_address()
+                == object::create_object_address(
+                    &@aave_pool, UI_INCENTIVE_DATA_PROVIDER_V3_NAME
+                ),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(aave_pool = @aave_pool)]
+    fun test_ui_incentive_data_provider_v3_data_object(
+        aave_pool: &signer
+    ) {
+        // init acl
+        init_module_test(aave_pool);
+        assert!(
+            ui_incentive_data_provider_v3_data_object()
+                == object::address_to_object<UiIncentiveDataProviderV3Data>(
+                    ui_incentive_data_provider_v3_data_address()
+                ),
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_acl = @aave_acl,
+            underlying_tokens = @underlying_tokens,
+            aave_rate = @aave_rate
+        )
+    ]
+    fun test_get_full_reserves_incentive_data(
+        aave_pool: &signer,
+        aave_acl: &signer,
+        underlying_tokens: &signer,
+        aave_rate: &signer
+    ) {
+        aptos_framework::account::create_account_for_test(
+            signer::address_of(aave_pool)
+        );
+
+        // init current module
+        init_module_test(aave_pool);
+
+        // init rewards controller
+        aave_pool::rewards_controller::initialize(
+            aave_pool, signer::address_of(aave_pool)
+        );
+
+        // init acl
+        aave_acl::acl_manage::test_init_module(aave_acl);
+
+        let role_admin = aave_acl::acl_manage::get_pool_admin_role();
+        aave_acl::acl_manage::grant_role(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            signer::address_of(aave_pool)
+        );
+        aave_acl::acl_manage::grant_role(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            signer::address_of(aave_acl)
+        );
+        aave_acl::acl_manage::set_role_admin(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            role_admin
+        );
+
+        // init the rate module - default strategy
+        aave_rate::default_reserve_interest_rate_strategy::init_interest_rate_strategy(
+            aave_rate
+        );
+
+        // init tokens base
+        aave_pool::token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        aave_pool::a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        aave_pool::variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlyings token factory
+        aave_pool::mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // create mocked underlying tokens
+        let i = 0;
+        let treasury = signer::address_of(underlying_tokens);
+        let a_token_name = string::utf8(b"a");
+        let a_token_symbol = string::utf8(b"a");
+        let variable_debt_token_name = string::utf8(b"BTC");
+        let variable_debt_token_symbol = string::utf8(b"BTC");
+
+        let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+        let symbol = string_utils::format1(&b"U_{}", i);
+        let decimals = 6;
+        let max_supply = 10000;
+        aave_pool::mock_underlying_token_factory::create_token(
+            underlying_tokens,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+
+        let underlying_asset_address = @0x033;
+        let treasury_address = @0x034;
+
+        // create atokens
+        aave_pool::a_token_factory::create_token(
+            aave_pool,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+
+        let underlying_token_address =
+            aave_pool::mock_underlying_token_factory::token_address(symbol);
+
+        // init the pool
+        aave_pool::pool::test_init_pool(aave_pool);
+
+        // set reserve interest rate using the pool admin
+        let optimal_usage_ratio: u256 =
+            aave_math::wad_ray_math::get_half_ray_for_testing();
+        let base_variable_borrow_rate: u256 = 0;
+        let variable_rate_slope1: u256 = 0;
+        let variable_rate_slope2: u256 = 0;
+        aave_rate::default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+            aave_pool,
+            underlying_token_address,
+            optimal_usage_ratio,
+            base_variable_borrow_rate,
+            variable_rate_slope1,
+            variable_rate_slope2
+        );
+
+        // create reserves using the pool admin
+        aave_pool::pool::init_reserve(
+            aave_pool,
+            underlying_token_address,
+            treasury,
+            a_token_name,
+            a_token_symbol,
+            variable_debt_token_name,
+            variable_debt_token_symbol
+        );
+
+        let index = 0;
+        let emission_per_second = 0;
+        let last_update_timestamp = 0;
+        let distribution_end = 0;
+
+        let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+
+        let name_2 = string_utils::format1(&b"APTOS_UNDERLYING_2_{}", i);
+        let symbol_2 = string_utils::format1(&b"U_2_{}", i);
+        let decimals_2 = 2 + i;
+
+        aave_pool::a_token_factory::create_token(
+            aave_pool,
+            name_2,
+            symbol_2,
+            decimals_2,
+            utf8(b"2"),
+            utf8(b"2"),
+            rewards_addr,
+            treasury_address
+        );
+
+        let a_token_address_2 =
+            a_token_factory::token_address(signer::address_of(aave_pool), symbol_2);
+
+        let users_data = std::simple_map::new();
+
+        let reward_data =
+            aave_pool::rewards_controller::create_reward_data(
+                index,
+                emission_per_second,
+                last_update_timestamp,
+                distribution_end,
+                users_data
+            );
+
+        let rewards_map = std::simple_map::new();
+
+        std::simple_map::upsert(&mut rewards_map, a_token_address_2, reward_data);
+
+        let available_rewards_count = 1;
+        let decimals = 2;
+        let available_rewards = std::simple_map::new();
+        std::simple_map::upsert(&mut available_rewards, 0, a_token_address_2);
+
+        let asset_data =
+            aave_pool::rewards_controller::create_asset_data(
+                rewards_map,
+                available_rewards,
+                available_rewards_count,
+                decimals
+            );
+
+        let base_data = aave_pool::pool::get_reserve_data(underlying_token_address);
+        let asset = aave_pool::pool::get_reserve_a_token_address(&base_data);
+
+        aave_pool::rewards_controller::add_asset(rewards_addr, asset, asset_data);
+
+        aave_pool::rewards_controller::add_rewards_by_asset(
+            asset, rewards_addr, 0, a_token_address_2
+        );
+
+        let rewards_map_2 = std::simple_map::new();
+        let reward_data_2 =
+            aave_pool::rewards_controller::create_reward_data(
+                index,
+                emission_per_second,
+                last_update_timestamp,
+                distribution_end,
+                users_data
+            );
+        std::simple_map::upsert(&mut rewards_map_2, a_token_address_2, reward_data_2);
+
+        let available_rewards_2 = std::simple_map::new();
+        std::simple_map::upsert(&mut available_rewards_2, 0, a_token_address_2);
+
+        let asset_data_2 =
+            aave_pool::rewards_controller::create_asset_data(
+                rewards_map_2,
+                available_rewards_2,
+                available_rewards_count,
+                decimals
+            );
+
+        let variable_debt_token_address =
+            pool::get_reserve_variable_debt_token_address(&base_data);
+        aave_pool::rewards_controller::add_asset(
+            rewards_addr, variable_debt_token_address, asset_data_2
+        );
+        aave_pool::rewards_controller::add_rewards_by_asset(
+            variable_debt_token_address,
+            rewards_addr,
+            0,
+            a_token_address_2
+        );
+
+        let user_data = aave_pool::rewards_controller::create_user_data(0, 0);
+        aave_pool::rewards_controller::add_user_asset_index(
+            rewards_addr,
+            asset,
+            a_token_address_2,
+            rewards_addr,
+            user_data
+        );
+
+        aave_pool::rewards_controller::add_user_asset_index(
+            rewards_addr,
+            variable_debt_token_address,
+            a_token_address_2,
+            rewards_addr,
+            user_data
+        );
+
+        aave_pool::rewards_controller::add_to_assets_list(asset, rewards_addr);
+
+        let (reserves_incentives_data, _user_reserves_incentives_data) =
+            get_full_reserves_incentive_data(rewards_addr);
+        assert!(
+            vector::length(&reserves_incentives_data) != 0,
+            TEST_SUCCESS
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-periphery/ui_pool_data_provider_v3.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-periphery/ui_pool_data_provider_v3.move
@@ -1,0 +1,760 @@
+module aave_pool::ui_pool_data_provider_v3 {
+    use std::option::Self;
+    use std::string::String;
+    use std::vector;
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aave_config::reserve_config;
+    use aave_config::user_config;
+    use aave_oracle::oracle::{get_asset_price};
+    use aave_oracle::oracle_base::{get_oracle_base_currency, get_base_currency_unit};
+    use aave_pool::a_token_factory;
+    use aave_rate::default_reserve_interest_rate_strategy::{
+        get_base_variable_borrow_rate,
+        get_optimal_usage_ratio,
+        get_variable_rate_slope1,
+        get_variable_rate_slope2
+    };
+    use aave_pool::eac_aggregator_proxy::{
+        create_eac_aggregator_proxy,
+        decimals,
+        latest_answer,
+        MockEacAggregatorProxy
+    };
+    use aave_pool::emode_logic;
+    use aave_pool::pool::{
+        Self,
+        get_reserve_a_token_address,
+        get_reserve_accrued_to_treasury,
+        get_reserve_current_liquidity_rate,
+        get_reserve_current_variable_borrow_rate,
+        get_reserve_isolation_mode_total_debt,
+        get_reserve_last_update_timestamp,
+        get_reserve_liquidity_index,
+        get_reserve_unbacked,
+        get_reserve_variable_borrow_index,
+        get_reserve_variable_debt_token_address
+    };
+    use aave_pool::token_base;
+    use aave_pool::variable_debt_token_factory;
+
+    const EMPTY_ADDRESS: address = @0x0;
+
+    const APT_CURRENCY_UNIT: u256 = 100000000;
+
+    const EROLE_NOT_EXISTS: u64 = 1;
+    const ESTREAM_NOT_EXISTS: u64 = 2;
+    const NOT_FUNDS_ADMIN: u64 = 3;
+    const ESTREAM_TO_THE_CONTRACT_ITSELF: u64 = 4;
+    const ESTREAM_TO_THE_CALLER: u64 = 5;
+    const EDEPOSIT_IS_ZERO: u64 = 6;
+    const ESTART_TIME_BEFORE_BLOCK_TIMESTAMP: u64 = 7;
+    const ESTOP_TIME_BEFORE_THE_START_TIME: u64 = 8;
+    const EDEPOSIT_SMALLER_THAN_TIME_DELTA: u64 = 9;
+    const EDEPOSIT_NOT_MULTIPLE_OF_TIME_DELTA: u64 = 10;
+    const EAMOUNT_IS_ZERO: u64 = 11;
+    const EAMOUNT_EXCEEDS_THE_AVAILABLE_BALANCE: u64 = 12;
+
+    const UI_POOL_DATA_PROVIDER_V3_NAME: vector<u8> = b"AAVE_UI_POOL_DATA_PROVIDER_V3";
+
+    struct UiPoolDataProviderV3Data has key {
+        network_base_token_price_in_usd_proxy_aggregator: MockEacAggregatorProxy,
+        market_reference_currency_price_in_usd_proxy_aggregator: MockEacAggregatorProxy
+    }
+
+    struct AggregatedReserveData has key, store, drop {
+        underlying_asset: address,
+        name: String,
+        symbol: String,
+        decimals: u256,
+        base_lt_vas_collateral: u256,
+        reserve_liquidation_threshold: u256,
+        reserve_liquidation_bonus: u256,
+        reserve_factor: u256,
+        usage_as_collateral_enabled: bool,
+        borrowing_enabled: bool,
+        is_active: bool,
+        is_frozen: bool,
+        // base data
+        liquidity_index: u128,
+        variable_borrow_index: u128,
+        liquidity_rate: u128,
+        variable_borrow_rate: u128,
+        last_update_timestamp: u128,
+        a_token_address: address,
+        variable_debt_token_address: address,
+        //
+        available_liquidity: u256,
+        total_scaled_variable_debt: u256,
+        price_in_market_reference_currency: u256,
+        price_oracle: address,
+        variable_rate_slope1: u256,
+        variable_rate_slope2: u256,
+        base_variable_borrow_rate: u256,
+        optimal_usage_ratio: u256,
+        // v3 only
+        is_paused: bool,
+        is_siloed_borrowing: bool,
+        accrued_to_treasury: u128,
+        unbacked: u128,
+        isolation_mode_total_debt: u128,
+        flash_loan_enabled: bool,
+        // debts
+        debt_ceiling: u256,
+        debt_ceiling_decimals: u256,
+        e_mode_category_id: u8,
+        borrow_cap: u256,
+        supply_cap: u256,
+        // e_mode
+        e_mode_ltv: u16,
+        e_mode_liquidation_threshold: u16,
+        e_mode_liquidation_bonus: u16,
+        e_mode_price_source: address,
+        e_mode_label: String,
+        borrowable_in_isolation: bool
+    }
+
+    #[test_only]
+    public fun get_available_liquidity(self: &AggregatedReserveData): u256 {
+        self.available_liquidity
+    }
+
+    struct UserReserveData has key, store, drop {
+        decimals: u256,
+        underlying_asset: address,
+        scaled_a_token_balance: u256,
+        usage_as_collateral_enabled_on_user: bool,
+        scaled_variable_debt: u256
+    }
+
+    struct BaseCurrencyInfo has key, store, drop {
+        market_reference_currency_unit: u256,
+        market_reference_currency_price_in_usd: u256,
+        network_base_token_price_in_usd: u256,
+        network_base_token_price_decimals: u8
+    }
+
+    fun init_module(sender: &signer) {
+        let state_object_constructor_ref =
+            &object::create_named_object(sender, UI_POOL_DATA_PROVIDER_V3_NAME);
+        let state_object_signer = &object::generate_signer(state_object_constructor_ref);
+
+        move_to(
+            state_object_signer,
+            UiPoolDataProviderV3Data {
+                network_base_token_price_in_usd_proxy_aggregator: create_eac_aggregator_proxy(),
+                market_reference_currency_price_in_usd_proxy_aggregator: create_eac_aggregator_proxy()
+            }
+        );
+    }
+
+    #[test_only]
+    public fun init_module_test(sender: &signer) {
+        init_module(sender);
+    }
+
+    #[view]
+    public fun ui_pool_data_provider_v3_data_address(): address {
+        object::create_object_address(&@aave_pool, UI_POOL_DATA_PROVIDER_V3_NAME)
+    }
+
+    #[view]
+    public fun ui_pool_data_provider_v3_data_object(): Object<UiPoolDataProviderV3Data> {
+        object::address_to_object<UiPoolDataProviderV3Data>(
+            ui_pool_data_provider_v3_data_address()
+        )
+    }
+
+    #[view]
+    public fun get_reserves_list(): vector<address> {
+        pool::get_reserves_list()
+    }
+
+    #[view]
+    public fun get_reserves_data(): (vector<AggregatedReserveData>, BaseCurrencyInfo) {
+        let oracle = @aave_oracle;
+
+        let reserves = pool::get_reserves_list();
+
+        let reserves_data = vector::empty<AggregatedReserveData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let underlying_asset = *vector::borrow(&reserves, i);
+
+            let base_data = pool::get_reserve_data(underlying_asset);
+
+            let liquidity_index = get_reserve_liquidity_index(&base_data);
+            let variable_borrow_index = get_reserve_variable_borrow_index(&base_data);
+            let liquidity_rate = get_reserve_current_liquidity_rate(&base_data);
+            let variable_borrow_rate =
+                get_reserve_current_variable_borrow_rate(&base_data);
+            let last_update_timestamp = get_reserve_last_update_timestamp(&base_data);
+            let a_token_address = get_reserve_a_token_address(&base_data);
+            let variable_debt_token_address =
+                get_reserve_variable_debt_token_address(&base_data);
+            let price_in_market_reference_currency = get_asset_price(underlying_asset);
+
+            let price_oracle = oracle;
+
+            let atoken_accunt_address =
+                a_token_factory::get_token_account_address(a_token_address);
+
+            let underlying_asset_metadata =
+                object::address_to_object<Metadata>(underlying_asset);
+
+            let available_liquidity =
+                primary_fungible_store::balance(
+                    atoken_accunt_address, underlying_asset_metadata
+                );
+
+            let total_scaled_variable_debt =
+                token_base::scaled_total_supply(variable_debt_token_address);
+
+            let symbol = fungible_asset::symbol(underlying_asset_metadata);
+            let name = fungible_asset::name(underlying_asset_metadata);
+
+            let reserve_configuration_map =
+                pool::get_reserve_configuration_by_reserve_data(&base_data);
+
+            let (
+                base_lt_vas_collateral,
+                reserve_liquidation_threshold,
+                reserve_liquidation_bonus,
+                decimals,
+                reserve_factor,
+                e_mode_category_id
+            ) = reserve_config::get_params(&reserve_configuration_map);
+            let usage_as_collateral_enabled = base_lt_vas_collateral != 0;
+
+            let (is_active, is_frozen, borrowing_enabled, is_paused) =
+                reserve_config::get_flags(&reserve_configuration_map);
+
+            let variable_rate_slope1 = get_variable_rate_slope1(underlying_asset);
+            let variable_rate_slope2 = get_variable_rate_slope2(underlying_asset);
+            let base_variable_borrow_rate =
+                get_base_variable_borrow_rate(underlying_asset);
+            let optimal_usage_ratio = get_optimal_usage_ratio(underlying_asset);
+
+            let debt_ceiling: u256 =
+                reserve_config::get_debt_ceiling(&reserve_configuration_map);
+            let debt_ceiling_decimals = reserve_config::get_debt_ceiling_decimals();
+            let (borrow_cap, supply_cap) =
+                reserve_config::get_caps(&reserve_configuration_map);
+
+            let flash_loan_enabled =
+                reserve_config::get_flash_loan_enabled(&reserve_configuration_map);
+
+            let is_siloed_borrowing =
+                reserve_config::get_siloed_borrowing(&reserve_configuration_map);
+            let unbacked = get_reserve_unbacked(&base_data);
+            let isolation_mode_total_debt =
+                get_reserve_isolation_mode_total_debt(&base_data);
+            let accrued_to_treasury = get_reserve_accrued_to_treasury(&base_data);
+
+            let e_mode_category_id_u8 = (e_mode_category_id as u8);
+
+            let (e_mode_ltv, e_mode_liquidation_threshold, _) =
+                emode_logic::get_emode_configuration(e_mode_category_id_u8);
+
+            let e_mode_liquidation_bonus =
+                emode_logic::get_emode_e_mode_liquidation_bonus(e_mode_category_id_u8);
+            let e_mode_price_source =
+                emode_logic::get_emode_e_mode_price_source(e_mode_category_id_u8);
+            let e_mode_label = emode_logic::get_emode_e_mode_label(e_mode_category_id_u8);
+
+            let borrowable_in_isolation =
+                reserve_config::get_borrowable_in_isolation(&reserve_configuration_map);
+
+            let aggregated_reserve_data = AggregatedReserveData {
+                underlying_asset,
+                name,
+                symbol,
+                decimals,
+                base_lt_vas_collateral,
+                reserve_liquidation_threshold,
+                reserve_liquidation_bonus,
+                reserve_factor,
+                usage_as_collateral_enabled,
+                borrowing_enabled,
+                is_active,
+                is_frozen,
+                liquidity_index,
+                variable_borrow_index,
+                liquidity_rate,
+                variable_borrow_rate,
+                last_update_timestamp: (last_update_timestamp as u128),
+                a_token_address,
+                variable_debt_token_address,
+                available_liquidity: (available_liquidity as u256),
+                total_scaled_variable_debt,
+                price_in_market_reference_currency,
+                price_oracle,
+                variable_rate_slope1,
+                variable_rate_slope2,
+                base_variable_borrow_rate,
+                optimal_usage_ratio,
+                is_paused,
+                is_siloed_borrowing,
+                accrued_to_treasury: (accrued_to_treasury as u128),
+                unbacked,
+                isolation_mode_total_debt,
+                flash_loan_enabled,
+                debt_ceiling,
+                debt_ceiling_decimals,
+                e_mode_category_id: e_mode_category_id_u8,
+                borrow_cap,
+                supply_cap,
+                e_mode_ltv: (e_mode_ltv as u16),
+                e_mode_liquidation_threshold: (e_mode_liquidation_threshold as u16),
+                e_mode_liquidation_bonus,
+                e_mode_price_source,
+                e_mode_label,
+                borrowable_in_isolation
+            };
+
+            vector::push_back(&mut reserves_data, aggregated_reserve_data);
+        };
+
+        let network_base_token_price_in_usd = latest_answer();
+        let network_base_token_price_decimals = decimals();
+
+        let opt_base_currency = get_oracle_base_currency();
+        let (market_reference_currency_unit, market_reference_currency_price_in_usd) =
+            if (option::is_some(&opt_base_currency)) {
+                let unit = get_base_currency_unit(&*option::borrow(&opt_base_currency));
+                ((unit as u256), (unit as u256))
+            } else {
+                (APT_CURRENCY_UNIT, latest_answer())
+            };
+
+        let base_currency_info = BaseCurrencyInfo {
+            market_reference_currency_unit,
+            market_reference_currency_price_in_usd,
+            network_base_token_price_in_usd,
+            network_base_token_price_decimals
+        };
+        (reserves_data, base_currency_info)
+    }
+
+    #[view]
+    public fun get_user_reserves_data(user: address): (vector<UserReserveData>, u8) {
+        let reserves = pool::get_reserves_list();
+        let user_config = pool::get_user_configuration(user);
+
+        let user_emode_category_id = emode_logic::get_user_emode(user);
+
+        let user_reserves_data = vector::empty<UserReserveData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let underlying_asset = *vector::borrow(&reserves, i);
+
+            let base_data = pool::get_reserve_data(underlying_asset);
+            let reserve_index = pool::get_reserve_id(&base_data);
+            let decimals =
+                fungible_asset::decimals(
+                    object::address_to_object<Metadata>(underlying_asset)
+                );
+
+            let scaled_a_token_balance =
+                a_token_factory::scaled_balance_of(
+                    user, pool::get_reserve_a_token_address(&base_data)
+                );
+
+            let usage_as_collateral_enabled_on_user =
+                user_config::is_using_as_collateral(&user_config, (reserve_index as u256));
+
+            let scaled_variable_debt = 0;
+            if (user_config::is_borrowing(&user_config, (reserve_index as u256))) {
+                scaled_variable_debt = variable_debt_token_factory::scaled_balance_of(
+                    user, pool::get_reserve_variable_debt_token_address(&base_data)
+                );
+            };
+
+            vector::push_back(
+                &mut user_reserves_data,
+                UserReserveData {
+                    decimals: (decimals as u256),
+                    underlying_asset,
+                    scaled_a_token_balance,
+                    usage_as_collateral_enabled_on_user,
+                    scaled_variable_debt
+                }
+            );
+        };
+
+        (user_reserves_data, (user_emode_category_id as u8))
+    }
+
+    #[test_only]
+    const TEST_SUCCESS: u64 = 1;
+    #[test_only]
+    const TEST_FAILED: u64 = 2;
+
+    #[test_only]
+    use std::string::{Self, utf8};
+    #[test_only]
+    use std::signer;
+    #[test_only]
+    use aptos_std::string_utils;
+    #[test_only]
+    use aave_rate::default_reserve_interest_rate_strategy::Self;
+    #[test_only]
+    use aave_math::wad_ray_math;
+    #[test_only]
+    use aptos_framework::account;
+
+    #[test]
+    fun test_ui_pool_data_provider_v3_data_address() {
+        assert!(
+            ui_pool_data_provider_v3_data_address()
+                == object::create_object_address(
+                    &@aave_pool, UI_POOL_DATA_PROVIDER_V3_NAME
+                ),
+            TEST_SUCCESS
+        );
+    }
+
+    #[test(aave_role_super_admin = @aave_pool)]
+    fun test_ui_pool_data_provider_v3_data_object(
+        aave_role_super_admin: &signer
+    ) {
+        init_module_test(aave_role_super_admin);
+        assert!(
+            ui_pool_data_provider_v3_data_object()
+                == object::address_to_object<UiPoolDataProviderV3Data>(
+                    ui_pool_data_provider_v3_data_address()
+                ),
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_acl = @aave_acl,
+            underlying_tokens = @underlying_tokens,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aave_rate = @aave_rate
+        )
+    ]
+    fun test_get_reserves_data(
+        aave_pool: &signer,
+        aave_acl: &signer,
+        underlying_tokens: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aave_rate: &signer
+    ) {
+        use aave_pool::mock_underlying_token_factory::Self;
+
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init current module
+        init_module_test(aave_pool);
+
+        // init acl
+        aave_acl::acl_manage::test_init_module(aave_acl);
+        let role_admin = aave_acl::acl_manage::get_pool_admin_role();
+        aave_acl::acl_manage::grant_role(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            signer::address_of(aave_pool)
+        );
+
+        aave_acl::acl_manage::grant_role(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            signer::address_of(aave_acl)
+        );
+        // set role admin
+        aave_acl::acl_manage::set_role_admin(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            role_admin
+        );
+
+        aave_acl::acl_manage::add_pool_admin(
+            aave_acl, signer::address_of(underlying_tokens)
+        );
+
+        // init tokens base
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        aave_pool::a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        aave_pool::variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlyings token factory
+        aave_pool::mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // create mocked underlying tokens
+        let i = 0;
+        let treasury = signer::address_of(underlying_tokens);
+        let a_token_name = string::utf8(b"a");
+        let a_token_symbol = string::utf8(b"a");
+        let variable_debt_token_name = string::utf8(b"BTC");
+        let variable_debt_token_symbol = string::utf8(b"BTC");
+
+        let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+        let symbol = string_utils::format1(&b"U_{}", i);
+        let decimals = 6;
+        let max_supply = 10000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+
+        let underlying_asset_address = @0x033;
+        let treasury_address = @0x034;
+
+        a_token_factory::create_token(
+            aave_pool,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+
+        aave_rate::default_reserve_interest_rate_strategy::init_interest_rate_strategy(
+            aave_rate
+        );
+
+        let underlying_token_address =
+            mock_underlying_token_factory::token_address(symbol);
+
+        // register asset with oracle
+        aave_oracle::oracle::set_asset_feed_id(
+            underlying_tokens,
+            underlying_token_address,
+            aave_oracle::oracle_tests::get_test_feed_id()
+        );
+
+        // init the pool
+        aave_pool::pool::test_init_pool(aave_pool);
+
+        // set reserve interest rate using the pool admin
+        let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+        let base_variable_borrow_rate: u256 = 0;
+        let variable_rate_slope1: u256 = 0;
+        let variable_rate_slope2: u256 = 0;
+        default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+            aave_acl,
+            underlying_token_address,
+            optimal_usage_ratio,
+            base_variable_borrow_rate,
+            variable_rate_slope1,
+            variable_rate_slope2
+        );
+
+        // create reserves using the pool admin
+        aave_pool::pool::test_init_reserve(
+            aave_pool,
+            underlying_token_address,
+            treasury,
+            a_token_name,
+            a_token_symbol,
+            variable_debt_token_name,
+            variable_debt_token_symbol
+        );
+
+        // init emode
+        aave_pool::emode_logic::init_emode(aave_pool);
+
+        let (_vector_aggregated_reserve_data, base_currency_info) = get_reserves_data();
+
+        let network_base_token_price_in_usd = latest_answer();
+        let network_base_token_price_decimals = decimals();
+
+        let opt_base_currency = get_oracle_base_currency();
+        let (market_reference_currency_unit, market_reference_currency_price_in_usd) =
+            if (option::is_some(&opt_base_currency)) {
+                let unit = get_base_currency_unit(&*option::borrow(&opt_base_currency));
+                ((unit as u256), (unit as u256))
+            } else {
+                (APT_CURRENCY_UNIT, latest_answer())
+            };
+
+        let base_currency_info_exp = BaseCurrencyInfo {
+            market_reference_currency_unit,
+            market_reference_currency_price_in_usd,
+            network_base_token_price_in_usd,
+            network_base_token_price_decimals
+        };
+
+        assert!(
+            base_currency_info == base_currency_info_exp,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_acl = @aave_acl,
+            underlying_tokens = @underlying_tokens,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aave_rate = @aave_rate
+        )
+    ]
+    fun test_get_user_reserves_data(
+        aave_pool: &signer,
+        aave_acl: &signer,
+        underlying_tokens: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aave_rate: &signer
+    ) {
+        use aave_pool::mock_underlying_token_factory::Self;
+
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init current module
+        init_module_test(aave_pool);
+
+        // init acl
+        aave_acl::acl_manage::test_init_module(aave_acl);
+        let role_admin = aave_acl::acl_manage::get_pool_admin_role();
+        aave_acl::acl_manage::grant_role(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            signer::address_of(aave_pool)
+        );
+
+        aave_acl::acl_manage::grant_role(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            signer::address_of(aave_acl)
+        );
+        // set role admin
+        aave_acl::acl_manage::set_role_admin(
+            aave_acl,
+            aave_acl::acl_manage::get_pool_admin_role_for_testing(),
+            role_admin
+        );
+
+        aave_acl::acl_manage::add_pool_admin(
+            aave_acl, signer::address_of(underlying_tokens)
+        );
+
+        // init tokens base
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        aave_pool::a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        aave_pool::variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlyings token factory
+        aave_pool::mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // create mocked underlying tokens
+        let i = 0;
+        let treasury = signer::address_of(underlying_tokens);
+        let a_token_name = string::utf8(b"a");
+        let a_token_symbol = string::utf8(b"a");
+        let variable_debt_token_name = string::utf8(b"BTC");
+        let variable_debt_token_symbol = string::utf8(b"BTC");
+
+        let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+        let symbol = string_utils::format1(&b"U_{}", i);
+        let decimals = 6;
+        let max_supply = 10000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+
+        let underlying_asset_address = @0x033;
+        let treasury_address = @0x034;
+
+        a_token_factory::create_token(
+            aave_pool,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+
+        // init rate strategy - default strategy
+        aave_rate::default_reserve_interest_rate_strategy::init_interest_rate_strategy(
+            aave_rate
+        );
+
+        let underlying_token_address =
+            mock_underlying_token_factory::token_address(symbol);
+
+        // init the pool
+        aave_pool::pool::test_init_pool(aave_pool);
+
+        // set reserve interest rate using the pool admin
+        let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+        let base_variable_borrow_rate: u256 = 0;
+        let variable_rate_slope1: u256 = 0;
+        let variable_rate_slope2: u256 = 0;
+        default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+            aave_acl,
+            underlying_token_address,
+            optimal_usage_ratio,
+            base_variable_borrow_rate,
+            variable_rate_slope1,
+            variable_rate_slope2
+        );
+
+        // create reserves using the pool admin
+        aave_pool::pool::test_init_reserve(
+            aave_pool,
+            underlying_token_address,
+            treasury,
+            a_token_name,
+            a_token_symbol,
+            variable_debt_token_name,
+            variable_debt_token_symbol
+        );
+
+        // init emode
+        aave_pool::emode_logic::init_emode(aave_pool);
+
+        let (_vector_aggregated_reserve_data, user_emode_category) =
+            get_user_reserves_data(signer::address_of(aave_pool));
+
+        let user_emode_category_id =
+            emode_logic::get_user_emode(signer::address_of(aave_pool));
+
+        assert!(
+            user_emode_category == (user_emode_category_id as u8),
+            TEST_SUCCESS
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-pool/pool.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-pool/pool.move
@@ -1,0 +1,1579 @@
+module aave_pool::pool {
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_framework::event;
+    use aptos_framework::timestamp;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_config::reserve_config::{Self, ReserveConfigurationMap};
+    use aave_config::user_config::{Self, UserConfigurationMap};
+    use aave_math::math_utils;
+    use aave_math::wad_ray_math;
+    use aave_rate::interest_rate_strategy;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::variable_debt_token_factory;
+
+    friend aave_pool::pool_configurator;
+    friend aave_pool::flashloan_logic;
+    friend aave_pool::supply_logic;
+    friend aave_pool::borrow_logic;
+    friend aave_pool::bridge_logic;
+    friend aave_pool::liquidation_logic;
+    friend aave_pool::isolation_mode_logic;
+
+    #[test_only]
+    friend aave_pool::pool_tests;
+    #[test_only]
+    friend aave_pool::ui_incentive_data_provider_v3;
+
+    const POOL_REVISION: u256 = 0x1;
+
+    #[event]
+    /// @dev Emitted when a reserve is initialized.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param a_token The address of the associated aToken contract
+    /// @param variable_debt_token The address of the associated variable rate debt token
+    struct ReserveInitialized has store, drop {
+        // Address of the underlying asset
+        asset: address,
+        // Address of the corresponding aToken
+        a_token: address,
+        // Address of the corresponding variable debt token
+        variable_debt_token: address
+    }
+
+    #[event]
+    /// @dev Emitted when the state of a reserve is updated.
+    /// @param reserve The address of the underlying asset of the reserve
+    /// @param liquidity_rate The next liquidity rate
+    /// @param variable_borrow_rate The next variable borrow rate
+    /// @param liquidity_index The next liquidity index
+    /// @param variable_borrow_index The next variable borrow index
+    struct ReserveDataUpdated has store, drop {
+        reserve: address,
+        liquidity_rate: u256,
+        variable_borrow_rate: u256,
+        liquidity_index: u256,
+        variable_borrow_index: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the protocol treasury receives minted aTokens from the accrued interest.
+    /// @param reserve The address of the reserve
+    /// @param amount_minted The amount minted to the treasury
+    struct MintedToTreasury has store, drop {
+        reserve: address,
+        amount_minted: u256
+    }
+
+    #[event]
+    /// @dev Emitted on borrow(), repay() and liquidation_call() when using isolated assets
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param total_debt The total isolation mode debt for the reserve
+    struct IsolationModeTotalDebtUpdated has store, drop {
+        asset: address,
+        total_debt: u256
+    }
+
+    struct ReserveExtendConfiguration has key, store, drop {
+        /// Fee of the protocol bridge, expressed in bps
+        bridge_protocol_fee: u256,
+        /// Total FlashLoan Premium, expressed in bps
+        flash_loan_premium_total: u128,
+        /// FlashLoan premium paid to protocol treasury, expressed in bps
+        flash_loan_premium_to_protocol: u128
+    }
+
+    struct ReserveData has key, store, copy, drop {
+        /// stores the reserve configuration
+        configuration: ReserveConfigurationMap,
+        /// the liquidity index. Expressed in ray
+        liquidity_index: u128,
+        /// the current supply rate. Expressed in ray
+        current_liquidity_rate: u128,
+        /// variable borrow index. Expressed in ray
+        variable_borrow_index: u128,
+        /// the current variable borrow rate. Expressed in ray
+        current_variable_borrow_rate: u128,
+        /// timestamp of last update (u40 -> u64)
+        last_update_timestamp: u64,
+        /// the id of the reserve. Represents the position in the list of the active reserves
+        id: u16,
+        /// aToken address
+        a_token_address: address,
+        /// variableDebtToken address
+        variable_debt_token_address: address,
+        /// the current treasury balance, scaled
+        accrued_to_treasury: u256,
+        /// the outstanding unbacked aTokens minted through the bridging feature
+        unbacked: u128,
+        /// the outstanding debt borrowed against this asset in isolation mode
+        isolation_mode_total_debt: u128
+    }
+
+    /// Map of reserves and their data (underlying_asset_of_reserve => reserveData)
+    struct ReserveList has key {
+        /// SmartTable to store reserve data with asset addresses as keys
+        value: SmartTable<address, ReserveData>,
+        /// Maximum number of active reserves there have been in the protocol. It is the upper bound of the reserves list
+        count: u16
+    }
+
+    /// List of reserves as a map (reserveId => reserve).
+    /// It is structured as a mapping for gas savings reasons, using the reserve id as index
+    struct ReserveAddressesList has key {
+        value: SmartTable<u256, address>
+    }
+
+    /// Map of users address and their configuration data (user_address => UserConfigurationMap)
+    struct UsersConfig has key {
+        value: SmartTable<address, UserConfigurationMap>
+    }
+
+    /// @notice Initializes the pool
+    /// @dev Only callable by the pool_configurator module
+    /// @param account The account signer of the caller
+    public(friend) fun init_pool(account: &signer) {
+        assert!(
+            (signer::address_of(account) == @aave_pool),
+            error_config::get_enot_pool_owner()
+        );
+
+        move_to(
+            account,
+            ReserveList {
+                value: smart_table::new<address, ReserveData>(),
+                count: 0
+            }
+        );
+
+        move_to(
+            account,
+            ReserveAddressesList {
+                value: smart_table::new<u256, address>()
+            }
+        );
+
+        move_to(
+            account,
+            UsersConfig {
+                value: smart_table::new<address, UserConfigurationMap>()
+            }
+        );
+
+        move_to(
+            account,
+            ReserveExtendConfiguration {
+                bridge_protocol_fee: 0,
+                flash_loan_premium_total: 0,
+                flash_loan_premium_to_protocol: 0
+            }
+        );
+    }
+
+    #[test_only]
+    public fun test_init_pool(account: &signer) {
+        init_pool(account);
+    }
+
+    #[view]
+    /// @notice Returns the revision number of the contract
+    /// @dev Needs to be defined in the inherited class as a constant.
+    /// @return The revision number
+    public fun get_revision(): u256 {
+        POOL_REVISION
+    }
+
+    /// @notice Initializes a reserve, activating it, assigning an aToken and debt tokens and an
+    /// interest rate strategy
+    /// @dev Only callable by the pool_configurator module
+    /// @param account The address of the caller
+    /// @param underlying_asset The address of the underlying asset of the reserve
+    /// @param treasury The address of the treasury
+    /// @param a_token_name The name of the aToken
+    /// @param a_token_symbol The symbol of the aToken
+    /// @param variable_debt_token_name The name of the variable debt token
+    /// @param variable_debt_token_symbol The symbol of the variable debt token
+    public(friend) fun init_reserve(
+        account: &signer,
+        underlying_asset: address,
+        treasury: address,
+        a_token_name: String,
+        a_token_symbol: String,
+        variable_debt_token_name: String,
+        variable_debt_token_symbol: String
+    ) acquires ReserveList, ReserveAddressesList {
+        // Check if underlying_asset exists
+        fungible_asset_manager::assert_token_exists(underlying_asset);
+
+        let asset_symbol = fungible_asset_manager::symbol(underlying_asset);
+        // Check whether the asset interest rate parameters are configured
+        interest_rate_strategy::asset_interest_rate_exists(
+            underlying_asset, asset_symbol
+        );
+
+        // Borrow the ReserveList resource
+        let reserve_data_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        // Assert that the asset is not already added
+        assert!(
+            !smart_table::contains(&reserve_data_list.value, underlying_asset),
+            error_config::get_ereserve_already_added()
+        );
+
+        let underlying_asset_decimals =
+            fungible_asset_manager::decimals(underlying_asset);
+        // Create a token for the underlying asset
+        let a_token_address =
+            a_token_factory::create_token(
+                account,
+                a_token_name,
+                a_token_symbol,
+                underlying_asset_decimals,
+                utf8(b""),
+                utf8(b""),
+                underlying_asset,
+                treasury
+            );
+
+        // Create variable debt token for the underlying asset
+        let variable_debt_token_address =
+            variable_debt_token_factory::create_token(
+                account,
+                variable_debt_token_name,
+                variable_debt_token_symbol,
+                underlying_asset_decimals,
+                utf8(b""),
+                utf8(b""),
+                underlying_asset
+            );
+
+        // Create Pool
+        let reserve_data = ReserveData {
+            configuration: reserve_config::init(),
+            liquidity_index: (wad_ray_math::ray() as u128),
+            current_liquidity_rate: 0,
+            variable_borrow_index: (wad_ray_math::ray() as u128),
+            current_variable_borrow_rate: 0,
+            last_update_timestamp: 0,
+            id: 0,
+            a_token_address,
+            variable_debt_token_address,
+            accrued_to_treasury: 0,
+            unbacked: 0,
+            isolation_mode_total_debt: 0
+        };
+
+        // Add the ReserveData in the smart table
+        smart_table::add(&mut reserve_data_list.value, underlying_asset, reserve_data);
+
+        let flag = false;
+        let reserve_count = reserve_data_list.count;
+        // Reorder assets
+        for (i in 0..reserve_count) {
+            let reserve_address_list =
+                borrow_global_mut<ReserveAddressesList>(@aave_pool);
+            if (!smart_table::contains(&reserve_address_list.value, (i as u256))) {
+                // update reserve id
+                set_reserve_id(reserve_data_list, underlying_asset, (i as u16));
+                // update reserve address list
+                add_reserve_address_list(
+                    reserve_address_list, (i as u256), underlying_asset
+                );
+                flag = true;
+            };
+        };
+
+        if (!flag) {
+            // Assert that the maximum number of reserves hasn't been reached
+            assert!(
+                reserve_count < max_number_reserves(),
+                error_config::get_eno_more_reserves_allowed()
+            );
+            // update reserve id
+            set_reserve_id(reserve_data_list, underlying_asset, reserve_count);
+
+            let reserve_address_list =
+                borrow_global_mut<ReserveAddressesList>(@aave_pool);
+            // update reserve address list
+            add_reserve_address_list(
+                reserve_address_list, (reserve_count as u256), underlying_asset
+            );
+
+            // Update the reserve count
+            reserve_data_list.count = reserve_data_list.count + 1;
+        };
+
+        // Set the reserve configuration
+        let reserve_configuration = reserve_config::init();
+        reserve_config::set_decimals(
+            &mut reserve_configuration, (underlying_asset_decimals as u256)
+        );
+        reserve_config::set_active(&mut reserve_configuration, true);
+        reserve_config::set_paused(&mut reserve_configuration, false);
+        reserve_config::set_frozen(&mut reserve_configuration, false);
+        set_reserve_configuration(underlying_asset, reserve_configuration);
+
+        // emit the ReserveInitialized event
+        event::emit(
+            ReserveInitialized {
+                asset: underlying_asset,
+                a_token: a_token_address,
+                variable_debt_token: variable_debt_token_address
+            }
+        )
+    }
+
+    #[test_only]
+    public fun test_init_reserve(
+        account: &signer,
+        underlying_asset: address,
+        treasury: address,
+        a_token_name: String,
+        a_token_symbol: String,
+        variable_debt_token_name: String,
+        variable_debt_token_symbol: String
+    ) acquires ReserveList, ReserveAddressesList {
+        init_reserve(
+            account,
+            underlying_asset,
+            treasury,
+            a_token_name,
+            a_token_symbol,
+            variable_debt_token_name,
+            variable_debt_token_symbol
+        );
+    }
+
+    /// @notice Drop a reserve
+    /// @dev Only callable by the pool_configurator module
+    /// @param asset The address of the underlying asset of the reserve
+    public(friend) fun drop_reserve(asset: address) acquires ReserveList, ReserveAddressesList {
+        assert!(asset != @0x0, error_config::get_ezero_address_not_valid());
+        // check if the asset is listed
+        let reserve_data = get_reserve_data(asset);
+
+        let variable_debt_token_total_supply =
+            variable_debt_token_total_supply(reserve_data.variable_debt_token_address);
+        assert!(
+            variable_debt_token_total_supply == 0,
+            error_config::get_evariable_debt_supply_not_zero()
+        );
+
+        let a_token_total_supply = a_token_total_supply(reserve_data.a_token_address);
+        assert!(
+            a_token_total_supply == 0 && reserve_data.accrued_to_treasury == 0,
+            error_config::get_eunderlying_claimable_rights_not_zero()
+        );
+
+        // Borrow the ReserveList resource
+        let reserve_data_list = borrow_global_mut<ReserveList>(@aave_pool);
+        // Remove the ReserveData entry from the smart_table
+        smart_table::remove(&mut reserve_data_list.value, asset);
+
+        // Remove ReserveAddressList
+        let reserve_address_list = borrow_global_mut<ReserveAddressesList>(@aave_pool);
+        if (smart_table::contains(&reserve_address_list.value, (reserve_data.id as u256))) {
+            smart_table::remove(
+                &mut reserve_address_list.value, (reserve_data.id as u256)
+            );
+        };
+
+        // assert assets count in storage
+        assert!(
+            smart_table::length(&reserve_address_list.value)
+                == smart_table::length(&reserve_data_list.value),
+            error_config::get_ereserves_storage_count_mismatch()
+        );
+
+        // drop a token and variable debt token associated data
+        a_token_factory::drop_token(reserve_data.a_token_address);
+        variable_debt_token_factory::drop_token(reserve_data.variable_debt_token_address);
+    }
+
+    #[test_only]
+    public fun test_drop_reserve(asset: address) acquires ReserveList, ReserveAddressesList {
+        drop_reserve(asset);
+    }
+
+    #[view]
+    /// @notice Returns the state and configuration of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The state and configuration data of the reserve
+    public fun get_reserve_data(asset: address): ReserveData acquires ReserveList {
+        // Get the signer address
+        let signer_address = @aave_pool;
+
+        // Assert that the signer has created a list
+        assert!(
+            exists<ReserveList>(signer_address),
+            error_config::get_ereserve_list_not_initialized()
+        );
+
+        // Get the ReserveList resource
+        let reserve_list = borrow_global<ReserveList>(signer_address);
+
+        // Assert that the asset is listed
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        // Borrow the ReserveData for the specified asset
+        let reserve_data =
+            smart_table::borrow<address, ReserveData>(&reserve_list.value, asset);
+
+        // Return the borrowed ReserveData
+        *reserve_data
+    }
+
+    #[view]
+    public fun get_reserve_data_and_reserves_count(
+        asset: address
+    ): (ReserveData, u256) acquires ReserveList {
+        // Get the ReserveList resource
+        let reserve_list = borrow_global<ReserveList>(@aave_pool);
+
+        // Assert that the asset is listed
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        // Borrow the ReserveData for the specified asset
+        let reserve_data =
+            smart_table::borrow<address, ReserveData>(&reserve_list.value, asset);
+
+        // Return the borrowed ReserveData
+        (*reserve_data, (reserve_list.count as u256))
+    }
+
+    #[view]
+    /// @notice Returns the configuration of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The configuration of the reserve
+    public fun get_reserve_configuration(
+        asset: address
+    ): ReserveConfigurationMap acquires ReserveList {
+        let reserve_list = borrow_global<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow<address, ReserveData>(&reserve_list.value, asset);
+        reserve_data.configuration
+    }
+
+    #[view]
+    public fun get_reserves_count(): u256 acquires ReserveList {
+        let reserve_list = borrow_global<ReserveList>(@aave_pool);
+        (reserve_list.count as u256)
+    }
+
+    public fun get_reserve_configuration_by_reserve_data(
+        reserve_data: &ReserveData
+    ): ReserveConfigurationMap {
+        reserve_data.configuration
+    }
+
+    public fun get_reserve_last_update_timestamp(reserve: &ReserveData): u64 {
+        reserve.last_update_timestamp
+    }
+
+    fun set_reserve_id(
+        reserve_list: &mut ReserveList, asset: address, id: u16
+    ) {
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data.id = id
+    }
+
+    fun set_reserve_last_update_timestamp(
+        asset: address, reserve_data_mut: &mut ReserveData, last_update_timestamp: u64
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data_mut.last_update_timestamp = last_update_timestamp;
+        reserve_data.last_update_timestamp = last_update_timestamp
+    }
+
+    public fun get_reserve_id(reserve: &ReserveData): u16 {
+        reserve.id
+    }
+
+    public fun get_reserve_a_token_address(reserve: &ReserveData): address {
+        reserve.a_token_address
+    }
+
+    /// @notice Update accrued_to_treasury of the reserve
+    /// @dev Only callable by the pool, bridge_logic and flashloan_logic module
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @accrued_to_treasury The new accrued_to_treasury value
+    public(friend) fun set_reserve_accrued_to_treasury(
+        asset: address, reserve_data_mut: &mut ReserveData, accrued_to_treasury: u256
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+
+        reserve_data.accrued_to_treasury = accrued_to_treasury;
+        reserve_data_mut.accrued_to_treasury = accrued_to_treasury;
+    }
+
+    public fun get_reserve_accrued_to_treasury(reserve: &ReserveData): u256 {
+        reserve.accrued_to_treasury
+    }
+
+    fun set_reserve_variable_borrow_index(
+        asset: address, reserve_data_mut: &mut ReserveData, variable_borrow_index: u128
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data_mut.variable_borrow_index = variable_borrow_index;
+        reserve_data.variable_borrow_index = variable_borrow_index
+    }
+
+    public fun get_reserve_variable_borrow_index(reserve: &ReserveData): u128 {
+        reserve.variable_borrow_index
+    }
+
+    fun set_reserve_liquidity_index(
+        asset: address, reserve_data_mut: &mut ReserveData, liquidity_index: u128
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data_mut.liquidity_index = liquidity_index;
+        reserve_data.liquidity_index = liquidity_index
+    }
+
+    public fun get_reserve_liquidity_index(reserve: &ReserveData): u128 {
+        reserve.liquidity_index
+    }
+
+    fun set_reserve_current_liquidity_rate(
+        asset: address, reserve_data_mut: &mut ReserveData, current_liquidity_rate: u128
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data_mut.current_liquidity_rate = current_liquidity_rate;
+        reserve_data.current_liquidity_rate = current_liquidity_rate
+    }
+
+    public fun get_reserve_current_liquidity_rate(reserve: &ReserveData): u128 {
+        reserve.current_liquidity_rate
+    }
+
+    fun set_reserve_current_variable_borrow_rate(
+        asset: address,
+        reserve_data_mut: &mut ReserveData,
+        current_variable_borrow_rate: u128
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+
+        reserve_data_mut.current_variable_borrow_rate = current_variable_borrow_rate;
+        reserve_data.current_variable_borrow_rate = current_variable_borrow_rate
+    }
+
+    public fun get_reserve_current_variable_borrow_rate(
+        reserve: &ReserveData
+    ): u128 {
+        reserve.current_variable_borrow_rate
+    }
+
+    public fun get_reserve_variable_debt_token_address(
+        reserve: &ReserveData
+    ): address {
+        reserve.variable_debt_token_address
+    }
+
+    /// @notice Updates unbacked of the reserve
+    /// @dev Only callable by the bridge_logic module
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param unbacked The new unbacked value
+    public(friend) fun set_reserve_unbacked(
+        asset: address, reserve_data_mut: &mut ReserveData, unbacked: u128
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data_mut.unbacked = unbacked;
+        reserve_data.unbacked = unbacked;
+    }
+
+    public fun get_reserve_unbacked(reserve: &ReserveData): u128 {
+        reserve.unbacked
+    }
+
+    /// @notice Updates isolation_mode_total_debt of the reserve
+    /// @dev Only callable by the borrow_logic and isolation_mode_logic module
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param isolation_mode_total_debt The new isolation_mode_total_debt value
+    public(friend) fun set_reserve_isolation_mode_total_debt(
+        asset: address, reserve_data_mut: &mut ReserveData, isolation_mode_total_debt: u128
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data_mut.isolation_mode_total_debt = isolation_mode_total_debt;
+        reserve_data.isolation_mode_total_debt = isolation_mode_total_debt
+    }
+
+    public fun get_reserve_isolation_mode_total_debt(
+        reserve: &ReserveData
+    ): u128 {
+        reserve.isolation_mode_total_debt
+    }
+
+    public fun set_reserve_configuration_with_guard(
+        account: &signer, asset: address, reserve_config_map: ReserveConfigurationMap
+    ) acquires ReserveList {
+        assert!(
+            acl_manage::is_asset_listing_admin(signer::address_of(account))
+                || acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+        set_reserve_configuration(asset, reserve_config_map);
+    }
+
+    /// @notice Sets the configuration bitmap of the reserve as a whole
+    /// @dev Only callable by the pool_configurator and pool module
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_config_map The new configuration bitmap
+    public(friend) fun set_reserve_configuration(
+        asset: address, reserve_config_map: ReserveConfigurationMap
+    ) acquires ReserveList {
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_dara =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+
+        reserve_dara.configuration = reserve_config_map;
+    }
+
+    #[test_only]
+    public fun test_set_reserve_configuration(
+        asset: address, reserve_config_map: ReserveConfigurationMap
+    ) acquires ReserveList {
+        set_reserve_configuration(asset, reserve_config_map);
+    }
+
+    #[view]
+    public fun get_user_configuration(user: address): UserConfigurationMap acquires UsersConfig {
+        let user_config_obj = borrow_global<UsersConfig>(@aave_pool);
+
+        if (smart_table::contains(&user_config_obj.value, user)) {
+            let user_config_map = smart_table::borrow(&user_config_obj.value, user);
+            return *user_config_map
+        };
+
+        user_config::init()
+    }
+
+    /// @notice Sets the configuration bitmap of the user
+    /// @dev Only callable by the supply_logic, borrow_logic, bridge_logic and liquidation_logic module
+    /// @param user The address of the user
+    /// @param user_config_map The new configuration bitmap
+    public(friend) fun set_user_configuration(
+        user: address, user_config_map: UserConfigurationMap
+    ) acquires UsersConfig {
+        let user_config_obj = borrow_global_mut<UsersConfig>(@aave_pool);
+        smart_table::upsert(&mut user_config_obj.value, user, user_config_map);
+    }
+
+    #[view]
+    /// @notice Returns the normalized income of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The reserve's normalized income
+    public fun get_reserve_normalized_income(asset: address): u256 acquires ReserveList {
+        let reserve_data = get_reserve_data(asset);
+
+        get_normalized_income_by_reserve_data(&reserve_data)
+    }
+
+    /// @notice Returns the ongoing normalized income for the reserve.
+    /// @dev A value of 1e27 means there is no income. As time passes, the income is accrued
+    /// @dev A value of 2*1e27 means for each unit of asset one unit of income has been accrued
+    /// @param reserve_data The reserve data
+    /// @return The normalized income, expressed in ray
+    public fun get_normalized_income_by_reserve_data(
+        reserve_data: &ReserveData
+    ): u256 {
+        let last_update_timestamp = reserve_data.last_update_timestamp;
+        if (last_update_timestamp == timestamp::now_seconds()) {
+            //if the index was updated in the same block, no need to perform any calculation
+            return (reserve_data.liquidity_index as u256)
+        };
+
+        wad_ray_math::ray_mul(
+            math_utils::calculate_linear_interest(
+                (reserve_data.current_liquidity_rate as u256), last_update_timestamp
+            ),
+            (reserve_data.liquidity_index as u256)
+        )
+    }
+
+    /// @notice Updates the liquidity cumulative index and the variable borrow index.
+    /// @dev Only callable by the supply_logic, borrow_logic, bridge_logic, flashloan_logic and liquidation_logic module
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param reserve_cache The reserve cache
+    public(friend) fun update_state(
+        asset: address,
+        reserve_data_mut: &mut ReserveData,
+        reserve_cache: &mut ReserveCache
+    ) acquires ReserveList {
+        let current_timestamp = timestamp::now_seconds();
+        if (reserve_data_mut.last_update_timestamp == current_timestamp) { return };
+
+        update_indexes(asset, reserve_data_mut, reserve_cache);
+        accrue_to_treasury(asset, reserve_data_mut, reserve_cache);
+
+        set_reserve_last_update_timestamp(asset, reserve_data_mut, current_timestamp)
+    }
+
+    /// @notice Updates the reserve indexes and the timestamp of the update.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param reserve_cache The reserve cache
+    fun update_indexes(
+        asset: address,
+        reserve_data_mut: &mut ReserveData,
+        reserve_cache: &mut ReserveCache
+    ) acquires ReserveList {
+        // Only cumulating on the supply side if there is any income being produced
+        // The case of Reserve Factor 100% is not a problem (currentLiquidityRate == 0),
+        // as liquidity index should not be updated
+        if (reserve_cache.curr_liquidity_rate != 0) {
+            let cumulated_liquidity_interest =
+                math_utils::calculate_linear_interest(
+                    reserve_cache.curr_liquidity_rate,
+                    reserve_cache.reserve_last_update_timestamp
+                );
+            let next_liquidity_index =
+                wad_ray_math::ray_mul(
+                    cumulated_liquidity_interest,
+                    reserve_cache.curr_liquidity_index
+                );
+            reserve_cache.next_liquidity_index = next_liquidity_index;
+
+            set_reserve_liquidity_index(
+                asset, reserve_data_mut, (next_liquidity_index as u128)
+            )
+        };
+
+        // Variable borrow index only gets updated if there is any variable debt.
+        // reserve_cache.curr_variable_borrow_rate != 0 is not a correct validation,
+        // because a positive base variable rate can be stored on
+        // reserve_cache.curr_variable_borrow_rate, but the index should not increase
+        if (reserve_cache.curr_scaled_variable_debt != 0) {
+            let cumulated_variable_borrow_interest =
+                math_utils::calculate_compounded_interest_now(
+                    reserve_cache.curr_variable_borrow_rate,
+                    reserve_cache.reserve_last_update_timestamp
+                );
+
+            reserve_cache.next_variable_borrow_index = wad_ray_math::ray_mul(
+                cumulated_variable_borrow_interest,
+                reserve_cache.curr_variable_borrow_index
+            );
+            // update reserve data
+            set_reserve_variable_borrow_index(
+                asset,
+                reserve_data_mut,
+                (reserve_cache.next_variable_borrow_index as u128)
+            )
+        }
+    }
+
+    struct AccrueToTreasuryLocalVars has drop {
+        prev_total_variable_debt: u256,
+        curr_total_variable_debt: u256,
+        total_debt_accrued: u256,
+        amount_to_mint: u256
+    }
+
+    fun create_accrue_to_treasury_local_vars(): AccrueToTreasuryLocalVars {
+        AccrueToTreasuryLocalVars {
+            prev_total_variable_debt: 0,
+            curr_total_variable_debt: 0,
+            total_debt_accrued: 0,
+            amount_to_mint: 0
+        }
+    }
+
+    /// @notice Update part of the repaid interest to the reserve treasury as a function of the reserve factor for the
+    /// specific asset.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param reserve_cache The reserve cache
+    fun accrue_to_treasury(
+        asset: address,
+        reserve_data_mut: &mut ReserveData,
+        reserve_cache: &mut ReserveCache
+    ) acquires ReserveList {
+        let vars = create_accrue_to_treasury_local_vars();
+        if (reserve_cache.reserve_factor == 0) { return };
+
+        //calculate the total variable debt at moment of the last interaction
+        vars.prev_total_variable_debt = wad_ray_math::ray_mul(
+            reserve_cache.curr_scaled_variable_debt,
+            reserve_cache.curr_variable_borrow_index
+        );
+
+        //calculate the new total variable debt after accumulation of the interest on the index
+        vars.curr_total_variable_debt = wad_ray_math::ray_mul(
+            reserve_cache.curr_scaled_variable_debt,
+            reserve_cache.next_variable_borrow_index
+        );
+
+        let total_debt_accrued =
+            vars.curr_total_variable_debt - vars.prev_total_variable_debt;
+        vars.amount_to_mint = math_utils::percent_mul(
+            total_debt_accrued, reserve_cache.reserve_factor
+        );
+
+        if (vars.amount_to_mint != 0) {
+            let new_accrued_to_treasury =
+                reserve_data_mut.accrued_to_treasury
+                    + wad_ray_math::ray_div(
+                        vars.amount_to_mint,
+                        reserve_cache.next_liquidity_index
+                    );
+
+            set_reserve_accrued_to_treasury(
+                asset, reserve_data_mut, new_accrued_to_treasury
+            )
+        }
+    }
+
+    #[view]
+    /// @notice Returns the normalized variable debt per unit of asset
+    /// @dev WARNING: This function is intended to be used primarily by the protocol itself to get a
+    /// "dynamic" variable index based on time, current stored index and virtual rate at the current
+    /// moment (approx. a borrower would get if opening a position). This means that is always used in
+    /// combination with variable debt supply/balances.
+    /// If using this function externally, consider that is possible to have an increasing normalized
+    /// variable debt that is not equivalent to how the variable debt index would be updated in storage
+    /// (e.g. only updates with non-zero variable debt supply)
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The reserve normalized variable debt
+    public fun get_reserve_normalized_variable_debt(asset: address): u256 acquires ReserveList {
+        let reserve_data = get_reserve_data(asset);
+        get_normalized_debt_by_reserve_data(&reserve_data)
+    }
+
+    /// @notice Returns the ongoing normalized variable debt for the reserve.
+    /// @dev A value of 1e27 means there is no debt. As time passes, the debt is accrued
+    /// @dev A value of 2*1e27 means that for each unit of debt, one unit worth of interest has been accumulated
+    /// @param reserve_data The reserve data
+    /// @return The normalized variable debt, expressed in ray
+    public fun get_normalized_debt_by_reserve_data(
+        reserve_data: &ReserveData
+    ): u256 {
+        let last_update_timestamp = reserve_data.last_update_timestamp;
+        if (last_update_timestamp == timestamp::now_seconds()) {
+            //if the index was updated in the same block, no need to perform any calculation
+            return (reserve_data.variable_borrow_index as u256)
+        };
+        wad_ray_math::ray_mul(
+            math_utils::calculate_compounded_interest_now(
+                (reserve_data.current_variable_borrow_rate as u256),
+                last_update_timestamp
+            ),
+            (reserve_data.variable_borrow_index as u256)
+        )
+    }
+
+    fun add_reserve_address_list(
+        reserve_address_list: &mut ReserveAddressesList, index: u256, asset: address
+    ) {
+        if (smart_table::length(&reserve_address_list.value) == 0) {
+            smart_table::add(&mut reserve_address_list.value, index, asset);
+        } else {
+            assert!(
+                !smart_table::contains(&mut reserve_address_list.value, index),
+                error_config::get_ereserve_already_added()
+            );
+
+            smart_table::add(&mut reserve_address_list.value, index, asset);
+        }
+    }
+
+    #[view]
+    /// @notice Returns the list of the underlying assets of all the initialized reserves
+    /// @dev It does not include dropped reserves
+    /// @return The addresses of the underlying assets of the initialized reserves
+    public fun get_reserves_list(): vector<address> acquires ReserveAddressesList, ReserveList {
+        let reserves_list_count = get_reserves_count();
+        let address_list = vector::empty<address>();
+
+        if (reserves_list_count == 0) {
+            return address_list
+        };
+
+        let reserve_address_list = borrow_global<ReserveAddressesList>(@aave_pool);
+
+        smart_table::for_each_ref(
+            &reserve_address_list.value,
+            |_k, v| {
+                vector::push_back(&mut address_list, *v);
+            }
+        );
+
+        address_list
+    }
+
+    #[view]
+    /// @notice Returns the address of the underlying asset of a reserve by the reserve id as stored in the ReserveData struct
+    /// @param id The id of the reserve as stored in the ReserveData struct
+    /// @return The address of the reserve associated with id
+    public fun get_reserve_address_by_id(id: u256): address acquires ReserveAddressesList {
+        let reserve_address_list = borrow_global<ReserveAddressesList>(@aave_pool);
+
+        if (!smart_table::contains(&reserve_address_list.value, id)) {
+            return @0x0
+        };
+
+        *smart_table::borrow(&reserve_address_list.value, id)
+    }
+
+    /// @notice Mints the assets accrued through the reserve factor to the treasury in the form of aTokens
+    /// @param assets The list of reserves for which the minting needs to be executed
+    public entry fun mint_to_treasury(assets: vector<address>) acquires ReserveList {
+        for (i in 0..vector::length(&assets)) {
+            let asset_address = *vector::borrow(&assets, i);
+            let reserve_data = &mut get_reserve_data(asset_address);
+            let reserve_config_map =
+                get_reserve_configuration_by_reserve_data(reserve_data);
+
+            // this cover both inactive reserves and invalid reserves since the flag will be 0 for both
+            if (!reserve_config::get_active(&reserve_config_map)) {
+                continue
+            };
+
+            let accrued_to_treasury = reserve_data.accrued_to_treasury;
+            if (accrued_to_treasury != 0) {
+                set_reserve_accrued_to_treasury(asset_address, reserve_data, 0);
+
+                let normalized_income = get_reserve_normalized_income(asset_address);
+                let amount_to_mint =
+                    wad_ray_math::ray_mul(accrued_to_treasury, normalized_income);
+
+                a_token_factory::mint_to_treasury(
+                    amount_to_mint,
+                    normalized_income,
+                    reserve_data.a_token_address
+                );
+
+                event::emit(
+                    MintedToTreasury {
+                        reserve: asset_address,
+                        amount_minted: amount_to_mint
+                    }
+                );
+            };
+        }
+    }
+
+    #[view]
+    public fun get_bridge_protocol_fee(): u256 acquires ReserveExtendConfiguration {
+        let reserve_extend_configuration =
+            borrow_global<ReserveExtendConfiguration>(@aave_pool);
+        reserve_extend_configuration.bridge_protocol_fee
+    }
+
+    /// @notice Sets the bridge protocol fee
+    /// @dev Only callable by the pool_configurator module
+    /// @param protocol_fee The new bridge protocol fee
+    public(friend) fun set_bridge_protocol_fee(
+        protocol_fee: u256
+    ) acquires ReserveExtendConfiguration {
+        let reserve_extend_configuration =
+            borrow_global_mut<ReserveExtendConfiguration>(@aave_pool);
+        reserve_extend_configuration.bridge_protocol_fee = protocol_fee
+    }
+
+    #[view]
+    public fun get_flashloan_premium_total(): u128 acquires ReserveExtendConfiguration {
+        let reserve_extend_configuration =
+            borrow_global<ReserveExtendConfiguration>(@aave_pool);
+        reserve_extend_configuration.flash_loan_premium_total
+    }
+
+    #[test_only]
+    public fun set_flashloan_premiums_test(
+        flash_loan_premium_total: u128, flash_loan_premium_to_protocol: u128
+    ) acquires ReserveExtendConfiguration {
+        update_flashloan_premiums(
+            flash_loan_premium_total, flash_loan_premium_to_protocol
+        )
+    }
+
+    /// @notice Updates flash loan premiums. Flash loan premium consists of two parts:
+    /// - A part is sent to aToken holders as extra, one time accumulated interest
+    /// - A part is collected by the protocol treasury
+    /// @dev The total premium is calculated on the total borrowed amount
+    /// @dev The premium to protocol is calculated on the total premium, being a percentage of `flash_loan_premium_total`
+    /// @dev Only callable by the pool_configurator module
+    /// @param flash_loan_premium_total The total premium, expressed in bps
+    /// @param flash_loan_premium_to_protocol The part of the premium sent to the protocol treasury, expressed in bps
+    public(friend) fun update_flashloan_premiums(
+        flash_loan_premium_total: u128, flash_loan_premium_to_protocol: u128
+    ) acquires ReserveExtendConfiguration {
+        let reserve_extend_configuration =
+            borrow_global_mut<ReserveExtendConfiguration>(@aave_pool);
+
+        reserve_extend_configuration.flash_loan_premium_total = flash_loan_premium_total;
+        reserve_extend_configuration.flash_loan_premium_to_protocol = flash_loan_premium_to_protocol
+    }
+
+    #[view]
+    public fun get_flashloan_premium_to_protocol(): u128 acquires ReserveExtendConfiguration {
+        let reserve_extend_configuration =
+            borrow_global<ReserveExtendConfiguration>(@aave_pool);
+        reserve_extend_configuration.flash_loan_premium_to_protocol
+    }
+
+    #[view]
+    /// @notice Returns the maximum number of reserves supported to be listed in this Pool
+    /// @return The maximum number of reserves supported
+    public fun max_number_reserves(): u16 {
+        reserve_config::get_max_reserves_count()
+    }
+
+    /// @notice Updates the reserve the current variable borrow rate and the current liquidity rate.
+    /// @dev Only callable by the supply_logic, borrow_logic, bridge_logic, flashloan_logic and liquidation_logic module
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param reserve_cache The reserve cache
+    /// @param reserve_address The address of the reserve to be updated
+    /// @param liquidity_added The amount of liquidity added to the protocol (supply or repay) in the previous action
+    /// @param liquidity_taken The amount of liquidity taken from the protocol (redeem or borrow)
+    public(friend) fun update_interest_rates(
+        reserve_data_mut: &mut ReserveData,
+        reserve_cache: &ReserveCache,
+        reserve_address: address,
+        liquidity_added: u256,
+        liquidity_taken: u256
+    ) acquires ReserveList {
+        let total_variable_debt =
+            wad_ray_math::ray_mul(
+                reserve_cache.next_scaled_variable_debt,
+                reserve_cache.next_variable_borrow_index
+            );
+        // The underlying token balance corresponding to the aToken
+        let a_token_underlying_balance =
+            (
+                fungible_asset_manager::balance_of(
+                    a_token_factory::get_token_account_address(
+                        reserve_cache.a_token_address
+                    ),
+                    reserve_address
+                ) as u256
+            );
+        let reserve_symbol = fungible_asset_manager::symbol(reserve_address);
+        let (next_liquidity_rate, next_variable_rate) =
+            interest_rate_strategy::calculate_interest_rates(
+                (reserve_data_mut.unbacked as u256),
+                liquidity_added,
+                liquidity_taken,
+                total_variable_debt,
+                reserve_cache.reserve_factor,
+                reserve_address,
+                reserve_symbol,
+                a_token_underlying_balance
+            );
+
+        set_reserve_current_liquidity_rate(
+            reserve_address, reserve_data_mut, (next_liquidity_rate as u128)
+        );
+        set_reserve_current_variable_borrow_rate(
+            reserve_address, reserve_data_mut, (next_variable_rate as u128)
+        );
+
+        event::emit(
+            ReserveDataUpdated {
+                reserve: reserve_address,
+                liquidity_rate: next_liquidity_rate,
+                variable_borrow_rate: next_variable_rate,
+                liquidity_index: reserve_cache.next_liquidity_index,
+                variable_borrow_index: reserve_cache.next_variable_borrow_index
+            }
+        )
+    }
+
+    /// @notice Returns the Isolation Mode state of the user
+    /// @param user_config_map The configuration of the user
+    /// @return True if the user is in isolation mode, false otherwise
+    /// @return The address of the only asset used as collateral
+    /// @return The debt ceiling of the reserve
+    public fun get_isolation_mode_state(
+        user_config_map: &UserConfigurationMap
+    ): (bool, address, u256) acquires ReserveAddressesList, ReserveList {
+        if (user_config::is_using_as_collateral_one(user_config_map)) {
+            let asset_id: u256 =
+                user_config::get_first_asset_id_by_mask(
+                    user_config_map,
+                    user_config::get_collateral_mask()
+                );
+            let asset_address = get_reserve_address_by_id(asset_id);
+            let reserves_config_map = get_reserve_configuration(asset_address);
+            let ceiling: u256 = reserve_config::get_debt_ceiling(&reserves_config_map);
+            if (ceiling != 0) {
+                return (true, asset_address, ceiling)
+            }
+        };
+        (false, @0x0, 0)
+    }
+
+    /// @notice Returns the siloed borrowing state for the user
+    /// @param account The address of the user
+    /// @return True if the user has borrowed a siloed asset, false otherwise
+    /// @return The address of the only borrowed asset
+    public fun get_siloed_borrowing_state(
+        account: address
+    ): (bool, address) acquires ReserveAddressesList, ReserveList, UsersConfig {
+        let user_configuration = get_user_configuration(account);
+
+        if (user_config::is_borrowing_one(&user_configuration)) {
+            let asset_id: u256 =
+                user_config::get_first_asset_id_by_mask(
+                    &user_configuration,
+                    user_config::get_borrowing_mask()
+                );
+            let asset_address = get_reserve_address_by_id(asset_id);
+            let reserves_config_map = get_reserve_configuration(asset_address);
+
+            if (reserve_config::get_siloed_borrowing(&reserves_config_map)) {
+                return (true, asset_address)
+            };
+        };
+        (false, @0x0)
+    }
+
+    /// @notice Accumulates a predefined amount of asset to the reserve as a fixed, instantaneous income. Used for example
+    /// to accumulate the flashloan fee to the reserve, and spread it between all the suppliers.
+    /// @dev Only callable by the flashloan_logic and bridge_logic module
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param reserve_data_mut The mutable reference of the reserve data
+    /// @param total_liquidity The total liquidity available in the reserve
+    /// @param amount The amount to accumulate
+    /// @return The next liquidity index of the reserve
+    public(friend) fun cumulate_to_liquidity_index(
+        asset: address,
+        reserve_data_mut: &mut ReserveData,
+        total_liquidity: u256,
+        amount: u256
+    ): u256 acquires ReserveList {
+        //next liquidity index is calculated this way: `((amount / totalLiquidity) + 1) * liquidityIndex`
+        //division `amount / totalLiquidity` done in ray for precision
+        let result =
+            wad_ray_math::ray_mul(
+                (
+                    wad_ray_math::ray_div(
+                        wad_ray_math::wad_to_ray(amount),
+                        wad_ray_math::wad_to_ray(total_liquidity)
+                    ) + wad_ray_math::ray()
+                ),
+                (reserve_data_mut.liquidity_index as u256)
+            );
+
+        set_reserve_liquidity_index(asset, reserve_data_mut, (result as u128));
+
+        result
+    }
+
+    /// @notice Resets the isolation mode total debt of the given asset to zero
+    /// @dev Only callable by the pool_configurator module
+    /// @dev It requires the given asset has zero debt ceiling
+    /// @param asset The address of the underlying asset to reset the isolation_mode_total_debt
+    public(friend) fun reset_isolation_mode_total_debt(asset: address) acquires ReserveList {
+        let reserve_config_map = get_reserve_configuration(asset);
+        assert!(
+            reserve_config::get_debt_ceiling(&reserve_config_map) == 0,
+            error_config::get_edebt_ceiling_not_zero()
+        );
+
+        let reserve_list = borrow_global_mut<ReserveList>(@aave_pool);
+        assert!(
+            smart_table::contains(&reserve_list.value, asset),
+            error_config::get_easset_not_listed()
+        );
+
+        let reserve_data =
+            smart_table::borrow_mut<address, ReserveData>(&mut reserve_list.value, asset);
+        reserve_data.isolation_mode_total_debt = 0;
+
+        event::emit(IsolationModeTotalDebtUpdated { asset, total_debt: 0 })
+    }
+
+    /// ====== Pool Cache ======
+    /// pool cache data
+    struct ReserveCache has drop {
+        curr_scaled_variable_debt: u256,
+        next_scaled_variable_debt: u256,
+        curr_liquidity_index: u256,
+        next_liquidity_index: u256,
+        curr_variable_borrow_index: u256,
+        next_variable_borrow_index: u256,
+        curr_liquidity_rate: u256,
+        curr_variable_borrow_rate: u256,
+        reserve_factor: u256,
+        reserve_configuration: ReserveConfigurationMap,
+        a_token_address: address,
+        variable_debt_token_address: address,
+        reserve_last_update_timestamp: u64
+    }
+
+    fun init_cache(): ReserveCache {
+        ReserveCache {
+            curr_scaled_variable_debt: 0,
+            next_scaled_variable_debt: 0,
+            curr_liquidity_index: 0,
+            next_liquidity_index: 0,
+            curr_variable_borrow_index: 0,
+            next_variable_borrow_index: 0,
+            curr_liquidity_rate: 0,
+            curr_variable_borrow_rate: 0,
+            reserve_factor: 0,
+            reserve_configuration: reserve_config::init(),
+            a_token_address: @0x0,
+            variable_debt_token_address: @0x0,
+            reserve_last_update_timestamp: 0
+        }
+    }
+
+    public fun cache(reserve_data: &ReserveData): ReserveCache {
+        let reserve_cache = init_cache();
+        reserve_cache.reserve_configuration = reserve_data.configuration;
+        reserve_cache.reserve_factor = reserve_config::get_reserve_factor(
+            &reserve_cache.reserve_configuration
+        );
+
+        let liquidity_index = (reserve_data.liquidity_index as u256);
+        reserve_cache.curr_liquidity_index = liquidity_index;
+        reserve_cache.next_liquidity_index = liquidity_index;
+
+        let variable_borrow_index = (reserve_data.variable_borrow_index as u256);
+        reserve_cache.curr_variable_borrow_index = variable_borrow_index;
+        reserve_cache.next_variable_borrow_index = variable_borrow_index;
+
+        reserve_cache.curr_liquidity_rate = (reserve_data.current_liquidity_rate as u256);
+        reserve_cache.curr_variable_borrow_rate = (
+            reserve_data.current_variable_borrow_rate as u256
+        );
+
+        reserve_cache.a_token_address = reserve_data.a_token_address;
+        reserve_cache.variable_debt_token_address = reserve_data.variable_debt_token_address;
+
+        reserve_cache.reserve_last_update_timestamp = reserve_data.last_update_timestamp;
+
+        let scaled_total_debt =
+            variable_debt_token_factory::scaled_total_supply(
+                reserve_cache.variable_debt_token_address
+            );
+        reserve_cache.curr_scaled_variable_debt = scaled_total_debt;
+        reserve_cache.next_scaled_variable_debt = scaled_total_debt;
+
+        reserve_cache
+    }
+
+    public fun get_reserve_cache_configuration(
+        reserve_cache: &ReserveCache
+    ): ReserveConfigurationMap {
+        reserve_cache.reserve_configuration
+    }
+
+    public fun get_reserve_factor(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.reserve_factor
+    }
+
+    public fun get_curr_liquidity_index(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.curr_liquidity_index
+    }
+
+    public fun set_curr_liquidity_index(
+        reserve_cache: &mut ReserveCache, index: u256
+    ) {
+        reserve_cache.curr_liquidity_index = index;
+    }
+
+    public fun get_next_liquidity_index(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.next_liquidity_index
+    }
+
+    public fun set_next_liquidity_index(
+        reserve_cache: &mut ReserveCache, index: u256
+    ) {
+        reserve_cache.next_liquidity_index = index;
+    }
+
+    public fun get_curr_variable_borrow_index(
+        reserve_cache: &ReserveCache
+    ): u256 {
+        reserve_cache.curr_variable_borrow_index
+    }
+
+    public fun get_next_variable_borrow_index(
+        reserve_cache: &ReserveCache
+    ): u256 {
+        reserve_cache.next_variable_borrow_index
+    }
+
+    public fun set_next_variable_borrow_index(
+        reserve_cache: &mut ReserveCache, index: u256
+    ) {
+        reserve_cache.next_variable_borrow_index = index;
+    }
+
+    public fun get_curr_liquidity_rate(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.curr_liquidity_rate
+    }
+
+    public fun set_curr_liquidity_rate(
+        reserve_cache: &mut ReserveCache, rate: u256
+    ) {
+        reserve_cache.curr_liquidity_rate = rate;
+    }
+
+    public fun get_curr_variable_borrow_rate(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.curr_variable_borrow_rate
+    }
+
+    public fun set_curr_variable_borrow_rate(
+        reserve_cache: &mut ReserveCache, rate: u256
+    ) {
+        reserve_cache.curr_variable_borrow_rate = rate;
+    }
+
+    public fun get_a_token_address(reserve_cache: &ReserveCache): address {
+        reserve_cache.a_token_address
+    }
+
+    public fun get_variable_debt_token_address(
+        reserve_cache: &ReserveCache
+    ): address {
+        reserve_cache.variable_debt_token_address
+    }
+
+    public fun get_curr_scaled_variable_debt(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.curr_scaled_variable_debt
+    }
+
+    public fun get_next_scaled_variable_debt(reserve_cache: &ReserveCache): u256 {
+        reserve_cache.next_scaled_variable_debt
+    }
+
+    public fun set_next_scaled_variable_debt(
+        reserve_cache: &mut ReserveCache, scaled_debt: u256
+    ) {
+        reserve_cache.next_scaled_variable_debt = scaled_debt;
+    }
+
+    #[view]
+    /// @notice Computes the total supply of aTokens for a specific aToken address, adjusted by the reserve's normalized income.
+    /// @dev Retrieves the scaled total supply of aTokens for the specified aToken address.
+    /// @dev Converts the scaled total supply into the underlying token denomination using the reserve's normalized income.
+    /// @dev Returns 0 if the scaled total supply is zero.
+    /// @param a_token_address The address of the aToken contract for which the total supply is being queried.
+    /// @return The adjusted total supply of the aTokens in the underlying token, considering the reserve's normalized income.
+    public fun a_token_total_supply(a_token_address: address): u256 acquires ReserveList {
+        let current_supply_scaled = a_token_factory::scaled_total_supply(a_token_address);
+        if (current_supply_scaled == 0) {
+            return 0
+        };
+        let underlying_token_address =
+            a_token_factory::get_underlying_asset_address(a_token_address);
+        wad_ray_math::ray_mul(
+            current_supply_scaled,
+            get_reserve_normalized_income(underlying_token_address)
+        )
+    }
+
+    #[view]
+    /// @notice Computes the current balance of aTokens for a specific owner, adjusted by the reserve's normalized income.
+    /// @dev Retrieves the scaled balance of aTokens for the specified owner and aToken address.
+    /// @dev Converts the scaled balance into the underlying token denomination using the reserve's normalized income.
+    /// @dev Returns 0 if the scaled balance is zero.
+    /// @param owner The address of the account whose aToken balance is to be queried.
+    /// @param a_token_address The address of the aToken contract for which the balance is being queried.
+    /// @return The adjusted balance of the owner in the underlying token, considering the reserve's normalized income.
+    public fun a_token_balance_of(
+        owner: address, a_token_address: address
+    ): u256 acquires ReserveList {
+        let current_balance_scale =
+            a_token_factory::scaled_balance_of(owner, a_token_address);
+        if (current_balance_scale == 0) {
+            return 0
+        };
+        let underlying_token_address =
+            a_token_factory::get_underlying_asset_address(a_token_address);
+        wad_ray_math::ray_mul(
+            current_balance_scale,
+            get_reserve_normalized_income(underlying_token_address)
+        )
+    }
+
+    #[view]
+    /// @notice Computes the total supply of variable debt tokens for a specific address, adjusted by the reserve's normalized variable debt.
+    /// @dev Retrieves the scaled total supply of variable debt tokens for the specified variable debt token address.
+    /// @dev Converts the scaled total supply into the underlying token denomination using the reserve's normalized variable debt.
+    /// @dev Returns 0 if the scaled total supply is zero.
+    /// @param variable_debt_token_address The address of the variable debt token contract for which the total supply is being queried.
+    /// @return The adjusted total supply of the variable debt tokens in the underlying token, considering the reserve's normalized variable debt.
+    public fun variable_debt_token_total_supply(
+        variable_debt_token_address: address
+    ): u256 acquires ReserveList {
+        let current_supply_scaled =
+            variable_debt_token_factory::scaled_total_supply(variable_debt_token_address);
+        if (current_supply_scaled == 0) {
+            return 0
+        };
+        let underlying_token_address =
+            variable_debt_token_factory::get_underlying_asset_address(
+                variable_debt_token_address
+            );
+
+        wad_ray_math::ray_mul(
+            current_supply_scaled,
+            get_reserve_normalized_variable_debt(underlying_token_address)
+        )
+    }
+
+    #[view]
+    /// @notice Computes the balance of variable debt tokens for a specific owner, adjusted by the reserve's normalized variable debt.
+    /// @dev Retrieves the scaled balance of variable debt tokens for the specified owner and variable debt token address.
+    /// @dev Converts the scaled balance into the underlying token denomination using the reserve's normalized variable debt.
+    /// @dev Returns 0 if the scaled balance is zero.
+    /// @param owner The address of the account whose variable debt token balance is being queried.
+    /// @param variable_debt_token_address The address of the variable debt token contract for which the balance is being queried.
+    /// @return The adjusted balance of the owner in variable debt tokens, considering the reserve's normalized variable debt.
+    public fun variable_debt_token_balance_of(
+        owner: address, variable_debt_token_address: address
+    ): u256 acquires ReserveList {
+        let current_balance_scale =
+            variable_debt_token_factory::scaled_balance_of(
+                owner, variable_debt_token_address
+            );
+        if (current_balance_scale == 0) {
+            return 0
+        };
+        let underlying_token_address =
+            variable_debt_token_factory::get_underlying_asset_address(
+                variable_debt_token_address
+            );
+        wad_ray_math::ray_mul(
+            current_balance_scale,
+            get_reserve_normalized_variable_debt(underlying_token_address)
+        )
+    }
+
+    fun only_pool_admin(admin: address): bool {
+        acl_manage::is_pool_admin(admin)
+    }
+
+    #[test_only]
+    public fun set_reserve_current_liquidity_rate_for_testing(
+        asset: address, current_liquidity_rate: u128
+    ) acquires ReserveList {
+        let reserve_data = get_reserve_data(asset);
+        set_reserve_current_liquidity_rate(
+            asset, &mut reserve_data, current_liquidity_rate
+        )
+    }
+
+    #[test_only]
+    public fun set_reserve_current_variable_borrow_rate_for_testing(
+        asset: address, current_variable_borrow_rate: u128
+    ) acquires ReserveList {
+        let reserve_data = get_reserve_data(asset);
+        set_reserve_current_variable_borrow_rate(
+            asset, &mut reserve_data, current_variable_borrow_rate
+        );
+    }
+
+    #[test_only]
+    public fun set_reserve_liquidity_index_for_testing(
+        asset: address, liquidity_index: u128
+    ) acquires ReserveList {
+        let reserve_data = get_reserve_data(asset);
+        set_reserve_liquidity_index(asset, &mut reserve_data, liquidity_index)
+    }
+
+    #[test_only]
+    public fun set_reserve_variable_borrow_index_for_testing(
+        asset: address, variable_borrow_index: u128
+    ) acquires ReserveList {
+        let reserve_data = get_reserve_data(asset);
+        set_reserve_variable_borrow_index(
+            asset, &mut reserve_data, variable_borrow_index
+        )
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-pool/pool_configurator.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-pool/pool_configurator.move
@@ -1,0 +1,981 @@
+module aave_pool::pool_configurator {
+    use std::signer;
+    use std::string::String;
+    use std::vector;
+    use aptos_framework::event;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_config::reserve_config;
+    use aave_math::math_utils;
+
+    use aave_pool::emode_logic;
+    use aave_pool::pool;
+
+    const CONFIGURATOR_REVISION: u256 = 0x1;
+
+    #[event]
+    /// @dev Emitted when borrowing is enabled or disabled on a reserve.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param enabled True if borrowing is enabled, false otherwise
+    struct ReserveBorrowing has store, drop {
+        asset: address,
+        enabled: bool
+    }
+
+    #[event]
+    /// @dev Emitted when flashloans are enabled or disabled on a reserve.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param enabled True if flashloans are enabled, false otherwise
+    struct ReserveFlashLoaning has store, drop {
+        asset: address,
+        enabled: bool
+    }
+
+    #[event]
+    /// @dev Emitted when the collateralization risk parameters for the specified asset are updated.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param ltv The loan to value of the asset when used as collateral
+    /// @param liquidation_threshold The threshold at which loans using this asset as collateral will be considered undercollateralized
+    /// @param liquidation_bonus The bonus liquidators receive to liquidate this asset
+    struct CollateralConfigurationChanged has store, drop {
+        asset: address,
+        ltv: u256,
+        liquidation_threshold: u256,
+        liquidation_bonus: u256
+    }
+
+    #[event]
+    /// @dev Emitted when a reserve is activated or deactivated
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param active True if reserve is active, false otherwise
+    struct ReserveActive has store, drop {
+        asset: address,
+        active: bool
+    }
+
+    #[event]
+    /// @dev Emitted when a reserve is frozen or unfrozen
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param frozen True if reserve is frozen, false otherwise
+    struct ReserveFrozen has store, drop {
+        asset: address,
+        frozen: bool
+    }
+
+    #[event]
+    /// @dev Emitted when a reserve is paused or unpaused
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param paused True if reserve is paused, false otherwise
+    struct ReservePaused has store, drop {
+        asset: address,
+        paused: bool
+    }
+
+    #[event]
+    /// @dev Emitted when a reserve is dropped.
+    /// @param asset The address of the underlying asset of the reserve
+    struct ReserveDropped has store, drop {
+        asset: address
+    }
+
+    #[event]
+    /// @dev Emitted when a reserve factor is updated.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_reserve_factor The old reserve factor, expressed in bps
+    /// @param new_reserve_factor The new reserve factor, expressed in bps
+    struct ReserveFactorChanged has store, drop {
+        asset: address,
+        old_reserve_factor: u256,
+        new_reserve_factor: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the borrow cap of a reserve is updated.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_borrow_cap The old borrow cap
+    /// @param new_borrow_cap The new borrow cap
+    struct BorrowCapChanged has store, drop {
+        asset: address,
+        old_borrow_cap: u256,
+        new_borrow_cap: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the supply cap of a reserve is updated.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_supply_cap The old supply cap
+    /// @param new_supply_cap The new supply cap
+    struct SupplyCapChanged has store, drop {
+        asset: address,
+        old_supply_cap: u256,
+        new_supply_cap: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the liquidation protocol fee of a reserve is updated.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_fee The old liquidation protocol fee, expressed in bps
+    /// @param new_fee The new liquidation protocol fee, expressed in bps
+    struct LiquidationProtocolFeeChanged has store, drop {
+        asset: address,
+        old_fee: u256,
+        new_fee: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the unbacked mint cap of a reserve is updated.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_unbacked_mint_cap The old unbacked mint cap
+    /// @param new_unbacked_mint_cap The new unbacked mint cap
+    struct UnbackedMintCapChanged has store, drop {
+        asset: address,
+        old_unbacked_mint_cap: u256,
+        new_unbacked_mint_cap: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the category of an asset in eMode is changed.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_category_id The old eMode asset category
+    /// @param new_category_id The new eMode asset category
+    struct EModeAssetCategoryChanged has store, drop {
+        asset: address,
+        old_category_id: u256,
+        new_category_id: u256
+    }
+
+    #[event]
+    /// @dev Emitted when a new eMode category is added.
+    /// @param category_id The new eMode category id
+    /// @param ltv The ltv for the asset category in eMode
+    /// @param liquidation_threshold The liquidationThreshold for the asset category in eMode
+    /// @param liquidation_bonus The liquidationBonus for the asset category in eMode
+    /// @param oracle The optional address of the price oracle specific for this category
+    /// @param label A human readable identifier for the category
+    struct EModeCategoryAdded has store, drop {
+        category_id: u8,
+        ltv: u16,
+        liquidation_threshold: u16,
+        liquidation_bonus: u16,
+        oracle: address,
+        label: String
+    }
+
+    #[event]
+    /// @dev Emitted when the debt ceiling of an asset is set.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_debt_ceiling The old debt ceiling
+    /// @param new_debt_ceiling The new debt ceiling
+    struct DebtCeilingChanged has store, drop {
+        asset: address,
+        old_debt_ceiling: u256,
+        new_debt_ceiling: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the the siloed borrowing state for an asset is changed.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param old_state The old siloed borrowing state
+    /// @param new_state The new siloed borrowing state
+    struct SiloedBorrowingChanged has store, drop {
+        asset: address,
+        old_state: bool,
+        new_state: bool
+    }
+
+    #[event]
+    /// @dev Emitted when the bridge protocol fee is updated.
+    /// @param old_bridge_protocol_fee The old protocol fee, expressed in bps
+    /// @param new_bridge_protocol_fee The new protocol fee, expressed in bps
+    struct BridgeProtocolFeeUpdated has store, drop {
+        old_bridge_protocol_fee: u256,
+        new_bridge_protocol_fee: u256
+    }
+
+    #[event]
+    /// @dev Emitted when the total premium on flashloans is updated.
+    /// @param old_flashloan_premium_total The old premium, expressed in bps
+    /// @param new_flashloan_premium_total The new premium, expressed in bps
+    struct FlashloanPremiumTotalUpdated has store, drop {
+        old_flashloan_premium_total: u128,
+        new_flashloan_premium_total: u128
+    }
+
+    #[event]
+    /// @dev Emitted when the part of the premium that goes to protocol is updated.
+    /// @param old_flashloan_premium_to_protocol The old premium, expressed in bps
+    /// @param new_flashloan_premium_to_protocol The new premium, expressed in bps
+    struct FlashloanPremiumToProtocolUpdated has store, drop {
+        old_flashloan_premium_to_protocol: u128,
+        new_flashloan_premium_to_protocol: u128
+    }
+
+    #[event]
+    /// @dev Emitted when the reserve is set as borrowable/non borrowable in isolation mode.
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param borrowable True if the reserve is borrowable in isolation, false otherwise
+    struct BorrowableInIsolationChanged has store, drop {
+        asset: address,
+        borrowable: bool
+    }
+
+    #[view]
+    /// @notice Returns the revision of the configurator
+    public fun get_revision(): u256 {
+        CONFIGURATOR_REVISION
+    }
+
+    #[test_only]
+    public fun test_init_module(account: &signer) {
+        init_module(account)
+    }
+
+    /// @notice Initializes the pool configurator
+    /// @param account The account signer of the caller
+    fun init_module(account: &signer) {
+        assert!(
+            signer::address_of(account) == @aave_pool,
+            error_config::get_enot_pool_owner()
+        );
+
+        pool::init_pool(account);
+        emode_logic::init_emode(account);
+    }
+
+    /// @notice Initializes multiple reserves.
+    /// @param account The account signer of the caller
+    /// @param underlying_asset The list of the underlying assets of the reserves
+    /// @param treasury The list of the treasury addresses of the reserves
+    /// @param a_token_name The list of the aToken names of the reserves
+    /// @param a_token_symbol The list of the aToken symbols of the reserves
+    /// @param variable_debt_token_name The list of the variable debt token names of the reserves
+    /// @param variable_debt_token_symbol The list of the variable debt token symbols of the reserves
+    /// @dev The caller needs to be an asset listing or pool admin
+    public entry fun init_reserves(
+        account: &signer,
+        underlying_asset: vector<address>,
+        treasury: vector<address>,
+        a_token_name: vector<String>,
+        a_token_symbol: vector<String>,
+        variable_debt_token_name: vector<String>,
+        variable_debt_token_symbol: vector<String>
+    ) {
+        assert!(
+            only_asset_listing_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        );
+
+        for (i in 0..vector::length(&underlying_asset)) {
+            pool::init_reserve(
+                account,
+                *vector::borrow(&underlying_asset, i),
+                *vector::borrow(&treasury, i),
+                *vector::borrow(&a_token_name, i),
+                *vector::borrow(&a_token_symbol, i),
+                *vector::borrow(&variable_debt_token_name, i),
+                *vector::borrow(&variable_debt_token_symbol, i)
+            );
+        };
+    }
+
+    /// @notice Drops a reserve entirely.
+    /// @dev Emits the `ReserveDropped` event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the reserve to drop
+    public entry fun drop_reserve(account: &signer, asset: address) {
+        assert!(
+            only_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_admin()
+        );
+        // Call the `drop_reserve` function in the `pool` module
+        pool::drop_reserve(asset);
+
+        event::emit(ReserveDropped { asset });
+    }
+
+    /// @notice Configures borrowing on a reserve.
+    /// @dev Emits the ReserveBorrowing event
+    /// @dev Can only be disabled (set to false)
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param enabled True if borrowing needs to be enabled, false otherwise
+    public entry fun set_reserve_borrowing(
+        account: &signer, asset: address, enabled: bool
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        reserve_config::set_borrowing_enabled(&mut reserve_config_map, enabled);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(ReserveBorrowing { asset, enabled })
+    }
+
+    /// @notice Configures the reserve collateralization parameters.
+    /// @dev Emits the CollateralConfigurationChanged event
+    /// @dev All the values are expressed in bps. A value of 10000, results in 100.00%
+    /// @dev The `liquidation_bonus` is always above 100%. A value of 105% means the liquidator will receive a 5% bonus
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param ltv The loan to value of the asset when used as collateral
+    /// @param liquidation_threshold The threshold at which loans using this asset as collateral will be considered undercollateralized
+    /// @param liquidation_bonus The bonus liquidators receive to liquidate this asset
+    public entry fun configure_reserve_as_collateral(
+        account: &signer,
+        asset: address,
+        ltv: u256,
+        liquidation_threshold: u256,
+        liquidation_bonus: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+        // validation of the parameters: the LTV can
+        // only be lower or equal than the liquidation threshold
+        // (otherwise a loan against the asset would cause instantaneous liquidation)
+        assert!(
+            ltv <= liquidation_threshold, error_config::get_einvalid_reserve_params()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+
+        if (liquidation_threshold != 0) {
+            //liquidation bonus must be bigger than 100.00%, otherwise the liquidator would receive less
+            //collateral than needed to cover the debt
+            assert!(
+                liquidation_bonus > math_utils::get_percentage_factor(),
+                error_config::get_einvalid_reserve_params()
+            );
+
+            //if threshold * bonus is less than PERCENTAGE_FACTOR, it's guaranteed that at the moment
+            //a loan is taken there is enough collateral available to cover the liquidation bonus
+            assert!(
+                math_utils::percent_mul(liquidation_threshold, liquidation_bonus)
+                    <= math_utils::get_percentage_factor(),
+                error_config::get_einvalid_reserve_params()
+            );
+        } else {
+            assert!(liquidation_bonus == 0, error_config::get_einvalid_reserve_params());
+            //if the liquidation threshold is being set to 0,
+            // the reserve is being disabled as collateral. To do so,
+            //we need to ensure no liquidity is supplied
+            check_no_suppliers(asset);
+        };
+
+        reserve_config::set_ltv(&mut reserve_config_map, ltv);
+        reserve_config::set_liquidation_threshold(
+            &mut reserve_config_map, liquidation_threshold
+        );
+        reserve_config::set_liquidation_bonus(&mut reserve_config_map, liquidation_bonus);
+
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(
+            CollateralConfigurationChanged {
+                asset,
+                ltv,
+                liquidation_threshold,
+                liquidation_bonus
+            }
+        )
+    }
+
+    /// @notice Enable or disable flashloans on a reserve
+    /// @dev Emits the ReserveFlashLoaning event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param enabled True if flashloans need to be enabled, false otherwise
+    public entry fun set_reserve_flash_loaning(
+        account: &signer, asset: address, enabled: bool
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+
+        reserve_config::set_flash_loan_enabled(&mut reserve_config_map, enabled);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(ReserveFlashLoaning { asset, enabled })
+    }
+
+    /// @notice Activate or deactivate a reserve
+    /// @dev Emits the ReserveActive event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param active True if the reserve needs to be active, false otherwise
+    public entry fun set_reserve_active(
+        account: &signer, asset: address, active: bool
+    ) {
+        assert!(
+            only_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_admin()
+        );
+
+        if (!active) {
+            check_no_suppliers(asset);
+        };
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+
+        reserve_config::set_active(&mut reserve_config_map, active);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(ReserveActive { asset, active })
+    }
+
+    /// @notice Freeze or unfreeze a reserve. A frozen reserve doesn't allow any new supply, borrow
+    /// or rate swap but allows repayments, liquidations, rate rebalances and withdrawals.
+    /// @dev Emits the ReserveFrozen event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param freeze True if the reserve needs to be frozen, false otherwise
+    public entry fun set_reserve_freeze(
+        account: &signer, asset: address, freeze: bool
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+
+        reserve_config::set_frozen(&mut reserve_config_map, freeze);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(ReserveFrozen { asset, frozen: freeze })
+    }
+
+    /// @notice Sets the borrowable in isolation flag for the reserve.
+    /// @dev When this flag is set to true, the asset will be borrowable against isolated collaterals and the
+    /// borrowed amount will be accumulated in the isolated collateral's total debt exposure
+    /// @dev Only assets of the same family (e.g. USD stablecoins) should be borrowable in isolation mode to keep
+    /// consistency in the debt ceiling calculations
+    /// @dev Emits the BorrowableInIsolationChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param borrowable True if the asset should be borrowable in isolation, false otherwise
+    public entry fun set_borrowable_in_isolation(
+        account: &signer, asset: address, borrowable: bool
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+
+        reserve_config::set_borrowable_in_isolation(&mut reserve_config_map, borrowable);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(BorrowableInIsolationChanged { asset, borrowable })
+    }
+
+    /// @notice Pauses a reserve. A paused reserve does not allow any interaction (supply, borrow, repay,
+    /// swap interest rate, liquidate, atoken transfers).
+    /// @dev Emits the ReservePaused event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param paused True if pausing the reserve, false if unpausing
+    public entry fun set_reserve_pause(
+        account: &signer, asset: address, paused: bool
+    ) {
+        assert!(
+            only_pool_or_emergency_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_or_emergency_admin()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+
+        reserve_config::set_paused(&mut reserve_config_map, paused);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(ReservePaused { asset, paused })
+    }
+
+    /// @notice Updates the reserve factor of a reserve.
+    /// @dev Emits the ReserveFactorChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_reserve_factor The new reserve factor of the reserve
+    public entry fun set_reserve_factor(
+        account: &signer, asset: address, new_reserve_factor: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        assert!(
+            new_reserve_factor <= math_utils::get_percentage_factor(),
+            error_config::get_einvalid_reserve_factor()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_reserve_factor: u256 =
+            reserve_config::get_reserve_factor(&reserve_config_map);
+
+        reserve_config::set_reserve_factor(&mut reserve_config_map, new_reserve_factor);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(ReserveFactorChanged { asset, old_reserve_factor, new_reserve_factor })
+    }
+
+    /// @notice Sets the debt ceiling for an asset.
+    /// @dev Emits the DebtCeilingChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_debt_ceiling The new debt ceiling
+    public entry fun set_debt_ceiling(
+        account: &signer, asset: address, new_debt_ceiling: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_debt_ceiling: u256 =
+            reserve_config::get_debt_ceiling(&reserve_config_map);
+
+        if (old_debt_ceiling == 0) {
+            check_no_suppliers(asset);
+        };
+
+        reserve_config::set_debt_ceiling(&mut reserve_config_map, new_debt_ceiling);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        if (new_debt_ceiling == 0) {
+            pool::reset_isolation_mode_total_debt(asset)
+        };
+
+        event::emit(DebtCeilingChanged { asset, old_debt_ceiling, new_debt_ceiling })
+    }
+
+    /// @notice Sets siloed borrowing for an asset
+    /// @dev Emits the SiloedBorrowingChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_siloed The new siloed borrowing state
+    public entry fun set_siloed_borrowing(
+        account: &signer, asset: address, new_siloed: bool
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        if (new_siloed) {
+            check_no_borrowers(asset);
+        };
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_siloed: bool = reserve_config::get_siloed_borrowing(&reserve_config_map);
+        reserve_config::set_siloed_borrowing(&mut reserve_config_map, new_siloed);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(
+            SiloedBorrowingChanged { asset, old_state: old_siloed, new_state: new_siloed }
+        )
+    }
+
+    /// @notice Updates the borrow cap of a reserve.
+    /// @dev Emits the BorrowCapChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_borrow_cap The new borrow cap of the reserve
+    public entry fun set_borrow_cap(
+        account: &signer, asset: address, new_borrow_cap: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_borrow_cap: u256 = reserve_config::get_borrow_cap(&reserve_config_map);
+
+        reserve_config::set_borrow_cap(&mut reserve_config_map, new_borrow_cap);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(BorrowCapChanged { asset, old_borrow_cap, new_borrow_cap })
+    }
+
+    /// @notice Updates the supply cap of a reserve.
+    /// @dev Emits the SupplyCapChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_supply_cap The new supply cap of the reserve
+    public entry fun set_supply_cap(
+        account: &signer, asset: address, new_supply_cap: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_supply_cap: u256 = reserve_config::get_supply_cap(&reserve_config_map);
+
+        reserve_config::set_supply_cap(&mut reserve_config_map, new_supply_cap);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(SupplyCapChanged { asset, old_supply_cap, new_supply_cap })
+    }
+
+    /// @notice Updates the liquidation protocol fee of reserve.
+    /// @dev Emits the LiquidationProtocolFeeChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_fee The new liquidation protocol fee of the reserve, expressed in bps
+    public entry fun set_liquidation_protocol_fee(
+        account: &signer, asset: address, new_fee: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        assert!(
+            new_fee <= math_utils::get_percentage_factor(),
+            error_config::get_einvalid_liquidation_protocol_fee()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_fee = reserve_config::get_liquidation_protocol_fee(&reserve_config_map);
+
+        reserve_config::set_liquidation_protocol_fee(&mut reserve_config_map, new_fee);
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(LiquidationProtocolFeeChanged { asset, old_fee, new_fee })
+    }
+
+    /// @notice Adds a new efficiency mode (eMode) category.
+    /// @dev If zero is provided as oracle address, the default asset oracles will be used to compute the overall debt and
+    /// overcollateralization of the users using this category.
+    /// @dev The new ltv and liquidation threshold must be greater than the base
+    /// ltvs and liquidation thresholds of all assets within the eMode category
+    /// @dev Emits the EModeCategoryAdded event
+    /// @param account The account signer of the caller
+    /// @param category_id The id of the category to be configured
+    /// @param ltv The ltv associated with the category
+    /// @param liquidation_threshold The liquidation threshold associated with the category
+    /// @param liquidation_bonus The liquidation bonus associated with the category
+    /// @param oracle The oracle associated with the category
+    /// @param label A label identifying the category
+    public entry fun set_emode_category(
+        account: &signer,
+        category_id: u8,
+        ltv: u16,
+        liquidation_threshold: u16,
+        liquidation_bonus: u16,
+        oracle: address,
+        label: String
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        assert!(ltv != 0, error_config::get_einvalid_emode_category_params());
+
+        assert!(
+            liquidation_threshold != 0,
+            error_config::get_einvalid_emode_category_params()
+        );
+
+        // validation of the parameters: the LTV can
+        // only be lower or equal than the liquidation threshold
+        // (otherwise a loan against the asset would cause instantaneous liquidation)
+        assert!(
+            ltv <= liquidation_threshold,
+            error_config::get_einvalid_emode_category_params()
+        );
+
+        assert!(
+            liquidation_bonus > (math_utils::get_percentage_factor() as u16),
+            error_config::get_einvalid_emode_category_params()
+        );
+
+        // if threshold * bonus is less than PERCENTAGE_FACTOR, it's guaranteed that at the moment
+        // a loan is taken there is enough collateral available to cover the liquidation bonus
+        assert!(
+            math_utils::percent_mul(
+                (liquidation_threshold as u256),
+                (liquidation_bonus as u256)
+            ) <= math_utils::get_percentage_factor(),
+            error_config::get_einvalid_emode_category_params()
+        );
+
+        let reserves = pool::get_reserves_list();
+        for (i in 0..vector::length(&reserves)) {
+            let reserve_config_map =
+                pool::get_reserve_configuration(*vector::borrow(&reserves, i));
+            if ((category_id as u256)
+                == reserve_config::get_emode_category(&reserve_config_map)) {
+                assert!(
+                    (ltv as u256) > reserve_config::get_ltv(&reserve_config_map),
+                    error_config::get_einvalid_emode_category_params()
+                );
+                assert!(
+                    (liquidation_threshold as u256)
+                        > reserve_config::get_liquidation_threshold(&reserve_config_map),
+                    error_config::get_einvalid_emode_category_params()
+                );
+            };
+        };
+
+        emode_logic::configure_emode_category(
+            category_id,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            oracle,
+            label
+        );
+
+        event::emit(
+            EModeCategoryAdded {
+                category_id,
+                ltv,
+                liquidation_threshold,
+                liquidation_bonus,
+                oracle,
+                label
+            }
+        )
+    }
+
+    /// @notice Assign an efficiency mode (eMode) category to asset.
+    /// @dev Emits the EModeAssetCategoryChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_category_id The new category id of the asset
+    public entry fun set_asset_emode_category(
+        account: &signer, asset: address, new_category_id: u8
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        if (new_category_id != 0) {
+            let emode_category = emode_logic::get_emode_category_data(new_category_id);
+            let liquidation_threshold =
+                emode_logic::get_emode_category_liquidation_threshold(&emode_category);
+
+            assert!(
+                liquidation_threshold
+                    > (
+                        reserve_config::get_liquidation_threshold(&reserve_config_map) as u16
+                    ),
+                error_config::get_einvalid_emode_category_assignment()
+            );
+        };
+
+        let old_category_id = reserve_config::get_emode_category(&reserve_config_map);
+        reserve_config::set_emode_category(
+            &mut reserve_config_map, (new_category_id as u256)
+        );
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(
+            EModeAssetCategoryChanged {
+                asset,
+                old_category_id,
+                new_category_id: (new_category_id as u256)
+            }
+        )
+    }
+
+    /// @notice Updates the unbacked mint cap of reserve.
+    /// @dev Emits the UnbackedMintCapChanged event
+    /// @param account The account signer of the caller
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param new_unbacked_mint_cap The new unbacked mint cap of the reserve
+    public entry fun set_unbacked_mint_cap(
+        account: &signer, asset: address, new_unbacked_mint_cap: u256
+    ) {
+        assert!(
+            only_risk_or_pool_admins(signer::address_of(account)),
+            error_config::get_ecaller_not_risk_or_pool_admin()
+        );
+
+        let reserve_config_map = pool::get_reserve_configuration(asset);
+        let old_unbacked_mint_cap: u256 =
+            reserve_config::get_unbacked_mint_cap(&reserve_config_map);
+
+        reserve_config::set_unbacked_mint_cap(
+            &mut reserve_config_map, new_unbacked_mint_cap
+        );
+        pool::set_reserve_configuration(asset, reserve_config_map);
+
+        event::emit(
+            UnbackedMintCapChanged { asset, old_unbacked_mint_cap, new_unbacked_mint_cap }
+        )
+    }
+
+    /// @notice Pauses or unpauses all the protocol reserves. In the paused state all the protocol interactions
+    /// are suspended.
+    /// @dev Emits the ReservePaused event for each reserve
+    /// @param account The account signer of the caller
+    /// @param paused True if protocol needs to be paused, false otherwise
+    public entry fun set_pool_pause(account: &signer, paused: bool) {
+        assert!(
+            only_emergency_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_emergency_admin()
+        );
+
+        let reserves_address = pool::get_reserves_list();
+        for (i in 0..vector::length(&reserves_address)) {
+            set_reserve_pause(
+                account,
+                *vector::borrow(&reserves_address, i),
+                paused
+            );
+        };
+    }
+
+    /// @notice Updates the protocol fee on the bridging
+    /// @dev Emits the BridgeProtocolFeeUpdated event
+    /// @param account The account signer of the caller
+    /// @param new_bridge_protocol_fee The part of the premium sent to the protocol treasury
+    public entry fun update_bridge_protocol_fee(
+        account: &signer, new_bridge_protocol_fee: u256
+    ) {
+        assert!(
+            only_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_admin()
+        );
+
+        assert!(
+            new_bridge_protocol_fee <= math_utils::get_percentage_factor(),
+            error_config::get_ebridge_protocol_fee_invalid()
+        );
+
+        let old_bridge_protocol_fee = pool::get_bridge_protocol_fee();
+        pool::set_bridge_protocol_fee(new_bridge_protocol_fee);
+
+        event::emit(
+            BridgeProtocolFeeUpdated { old_bridge_protocol_fee, new_bridge_protocol_fee }
+        );
+    }
+
+    /// @notice Updates the total flash loan premium.
+    /// Total flash loan premium consists of two parts:
+    /// - A part is sent to aToken holders as extra balance
+    /// - A part is collected by the protocol reserves
+    /// @dev Expressed in bps
+    /// @dev The premium is calculated on the total amount borrowed
+    /// @dev Emits the FlashloanPremiumTotalUpdated event
+    /// @param account The account signer of the caller
+    /// @param new_flashloan_premium_total The total flashloan premium
+    public entry fun update_flashloan_premium_total(
+        account: &signer, new_flashloan_premium_total: u128
+    ) {
+        assert!(
+            only_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_admin()
+        );
+
+        assert!(
+            new_flashloan_premium_total
+                <= (math_utils::get_percentage_factor() as u128),
+            error_config::get_eflashloan_premium_invalid()
+        );
+
+        let old_flashloan_premium_total = pool::get_flashloan_premium_total();
+        pool::update_flashloan_premiums(
+            new_flashloan_premium_total,
+            pool::get_flashloan_premium_to_protocol()
+        );
+
+        event::emit(
+            FlashloanPremiumTotalUpdated {
+                old_flashloan_premium_total,
+                new_flashloan_premium_total
+            }
+        );
+    }
+
+    /// @notice Updates the flash loan premium collected by protocol reserves
+    /// @dev Expressed in bps
+    /// @dev The premium to protocol is calculated on the total flashloan premium
+    /// @dev Emits the FlashloanPremiumToProtocolUpdated event
+    /// @param account The account signer of the caller
+    /// @param new_flashloan_premium_to_protocol The part of the flashloan premium sent to the protocol treasury
+    public entry fun update_flashloan_premium_to_protocol(
+        account: &signer, new_flashloan_premium_to_protocol: u128
+    ) {
+        assert!(
+            only_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_admin()
+        );
+
+        assert!(
+            new_flashloan_premium_to_protocol
+                <= (math_utils::get_percentage_factor() as u128),
+            error_config::get_eflashloan_premium_invalid()
+        );
+
+        let old_flashloan_premium_to_protocol = pool::get_flashloan_premium_to_protocol();
+        pool::update_flashloan_premiums(
+            pool::get_flashloan_premium_total(),
+            new_flashloan_premium_to_protocol
+        );
+
+        event::emit(
+            FlashloanPremiumToProtocolUpdated {
+                old_flashloan_premium_to_protocol,
+                new_flashloan_premium_to_protocol
+            }
+        )
+    }
+
+    fun check_no_suppliers(asset: address) {
+        let reserve_data = pool::get_reserve_data(asset);
+        let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+        let reserve_accrued_to_treasury =
+            pool::get_reserve_accrued_to_treasury(&reserve_data);
+        let a_token_total_supply = pool::a_token_total_supply(a_token_address);
+
+        assert!(
+            a_token_total_supply == 0 && reserve_accrued_to_treasury == 0,
+            error_config::get_ereserve_liquidity_not_zero()
+        );
+    }
+
+    fun check_no_borrowers(asset: address) {
+        let reserve_data = pool::get_reserve_data(asset);
+        let variable_debt_token_address =
+            pool::get_reserve_variable_debt_token_address(&reserve_data);
+        let total_debt =
+            pool::variable_debt_token_total_supply(variable_debt_token_address);
+
+        assert!(total_debt == 0, error_config::get_ereserve_debt_not_zero())
+    }
+
+    fun only_pool_admin(account: address): bool {
+        acl_manage::is_pool_admin(account)
+    }
+
+    fun only_emergency_admin(account: address): bool {
+        acl_manage::is_emergency_admin(account)
+    }
+
+    fun only_pool_or_emergency_admin(account: address): bool {
+        acl_manage::is_pool_admin(account) || acl_manage::is_emergency_admin(account)
+    }
+
+    fun only_asset_listing_or_pool_admins(account: address): bool {
+        acl_manage::is_asset_listing_admin(account)
+            || acl_manage::is_pool_admin(account)
+    }
+
+    fun only_risk_or_pool_admins(account: address): bool {
+        acl_manage::is_risk_admin(account) || acl_manage::is_pool_admin(account)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-pool/pool_data_provider.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-pool/pool_data_provider.move
@@ -1,0 +1,334 @@
+module aave_pool::pool_data_provider {
+    use std::string::String;
+    use std::vector;
+
+    use aave_config::reserve_config;
+    use aave_config::user_config;
+
+    use aave_pool::a_token_factory;
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::pool;
+    use aave_pool::variable_debt_token_factory;
+
+    struct TokenData has drop {
+        symbol: String,
+        token_address: address
+    }
+
+    #[test_only]
+    public fun get_reserve_token_symbol(token_data: &TokenData): String {
+        token_data.symbol
+    }
+
+    #[test_only]
+    public fun get_reserve_token_address(token_data: &TokenData): address {
+        token_data.token_address
+    }
+
+    #[view]
+    /// @notice Returns the list of the existing reserves in the pool.
+    /// @return The list of reserves, pairs of symbols and addresses
+    public fun get_all_reserves_tokens(): vector<TokenData> {
+        let reserves = pool::get_reserves_list();
+        let reserves_tokens = vector::empty<TokenData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let reserve_address = *vector::borrow(&reserves, i);
+
+            vector::push_back<TokenData>(
+                &mut reserves_tokens,
+                TokenData {
+                    symbol: fungible_asset_manager::symbol(reserve_address),
+                    token_address: reserve_address
+                }
+            );
+        };
+
+        reserves_tokens
+    }
+
+    #[view]
+    /// @notice Returns the list of the existing ATokens in the pool.
+    /// @return The list of ATokens, pairs of symbols and addresses
+    public fun get_all_a_tokens(): vector<TokenData> {
+        let reserves = pool::get_reserves_list();
+        let a_tokens = vector::empty<TokenData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let reserve_address = *vector::borrow(&reserves, i);
+            let reserve_data = pool::get_reserve_data(reserve_address);
+            let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+
+            vector::push_back<TokenData>(
+                &mut a_tokens,
+                TokenData {
+                    symbol: a_token_factory::symbol(a_token_address),
+                    token_address: a_token_address
+                }
+            );
+        };
+
+        a_tokens
+    }
+
+    #[view]
+    /// @notice Returns the list of the existing variable debt Tokens in the pool.
+    /// @return The list of variableDebtTokens, pairs of symbols and addresses
+    public fun get_all_var_tokens(): vector<TokenData> {
+        let reserves = pool::get_reserves_list();
+        let var_tokens = vector::empty<TokenData>();
+
+        for (i in 0..vector::length(&reserves)) {
+            let reserve_address = *vector::borrow(&reserves, i);
+            let reserve_data = pool::get_reserve_data(reserve_address);
+            let var_token_address =
+                pool::get_reserve_variable_debt_token_address(&reserve_data);
+
+            vector::push_back<TokenData>(
+                &mut var_tokens,
+                TokenData {
+                    symbol: variable_debt_token_factory::symbol(var_token_address),
+                    token_address: var_token_address
+                }
+            );
+        };
+
+        var_tokens
+    }
+
+    #[view]
+    /// @notice Returns the configuration data of the reserve
+    /// @dev Not returning borrow and supply caps for compatibility, nor pause flag
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return decimals The number of decimals of the reserve
+    /// @return ltv The ltv of the reserve
+    /// @return liquidation_threshold The liquidationThreshold of the reserve
+    /// @return liquidation_bonus The liquidationBonus of the reserve
+    /// @return reserve_factor The reserveFactor of the reserve
+    /// @return usage_as_collateral_enabled True if the usage as collateral is enabled, false otherwise
+    /// @return borrowing_enabled True if borrowing is enabled, false otherwise
+    /// @return is_active True if it is active, false otherwise
+    /// @return is_frozen True if it is frozen, false otherwise
+    public fun get_reserve_configuration_data(
+        asset: address
+    ): (u256, u256, u256, u256, u256, bool, bool, bool, bool) {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+        let (ltv, liquidation_threshold, liquidation_bonus, decimals, reserve_factor, _) =
+            reserve_config::get_params(&reserve_configuration);
+
+        let (is_active, is_frozen, borrowing_enabled, _) =
+            reserve_config::get_flags(&reserve_configuration);
+
+        let usage_as_collateral_enabled = liquidation_threshold != 0;
+
+        (
+            decimals,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            reserve_factor,
+            usage_as_collateral_enabled,
+            borrowing_enabled,
+            is_active,
+            is_frozen
+        )
+    }
+
+    #[view]
+    /// @notice Returns the efficiency mode category of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The eMode id of the reserve
+    public fun get_reserve_emode_category(asset: address): u256 {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_emode_category(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns the caps parameters of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return borrow_cap The borrow cap of the reserve
+    /// @return supply_cap The supply cap of the reserve
+    public fun get_reserve_caps(asset: address): (u256, u256) {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+        reserve_config::get_caps(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns if the pool is paused
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return isPaused True if the pool is paused, false otherwise
+    public fun get_paused(asset: address): bool {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_paused(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns the siloed borrowing flag
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return True if the asset is siloed for borrowing
+    public fun get_siloed_borrowing(asset: address): bool {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_siloed_borrowing(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns the protocol fee on the liquidation bonus
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The protocol fee on liquidation
+    public fun get_liquidation_protocol_fee(asset: address): u256 {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_liquidation_protocol_fee(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns the unbacked mint cap of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The unbacked mint cap of the reserve
+    public fun get_unbacked_mint_cap(asset: address): u256 {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_unbacked_mint_cap(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns the debt ceiling of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The debt ceiling of the reserve
+    public fun get_debt_ceiling(asset: address): u256 {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_debt_ceiling(&reserve_configuration)
+    }
+
+    #[view]
+    /// @notice Returns the debt ceiling decimals
+    /// @return The debt ceiling decimals
+    public fun get_debt_ceiling_decimals(): u256 {
+        reserve_config::get_debt_ceiling_decimals()
+    }
+
+    #[view]
+    /// @notice Returns the reserve data
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return unbacked The amount of unbacked tokens
+    /// @return accrued_to_treasury_scaled The scaled amount of tokens accrued to treasury that is to be minted
+    /// @return total_a_token The total supply of the aToken
+    /// @return total_variable_debt The total variable debt of the reserve
+    /// @return liquidity_rate The liquidity rate of the reserve
+    /// @return variable_borrow_rate The variable borrow rate of the reserve
+    /// @return liquidity_index The liquidity index of the reserve
+    /// @return variable_borrow_index The variable borrow index of the reserve
+    /// @return last_update_timestamp The timestamp of the last update of the reserve
+    public fun get_reserve_data(asset: address):
+        (
+        u256, u256, u256, u256, u256, u256, u256, u256, u64
+    ) {
+        let reserve_data = pool::get_reserve_data(asset);
+        let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+        let variable_token_address =
+            pool::get_reserve_variable_debt_token_address(&reserve_data);
+
+        (
+            (pool::get_reserve_unbacked(&reserve_data) as u256),
+            pool::get_reserve_accrued_to_treasury(&reserve_data),
+            pool::a_token_total_supply(a_token_address),
+            pool::variable_debt_token_total_supply(variable_token_address),
+            (pool::get_reserve_current_liquidity_rate(&reserve_data) as u256),
+            (pool::get_reserve_current_variable_borrow_rate(&reserve_data) as u256),
+            (pool::get_reserve_liquidity_index(&reserve_data) as u256),
+            (pool::get_reserve_variable_borrow_index(&reserve_data) as u256),
+            pool::get_reserve_last_update_timestamp(&reserve_data)
+        )
+    }
+
+    #[view]
+    /// @notice Returns the total supply of aTokens for a given asset
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The total supply of the aToken
+    public fun get_a_token_total_supply(asset: address): u256 {
+        let reserve_data = pool::get_reserve_data(asset);
+        let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+
+        pool::a_token_total_supply(a_token_address)
+    }
+
+    #[view]
+    /// @notice Returns the total debt for a given asset
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return The total debt for asset
+    public fun get_total_debt(asset: address): u256 {
+        let reserve_data = pool::get_reserve_data(asset);
+        let variable_token_address =
+            pool::get_reserve_variable_debt_token_address(&reserve_data);
+
+        pool::variable_debt_token_total_supply(variable_token_address)
+    }
+
+    #[view]
+    /// @notice Returns the user data in a reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @param user The address of the user
+    /// @return current_a_token_balance The current AToken balance of the user
+    /// @return current_variable_debt The current variable debt of the user
+    /// @return scaled_variable_debt The scaled variable debt of the user
+    /// @return liquidity_rate The liquidity rate of the reserve
+    /// @return usage_as_collateral_enabled True if the user is using the asset as collateral, false otherwise
+    public fun get_user_reserve_data(asset: address, user: address):
+        (u256, u256, u256, u256, bool) {
+        let reserve_data = pool::get_reserve_data(asset);
+        let a_token_address = pool::get_reserve_a_token_address(&reserve_data);
+        let variable_token_address =
+            pool::get_reserve_variable_debt_token_address(&reserve_data);
+
+        let current_a_token_balance = pool::a_token_balance_of(user, a_token_address);
+        let current_variable_debt =
+            pool::variable_debt_token_balance_of(user, variable_token_address);
+        let scaled_variable_debt =
+            variable_debt_token_factory::scaled_balance_of(user, variable_token_address);
+        let liquidity_rate =
+            (pool::get_reserve_current_liquidity_rate(&reserve_data) as u256);
+
+        let user_configuration = pool::get_user_configuration(user);
+        let usage_as_collateral_enabled =
+            user_config::is_using_as_collateral(
+                &user_configuration,
+                (pool::get_reserve_id(&reserve_data) as u256)
+            );
+
+        (
+            current_a_token_balance,
+            current_variable_debt,
+            scaled_variable_debt,
+            liquidity_rate,
+            usage_as_collateral_enabled
+        )
+    }
+
+    #[view]
+    /// @notice Returns the token addresses of the reserve
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return a_token_address The AToken address of the reserve
+    /// @return variable_debt_token_address The VariableDebtToken address of the reserve
+    public fun get_reserve_tokens_addresses(asset: address): (address, address) {
+        let reserve_data = pool::get_reserve_data(asset);
+
+        (
+            pool::get_reserve_a_token_address(&reserve_data),
+            pool::get_reserve_variable_debt_token_address(&reserve_data)
+        )
+    }
+
+    #[view]
+    /// @notice Returns whether the reserve has FlashLoans enabled or disabled
+    /// @param asset The address of the underlying asset of the reserve
+    /// @return True if FlashLoans are enabled, false otherwise
+    public fun get_flash_loan_enabled(asset: address): bool {
+        let reserve_configuration = pool::get_reserve_configuration(asset);
+
+        reserve_config::get_flash_loan_enabled(&reserve_configuration)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-tokens/a_token_factory.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-tokens/a_token_factory.move
@@ -1,0 +1,544 @@
+module aave_pool::a_token_factory {
+    use std::option;
+    use std::signer;
+    use std::string::{Self, String};
+    use aptos_std::smart_table;
+    use aptos_std::smart_table::SmartTable;
+    use aptos_std::string_utils::format2;
+    use aptos_framework::account;
+    use aptos_framework::account::SignerCapability;
+    use aptos_framework::event::Self;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::{Self, Object};
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_math::wad_ray_math;
+
+    use aave_pool::fungible_asset_manager;
+    use aave_pool::token_base;
+
+    friend aave_pool::pool;
+    friend aave_pool::flashloan_logic;
+    friend aave_pool::supply_logic;
+    friend aave_pool::borrow_logic;
+    friend aave_pool::bridge_logic;
+    friend aave_pool::liquidation_logic;
+
+    #[test_only]
+    friend aave_pool::a_token_factory_tests;
+    #[test_only]
+    friend aave_pool::pool_configurator_tests;
+    #[test_only]
+    friend aave_pool::ui_incentive_data_provider_v3;
+    #[test_only]
+    friend aave_pool::ui_pool_data_provider_v3;
+    // #[test_only]
+    // friend aave_pool::emission_manager_tests;
+    // #[test_only]
+    // friend aave_pool::rewards_controller_tests;
+
+    const ATOKEN_REVISION: u256 = 0x1;
+
+    #[event]
+    /// @dev Emitted when an aToken is initialized
+    /// @param underlying_asset The address of the underlying asset
+    /// @param treasury The address of the treasury
+    /// @param a_token_decimals The decimals of the underlying
+    /// @param a_token_name The name of the aToken
+    /// @param a_token_symbol The symbol of the aToken
+    struct Initialized has store, drop {
+        underlying_asset: address,
+        treasury: address,
+        a_token_decimals: u8,
+        a_token_name: String,
+        a_token_symbol: String
+    }
+
+    #[event]
+    /// @dev Emitted during the transfer action
+    /// @param from The user whose tokens are being transferred
+    /// @param to The recipient
+    /// @param value The scaled amount being transferred
+    /// @param index The next liquidity index of the reserve
+    struct BalanceTransfer has store, drop {
+        from: address,
+        to: address,
+        value: u256,
+        index: u256
+    }
+
+    struct TokenData has store, drop {
+        underlying_asset: address,
+        treasury: address,
+        signer_cap: SignerCapability
+    }
+
+    // Atoken metadata_address => TokenData
+    struct TokenMap has key {
+        value: SmartTable<address, TokenData>,
+        count: u256
+    }
+
+    fun init_module(signer: &signer) {
+        token_base::only_token_admin(signer);
+        move_to(
+            signer,
+            TokenMap {
+                value: smart_table::new<address, TokenData>(),
+                count: 0
+            }
+        )
+    }
+
+    fun assert_token_exists(metadata_address: address) acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+        assert!(
+            smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_not_exist()
+        );
+    }
+
+    //
+    // Entry Functions
+    //
+    /// @notice Creates a new aToken
+    /// @dev Only callable by the pool module
+    /// @param signer The signer of the caller
+    /// @param name The name of the aToken
+    /// @param symbol The symbol of the aToken
+    /// @param decimals The decimals of the aToken
+    /// @param icon_uri The icon URI of the aToken
+    /// @param project_uri The project URI of the aToken
+    /// @param underlying_asset The address of the underlying asset
+    /// @param treasury The address of the treasury
+    /// @return The address of the aToken
+    public(friend) fun create_token(
+        signer: &signer,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String,
+        underlying_asset: address,
+        treasury: address
+    ): address acquires TokenMap {
+        only_asset_listing_or_pool_admins(signer);
+
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        validate_unique_token(token_map, name, symbol);
+
+        let token_count = token_map.count + 1;
+        let seed = *string::bytes(&format2(&b"{}_{}", symbol, token_count));
+        let user_signer_addr = signer::address_of(signer);
+        let metadata_address = object::create_object_address(&user_signer_addr, seed);
+
+        assert!(
+            !smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_already_exists()
+        );
+
+        let (_resource_signer, signer_cap) =
+            account::create_resource_account(signer, seed);
+
+        let token_data = TokenData { underlying_asset, treasury, signer_cap };
+        smart_table::add(&mut token_map.value, metadata_address, token_data);
+
+        let constructor_ref = &object::create_named_object(signer, seed);
+        token_base::create_token(
+            constructor_ref,
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            project_uri
+        );
+
+        token_map.count = token_count;
+
+        event::emit(
+            Initialized {
+                underlying_asset,
+                treasury,
+                a_token_decimals: decimals,
+                a_token_name: name,
+                a_token_symbol: symbol
+            }
+        );
+
+        metadata_address
+    }
+
+    /// @notice Rescue and transfer tokens locked in this contract
+    /// @param account The account signer of the caller
+    /// @param token The address of the underlying token
+    /// @param to The address of the recipient
+    /// @param amount The amount of token to transfer
+    /// @param meadata_address The address of the aToken
+    public entry fun rescue_tokens(
+        account: &signer,
+        token: address,
+        to: address,
+        amount: u256,
+        metadata_address: address
+    ) acquires TokenMap {
+        token_base::only_pool_admin(account);
+        assert_token_exists(metadata_address);
+
+        assert!(
+            token != get_underlying_asset_address(metadata_address),
+            error_config::get_eunderlying_cannot_be_rescued()
+        );
+
+        let a_token_resource_account = get_token_account_with_signer(metadata_address);
+        fungible_asset_manager::transfer(
+            &a_token_resource_account,
+            to,
+            (amount as u64),
+            token
+        );
+    }
+
+    //
+    //  Functions Call between contracts
+    //
+
+    /// @notice Mints `amount` aTokens to `on_behalf_of`
+    /// @dev Only callable by the bridge_logic and supply_logic module
+    /// @param caller The address performing the mint
+    /// @param on_behalf_of The address of the user that will receive the minted aTokens
+    /// @param amount The amount of tokens getting minted
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the aToken
+    public(friend) fun mint(
+        caller: address,
+        on_behalf_of: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+        token_base::mint_scaled(
+            caller,
+            on_behalf_of,
+            amount,
+            index,
+            metadata_address
+        );
+    }
+
+    /// @notice Burns aTokens from `from` and sends the equivalent amount of underlying to `receiver_of_underlying`
+    /// @dev Only callable by the supply_logic, borrow_logic and liquidation_logic module
+    /// @dev In some instances, the mint event could be emitted from a burn transaction
+    /// if the amount to burn is less than the interest that the user accrued
+    /// @param from The address from which the aTokens will be burned
+    /// @param receiver_of_underlying The address that will receive the underlying
+    /// @param amount The amount being burned
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the aToken
+    public(friend) fun burn(
+        from: address,
+        receiver_of_underlying: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+
+        token_base::burn_scaled(
+            from,
+            receiver_of_underlying,
+            amount,
+            index,
+            metadata_address
+        );
+
+        let a_token_resource_account = get_token_account_address(metadata_address);
+        if (receiver_of_underlying != a_token_resource_account) {
+            fungible_asset_manager::transfer(
+                &get_token_account_with_signer(metadata_address),
+                receiver_of_underlying,
+                (amount as u64),
+                get_underlying_asset_address(metadata_address)
+            )
+        }
+    }
+
+    /// @notice Mints aTokens to the reserve treasury
+    /// @dev Only callable by the pool module
+    /// @param amount The amount of tokens getting minted
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the aToken
+    public(friend) fun mint_to_treasury(
+        amount: u256, index: u256, metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+        if (amount != 0) {
+            let token_data = get_token_data(metadata_address);
+            token_base::mint_scaled(
+                @aave_pool,
+                token_data.treasury,
+                amount,
+                index,
+                metadata_address
+            )
+        }
+    }
+
+    /// @notice Transfers the underlying asset to `to`.
+    /// @dev Only callable by the borrow_logic and flashloan_logic module
+    /// @param to The recipient of the underlying
+    /// @param amount The amount getting transferred
+    /// @param metadata_address The address of the aToken
+    public(friend) fun transfer_underlying_to(
+        to: address, amount: u256, metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+        fungible_asset_manager::transfer(
+            &get_token_account_with_signer(metadata_address),
+            to,
+            (amount as u64),
+            get_underlying_asset_address(metadata_address)
+        )
+    }
+
+    /// @notice Transfers aTokens in the event of a borrow being liquidated, in case the liquidators reclaims the aToken
+    /// @dev Only callable by the liquidation_logic module
+    /// @param from The address getting liquidated, current owner of the aTokens
+    /// @param to The recipient
+    /// @param amount The amount of tokens getting transferred
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the aToken
+    public(friend) fun transfer_on_liquidation(
+        from: address,
+        to: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+        token_base::transfer(from, to, amount, index, metadata_address);
+        // send balance transfer event
+        event::emit(
+            BalanceTransfer { from, to, value: wad_ray_math::ray_div(amount, index), index }
+        );
+    }
+
+    /// @notice Handles the underlying received by the aToken after the transfer has been completed.
+    /// @dev The default implementation is empty, nothing needs to be done after the transfer is concluded.
+    /// However in the future there may be aTokens that allow for example to stake the underlying
+    /// to receive LM rewards. In that case, `handle_repayment()` would perform the staking of the underlying asset.
+    /// @param _user The user executing the repayment
+    /// @param _on_behalf_of The address of the user who will get his debt reduced/removed
+    /// @param _amount The amount getting repaid
+    /// @param _metadata_address The address of the aToken
+    public fun handle_repayment(
+        _user: address,
+        _on_behalf_of: address,
+        _amount: u256,
+        _metadata_address: address
+    ) {
+        // Intentionally left blank
+    }
+
+    //
+    //  View functions
+    //
+
+    inline fun get_token_data(metadata_address: address): &TokenData acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+        assert!(
+            smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_not_exist()
+        );
+
+        smart_table::borrow(&token_map.value, metadata_address)
+    }
+
+    #[view]
+    public fun get_revision(): u256 {
+        ATOKEN_REVISION
+    }
+
+    #[view]
+    /// @notice Retrieves the account address of the managed fungible asset associated with a specific aToken.
+    /// @dev Creates a signer capability for the resource account managing the fungible asset and then retrieves its address.
+    /// @param metadata_address The address of the aToken
+    /// @return The address of the managed fungible asset account.
+    public fun get_token_account_address(metadata_address: address): address acquires TokenMap {
+        let token_data = get_token_data(metadata_address);
+        let account_signer =
+            account::create_signer_with_capability(&token_data.signer_cap);
+        signer::address_of(&account_signer)
+    }
+
+    /// @notice Retrieves the signer of the managed fungible asset associated with a specific aToken.
+    /// @dev Creates a signer capability for the resource account that manages the fungible asset.
+    /// @param metadata_address The address of the aToken.
+    /// @return The signer of the managed fungible asset.
+    fun get_token_account_with_signer(metadata_address: address): signer acquires TokenMap {
+        let token_data = get_token_data(metadata_address);
+        account::create_signer_with_capability(&token_data.signer_cap)
+    }
+
+    #[view]
+    /// @notice Returns the address of the Aave treasury, receiving the fees on this aToken.
+    /// @param metadata_address The address of the aToken
+    /// @return Address of the Aave treasury
+    public fun get_reserve_treasury_address(metadata_address: address): address acquires TokenMap {
+        let token_data = get_token_data(metadata_address);
+        token_data.treasury
+    }
+
+    #[view]
+    /// @notice Returns the address of the underlying asset of this aToken (E.g. WETH for aWETH)
+    /// @param metadata_address The address of the aToken
+    /// @return The address of the underlying asset
+    public fun get_underlying_asset_address(metadata_address: address): address acquires TokenMap {
+        let token_data = get_token_data(metadata_address);
+        token_data.underlying_asset
+    }
+
+    #[view]
+    /// @notice Returns last index interest was accrued to the user's balance
+    /// @param user The address of the user
+    /// @param metadata_address The address of the aToken
+    /// @return The last index interest was accrued to the user's balance, expressed in ray
+    public fun get_previous_index(
+        user: address, metadata_address: address
+    ): u256 {
+        token_base::get_previous_index(user, metadata_address)
+    }
+
+    #[view]
+    /// @notice Returns the scaled balance of the user and the scaled total supply.
+    /// @param owner The address of the user
+    /// @param metadata_address The address of the aToken
+    /// @return The scaled balance of the user
+    /// @return The scaled total supply
+    public fun get_scaled_user_balance_and_supply(
+        owner: address, metadata_address: address
+    ): (u256, u256) {
+        token_base::get_scaled_user_balance_and_supply(owner, metadata_address)
+    }
+
+    #[view]
+    /// @notice Returns the scaled balance of the user.
+    /// @dev The scaled balance is the sum of all the updated stored balance divided by the reserve's liquidity index
+    /// at the moment of the update
+    /// @param owner The user whose balance is calculated
+    /// @param metadata_address The address of the aToken
+    /// @return The scaled balance of the user
+    public fun scaled_balance_of(
+        owner: address, metadata_address: address
+    ): u256 {
+        token_base::scaled_balance_of(owner, metadata_address)
+    }
+
+    #[view]
+    /// @notice Returns the scaled total supply of the scaled balance token. Represents sum(debt/index)
+    /// @param metadata_address The address of the aToken
+    /// @return The scaled total supply
+    public fun scaled_total_supply(metadata_address: address): u256 {
+        token_base::scaled_total_supply(metadata_address)
+    }
+
+    #[view]
+    public fun name(metadata_address: address): String {
+        token_base::name(metadata_address)
+    }
+
+    #[view]
+    public fun symbol(metadata_address: address): String {
+        token_base::symbol(metadata_address)
+    }
+
+    #[view]
+    public fun decimals(metadata_address: address): u8 {
+        token_base::decimals(metadata_address)
+    }
+
+    /// @notice Validates that the aToken name and symbol are unique
+    /// @param token_map The aToken map
+    /// @param name The name of the aToken
+    /// @param symbol The symbol of the aToken
+    fun validate_unique_token(
+        token_map: &TokenMap, name: String, symbol: String
+    ) {
+        smart_table::for_each_ref(
+            &token_map.value,
+            |metadata_address, _token_data| {
+                let asset_name = name(*metadata_address);
+                let asset_symbol = symbol(*metadata_address);
+                assert!(
+                    asset_name != name, error_config::get_etoken_name_already_exist()
+                );
+                assert!(
+                    asset_symbol != symbol,
+                    error_config::get_etoken_symbol_already_exist()
+                );
+            }
+        );
+    }
+
+    /// @notice Drops the a token associated data
+    /// @dev Only callable by the pool module
+    /// @param metadata_address The address of the metadata object
+    public(friend) fun drop_token(metadata_address: address) acquires TokenMap {
+        assert_token_exists(metadata_address);
+        // Remove metadata_address from token map
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        smart_table::remove(&mut token_map.value, metadata_address);
+
+        // Remove metadata_address from token_base module's token map
+        token_base::drop_token(metadata_address);
+    }
+
+    fun only_asset_listing_or_pool_admins(account: &signer) {
+        let account_address = signer::address_of(account);
+        assert!(
+            acl_manage::is_asset_listing_admin(account_address)
+                || acl_manage::is_pool_admin(account_address),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        )
+    }
+
+    #[view]
+    public fun token_address(owner: address, symbol: String): address acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+
+        let address_found = option::none<address>();
+        smart_table::for_each_ref(
+            &token_map.value,
+            |metadata_address, _token_data| {
+                let token_metadata =
+                    object::address_to_object<Metadata>(*metadata_address);
+                if (object::owner(token_metadata) == owner) {
+                    let token_symbol = fungible_asset::symbol(token_metadata);
+                    if (token_symbol == symbol) {
+                        if (std::option::is_some(&address_found)) {
+                            abort(error_config::get_etoken_already_exists())
+                        };
+                        std::option::fill(&mut address_found, *metadata_address);
+                    };
+                }
+            }
+        );
+
+        if (std::option::is_none(&address_found)) {
+            abort(error_config::get_etoken_not_exist())
+        };
+        std::option::destroy_some(address_found)
+    }
+
+    #[view]
+    public fun asset_metadata(owner: address, symbol: String): Object<Metadata> acquires TokenMap {
+        object::address_to_object<Metadata>(token_address(owner, symbol))
+    }
+
+    #[test_only]
+    public fun test_init_module(signer: &signer) {
+        init_module(signer);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-tokens/fungible_asset_manager.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-tokens/fungible_asset_manager.move
@@ -1,0 +1,86 @@
+module aave_pool::fungible_asset_manager {
+    use std::option::Option;
+    use std::string::String;
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+
+    use aave_config::error_config;
+
+    friend aave_pool::a_token_factory;
+    friend aave_pool::supply_logic;
+    friend aave_pool::borrow_logic;
+    friend aave_pool::liquidation_logic;
+    friend aave_pool::bridge_logic;
+    friend aave_pool::flashloan_logic;
+
+    /// @notice Transfer a given amount of the asset to a recipient.
+    /// @dev Only callable by the supply_logic, borrow_logic, liquidation_logic, bridge_logic, flashloan_logic and a_token_factory module.
+    /// @param from The account signer of the caller
+    /// @param to The recipient of the asset
+    /// @param amount The amount to transfer
+    /// @param metadata_address The address of the metadata object
+    public(friend) fun transfer(
+        from: &signer,
+        to: address,
+        amount: u64,
+        metadata_address: address
+    ) {
+        let asset_metadata = get_metadata(metadata_address);
+        primary_fungible_store::transfer(from, asset_metadata, to, amount);
+    }
+
+    /// Return the address of the managed fungible asset that's created when this module is deployed.
+    fun get_metadata(metadata_address: address): Object<Metadata> {
+        object::address_to_object<Metadata>(metadata_address)
+    }
+
+    public fun assert_token_exists(metadata_address: address) {
+        assert!(
+            object::object_exists<Metadata>(metadata_address),
+            error_config::get_eresource_not_exist()
+        )
+    }
+
+    #[view]
+    /// Get the balance of a given store.
+    public fun balance_of(owner: address, metadata_address: address): u64 {
+        let metadata = get_metadata(metadata_address);
+        primary_fungible_store::balance(owner, metadata)
+    }
+
+    #[view]
+    /// Get the current supply from the `metadata` object.
+    public fun supply(metadata_address: address): Option<u128> {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::supply(asset)
+    }
+
+    #[view]
+    /// Get the maximum supply from the `metadata` object.
+    public fun maximum(metadata_address: address): Option<u128> {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::maximum(asset)
+    }
+
+    #[view]
+    /// Get the name of the fungible asset from the `metadata` object.
+    public fun name(metadata_address: address): String {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::name(asset)
+    }
+
+    #[view]
+    /// Get the symbol of the fungible asset from the `metadata` object.
+    public fun symbol(metadata_address: address): String {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::symbol(asset)
+    }
+
+    #[view]
+    /// Get the decimals from the `metadata` object.
+    public fun decimals(metadata_address: address): u8 {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::decimals(asset)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-tokens/standard_token.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-tokens/standard_token.move
@@ -1,0 +1,420 @@
+module aave_pool::standard_token {
+    use aptos_framework::fungible_asset::{
+        Self,
+        MintRef,
+        TransferRef,
+        BurnRef,
+        Metadata,
+        FungibleStore,
+        FungibleAsset
+    };
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+    use aptos_framework::event::{Self};
+    use std::error;
+    use std::signer;
+    use std::string::{Self, String};
+    use std::option;
+    use std::vector;
+    use std::option::Option;
+
+    /// Only fungible asset metadata owner can make changes.
+    const ERR_NOT_OWNER: u64 = 1;
+    /// The length of ref_flags is not 3.
+    const ERR_INVALID_REF_FLAGS_LENGTH: u64 = 2;
+    /// The lengths of two vector do not equal.
+    const ERR_VECTORS_LENGTH_MISMATCH: u64 = 3;
+    /// MintRef error.
+    const ERR_MINT_REF: u64 = 4;
+    /// TransferRef error.
+    const ERR_TRANSFER_REF: u64 = 5;
+    /// BurnRef error.
+    const ERR_BURN_REF: u64 = 6;
+    // error config
+    const E_NOT_A_TOKEN_ADMIN: u64 = 1;
+
+    const REVISION: u64 = 1;
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Hold refs to control the minting, transfer and burning of fungible assets.
+    struct ManagingRefs has key {
+        mint_ref: Option<MintRef>,
+        transfer_ref: Option<TransferRef>,
+        burn_ref: Option<BurnRef>
+    }
+
+    #[event]
+    struct AaveTokenInitialized has store, drop {
+        supply: Option<u128>,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String,
+        underlying_asset_address: address,
+        is_coin_underlying: bool
+    }
+
+    /// Initialize metadata object and store the refs specified by `ref_flags`.
+    public fun initialize(
+        creator: &signer,
+        maximum_supply: u128,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String,
+        ref_flags: vector<bool>,
+        underlying_asset_address: address,
+        is_coin_underlying: bool
+    ) {
+        only_token_admin(creator);
+        assert!(
+            vector::length(&ref_flags) == 3,
+            error::invalid_argument(ERR_INVALID_REF_FLAGS_LENGTH)
+        );
+        let supply =
+            if (maximum_supply != 0) {
+                option::some(maximum_supply)
+            } else {
+                option::none()
+            };
+
+        let constructor_ref =
+            &object::create_named_object(creator, *string::bytes(&symbol));
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor_ref,
+            supply,
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            project_uri
+        );
+
+        // Optionally create mint/burn/transfer refs to allow creator to manage the fungible asset.
+        let mint_ref =
+            if (*vector::borrow(&ref_flags, 0)) {
+                option::some(fungible_asset::generate_mint_ref(constructor_ref))
+            } else {
+                option::none()
+            };
+        let transfer_ref =
+            if (*vector::borrow(&ref_flags, 1)) {
+                option::some(fungible_asset::generate_transfer_ref(constructor_ref))
+            } else {
+                option::none()
+            };
+        let burn_ref =
+            if (*vector::borrow(&ref_flags, 2)) {
+                option::some(fungible_asset::generate_burn_ref(constructor_ref))
+            } else {
+                option::none()
+            };
+        let metadata_object_signer = object::generate_signer(constructor_ref);
+
+        // save the managing refs
+        move_to(
+            &metadata_object_signer,
+            ManagingRefs { mint_ref, transfer_ref, burn_ref }
+        );
+
+        event::emit(
+            AaveTokenInitialized {
+                supply,
+                name,
+                symbol,
+                decimals,
+                icon_uri,
+                project_uri,
+                underlying_asset_address,
+                is_coin_underlying
+            }
+        )
+    }
+
+    #[view]
+    /// Return the revision of the aave token implementation
+    public fun get_revision(): u64 {
+        REVISION
+    }
+
+    /// Mint as the owner of metadata object to the primary fungible stores of the accounts with amounts of FAs.
+    public entry fun mint_to_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        to: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let receiver_primary_stores = vector::map(
+            to, |addr| primary_fungible_store::ensure_primary_store_exists(addr, asset)
+        );
+        mint(admin, asset, receiver_primary_stores, amounts);
+    }
+
+    /// Mint as the owner of metadata object to multiple fungible stores with amounts of FAs.
+    public entry fun mint(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(
+            length == vector::length(&amounts),
+            error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH)
+        );
+        let mint_ref = authorized_borrow_mint_ref(admin, asset);
+        for (i in 0..length) {
+            fungible_asset::mint_to(
+                mint_ref,
+                *vector::borrow(&stores, i),
+                *vector::borrow(&amounts, i)
+            );
+        }
+    }
+
+    /// Transfer as the owner of metadata object ignoring `frozen` field from primary stores to primary stores of
+    /// accounts.
+    public entry fun transfer_between_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        to: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let sender_primary_stores = vector::map(
+            from, |addr| primary_fungible_store::primary_store(addr, asset)
+        );
+        let receiver_primary_stores = vector::map(
+            to, |addr| primary_fungible_store::ensure_primary_store_exists(addr, asset)
+        );
+        transfer(
+            admin,
+            asset,
+            sender_primary_stores,
+            receiver_primary_stores,
+            amounts
+        );
+    }
+
+    /// Transfer as the owner of metadata object ignoring `frozen` field between fungible stores.
+    public entry fun transfer(
+        admin: &signer,
+        asset: Object<Metadata>,
+        sender_stores: vector<Object<FungibleStore>>,
+        receiver_stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let length = vector::length(&sender_stores);
+        assert!(
+            length == vector::length(&receiver_stores),
+            error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH)
+        );
+        assert!(
+            length == vector::length(&amounts),
+            error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH)
+        );
+        let transfer_ref = authorized_borrow_transfer_ref(admin, asset);
+        for (i in 0..length) {
+            fungible_asset::transfer_with_ref(
+                transfer_ref,
+                *vector::borrow(&sender_stores, i),
+                *vector::borrow(&receiver_stores, i),
+                *vector::borrow(&amounts, i)
+            );
+        }
+    }
+
+    /// Burn fungible assets as the owner of metadata object from the primary stores of accounts.
+    public entry fun burn_from_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let primary_stores = vector::map(
+            from, |addr| primary_fungible_store::primary_store(addr, asset)
+        );
+        burn(admin, asset, primary_stores, amounts);
+    }
+
+    /// Burn fungible assets as the owner of metadata object from fungible stores.
+    public entry fun burn(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(
+            length == vector::length(&amounts),
+            error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH)
+        );
+        let burn_ref = authorized_borrow_burn_ref(admin, asset);
+        for (i in 0..length) {
+            fungible_asset::burn_from(
+                burn_ref,
+                *vector::borrow(&stores, i),
+                *vector::borrow(&amounts, i)
+            );
+        };
+    }
+
+    /// Freeze/unfreeze the primary stores of accounts so they cannot transfer or receive fungible assets.
+    public entry fun set_primary_stores_frozen_status(
+        admin: &signer,
+        asset: Object<Metadata>,
+        accounts: vector<address>,
+        frozen: bool
+    ) acquires ManagingRefs {
+        let primary_stores = vector::map(
+            accounts,
+            |acct| { primary_fungible_store::ensure_primary_store_exists(acct, asset) }
+        );
+        set_frozen_status(admin, asset, primary_stores, frozen);
+    }
+
+    /// Freeze/unfreeze the fungible stores so they cannot transfer or receive fungible assets.
+    public entry fun set_frozen_status(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        frozen: bool
+    ) acquires ManagingRefs {
+        let transfer_ref = authorized_borrow_transfer_ref(admin, asset);
+        vector::for_each(
+            stores,
+            |store| {
+                fungible_asset::set_frozen_flag(transfer_ref, store, frozen);
+            }
+        );
+    }
+
+    /// Withdraw as the owner of metadata object ignoring `frozen` field from primary fungible stores of accounts.
+    public fun withdraw_from_primary_stores(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        amounts: vector<u64>
+    ): FungibleAsset acquires ManagingRefs {
+        let primary_stores = vector::map(
+            from, |addr| primary_fungible_store::primary_store(addr, asset)
+        );
+        withdraw(admin, asset, primary_stores, amounts)
+    }
+
+    /// Withdraw as the owner of metadata object ignoring `frozen` field from fungible stores.
+    /// return a fungible asset `fa` where `fa.amount = sum(amounts)`.
+    public fun withdraw(
+        admin: &signer,
+        asset: Object<Metadata>,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ): FungibleAsset acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(
+            length == vector::length(&amounts),
+            error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH)
+        );
+        let transfer_ref = authorized_borrow_transfer_ref(admin, asset);
+        let sum = fungible_asset::zero(asset);
+        for (i in 0..length) {
+            let fa =
+                fungible_asset::withdraw_with_ref(
+                    transfer_ref,
+                    *vector::borrow(&stores, i),
+                    *vector::borrow(&amounts, i)
+                );
+            fungible_asset::merge(&mut sum, fa);
+        };
+        sum
+    }
+
+    /// Deposit as the owner of metadata object ignoring `frozen` field to primary fungible stores of accounts from a
+    /// single source of fungible asset.
+    public fun deposit_to_primary_stores(
+        admin: &signer,
+        fa: &mut FungibleAsset,
+        from: vector<address>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let primary_stores = vector::map(
+            from,
+            |addr| primary_fungible_store::ensure_primary_store_exists(
+                addr, fungible_asset::asset_metadata(fa)
+            )
+        );
+        deposit(admin, fa, primary_stores, amounts);
+    }
+
+    /// Deposit as the owner of metadata object ignoring `frozen` field from fungible stores. The amount left in `fa`
+    /// is `fa.amount - sum(amounts)`.
+    public fun deposit(
+        admin: &signer,
+        fa: &mut FungibleAsset,
+        stores: vector<Object<FungibleStore>>,
+        amounts: vector<u64>
+    ) acquires ManagingRefs {
+        let length = vector::length(&stores);
+        assert!(
+            length == vector::length(&amounts),
+            error::invalid_argument(ERR_VECTORS_LENGTH_MISMATCH)
+        );
+        let transfer_ref =
+            authorized_borrow_transfer_ref(admin, fungible_asset::asset_metadata(fa));
+        for (i in 0..length) {
+            let split_fa = fungible_asset::extract(fa, *vector::borrow(&amounts, i));
+            fungible_asset::deposit_with_ref(
+                transfer_ref,
+                *vector::borrow(&stores, i),
+                split_fa
+            );
+        };
+    }
+
+    /// Borrow the immutable reference of the refs of `metadata`.
+    /// This validates that the signer is the metadata object's owner.
+    inline fun authorized_borrow_refs(
+        owner: &signer, asset: Object<Metadata>
+    ): &ManagingRefs acquires ManagingRefs {
+        assert!(
+            object::is_owner(asset, signer::address_of(owner)),
+            error::permission_denied(ERR_NOT_OWNER)
+        );
+        borrow_global<ManagingRefs>(object::object_address(&asset))
+    }
+
+    /// Check the existence and borrow `MintRef`.
+    inline fun authorized_borrow_mint_ref(
+        owner: &signer, asset: Object<Metadata>
+    ): &MintRef acquires ManagingRefs {
+        let refs = authorized_borrow_refs(owner, asset);
+        assert!(option::is_some(&refs.mint_ref), error::not_found(ERR_MINT_REF));
+        option::borrow(&refs.mint_ref)
+    }
+
+    /// Check the existence and borrow `TransferRef`.
+    inline fun authorized_borrow_transfer_ref(
+        owner: &signer, asset: Object<Metadata>
+    ): &TransferRef acquires ManagingRefs {
+        let refs = authorized_borrow_refs(owner, asset);
+        assert!(
+            option::is_some(&refs.transfer_ref), error::not_found(ERR_TRANSFER_REF)
+        );
+        option::borrow(&refs.transfer_ref)
+    }
+
+    /// Check the existence and borrow `BurnRef`.
+    inline fun authorized_borrow_burn_ref(
+        owner: &signer, asset: Object<Metadata>
+    ): &BurnRef acquires ManagingRefs {
+        let refs = authorized_borrow_refs(owner, asset);
+        assert!(option::is_some(&refs.mint_ref), error::not_found(ERR_BURN_REF));
+        option::borrow(&refs.burn_ref)
+    }
+
+    fun only_token_admin(account: &signer) {
+        assert!(signer::address_of(account) == @aave_pool, E_NOT_A_TOKEN_ADMIN)
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-tokens/token_base.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-tokens/token_base.move
@@ -1,0 +1,532 @@
+module aave_pool::token_base {
+    use std::option::Self;
+    use std::signer;
+    use std::string::String;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use aptos_std::string_utils::format2;
+    use aptos_framework::event;
+    use aptos_framework::fungible_asset::{Self, BurnRef, Metadata, MintRef, TransferRef};
+    use aptos_framework::object::{Self, ConstructorRef, Object};
+    use aptos_framework::primary_fungible_store;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+    use aave_math::wad_ray_math;
+
+    friend aave_pool::a_token_factory;
+    friend aave_pool::variable_debt_token_factory;
+    friend aave_pool::user_logic;
+
+    #[event]
+    /// @dev Emitted when `value` tokens are moved from one account (`from`) to
+    /// another (`to`).
+    ///
+    /// Note that `value` may be zero.
+    struct Transfer has store, drop {
+        from: address,
+        to: address,
+        value: u256
+    }
+
+    #[event]
+    /// @dev Emitted after the mint action
+    /// @param caller The address performing the mint
+    /// @param on_behalf_of The address of the user that will receive the minted tokens
+    /// @param value The scaled-up amount being minted (based on user entered amount and balance increase from interest)
+    /// @param balance_increase The increase in scaled-up balance since the last action of 'on_behalf_of'
+    /// @param index The next liquidity index of the reserve
+    struct Mint has store, drop {
+        caller: address,
+        on_behalf_of: address,
+        value: u256,
+        balance_increase: u256,
+        index: u256
+    }
+
+    #[event]
+    /// @dev Emitted after the burn action
+    /// @dev If the burn function does not involve a transfer of the underlying asset, the target defaults to zero address
+    /// @param from The address from which the tokens will be burned
+    /// @param target The address that will receive the underlying, if any
+    /// @param value The scaled-up amount being burned (user entered amount - balance increase from interest)
+    /// @param balance_increase The increase in scaled-up balance since the last action of 'from'
+    /// @param index The next liquidity index of the reserve
+    struct Burn has store, drop {
+        from: address,
+        target: address,
+        value: u256,
+        balance_increase: u256,
+        index: u256
+    }
+
+    struct UserState has store, copy, drop {
+        balance: u128,
+        additional_data: u128
+    }
+
+    // Map of users address and their state data (key = user_address_token_address => UserState)
+    struct UserStateMap has key {
+        value: SmartTable<String, UserState>
+    }
+
+    struct TokenData has store, copy, drop {
+        scaled_total_supply: u256
+    }
+
+    // token metadata_address => TokenData
+    struct TokenMap has key {
+        value: SmartTable<address, TokenData>
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Hold refs to control the minting, transfer and burning of fungible assets.
+    struct ManagedFungibleAsset has key {
+        mint_ref: MintRef,
+        transfer_ref: TransferRef,
+        burn_ref: BurnRef
+    }
+
+    fun init_module(signer: &signer) {
+        only_token_admin(signer);
+        move_to(
+            signer,
+            UserStateMap {
+                value: smart_table::new<String, UserState>()
+            }
+        );
+        move_to(
+            signer,
+            TokenMap {
+                value: smart_table::new<address, TokenData>()
+            }
+        )
+    }
+
+    fun assert_token_exists(metadata_address: address) acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+        assert!(
+            smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_not_exist()
+        );
+    }
+
+    public fun get_user_state(
+        user: address, metadata_address: address
+    ): UserState acquires UserStateMap {
+        let user_state_map = borrow_global<UserStateMap>(@aave_pool);
+        let key = format2(&b"{}_{}", user, metadata_address);
+        if (!smart_table::contains(&user_state_map.value, key)) {
+            return UserState { balance: 0, additional_data: 0 }
+        };
+        *smart_table::borrow(&user_state_map.value, key)
+    }
+
+    fun set_user_state(
+        user: address,
+        metadata_address: address,
+        balance: u128,
+        additional_data: u128
+    ) acquires UserStateMap {
+        let user_state_map = borrow_global_mut<UserStateMap>(@aave_pool);
+        let key = format2(&b"{}_{}", user, metadata_address);
+
+        smart_table::upsert(
+            &mut user_state_map.value,
+            key,
+            UserState { balance, additional_data }
+        );
+    }
+
+    public fun get_token_data(metadata_address: address): TokenData acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+        assert!(
+            smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_not_exist()
+        );
+
+        *smart_table::borrow(&token_map.value, metadata_address)
+    }
+
+    fun set_scaled_total_supply(
+        metadata_address: address, scaled_total_supply: u256
+    ) acquires TokenMap {
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        let token_data = smart_table::borrow_mut(&mut token_map.value, metadata_address);
+        token_data.scaled_total_supply = scaled_total_supply;
+    }
+
+    public fun get_previous_index(
+        user: address, metadata_address: address
+    ): u256 acquires UserStateMap {
+        let user_state = get_user_state(user, metadata_address);
+        (user_state.additional_data as u256)
+    }
+
+    public fun get_scaled_total_supply(token_data: &TokenData): u256 {
+        token_data.scaled_total_supply
+    }
+
+    /// @notice Creates a new FA Token
+    /// @dev Only callable by the a_token_factory and variable_debt_token_factory module
+    /// @param constructor_ref The constructor reference of the Token
+    /// @param name The name of the Token
+    /// @param symbol The symbol of the Token
+    /// @param decimals The decimals of the Token
+    /// @param icon_uri The icon URI of the Token
+    /// @param project_uri The project URI of the Token
+    public(friend) fun create_token(
+        constructor_ref: &ConstructorRef,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String
+    ) acquires TokenMap {
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        let metadata_address = object::address_from_constructor_ref(constructor_ref);
+        assert!(
+            !smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_already_exists()
+        );
+        let token_data = TokenData { scaled_total_supply: 0 };
+        smart_table::add(&mut token_map.value, metadata_address, token_data);
+
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor_ref,
+            option::none(),
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            project_uri
+        );
+
+        // Create mint/burn/transfer refs to allow creator to manage the fungible asset.
+        let mint_ref = fungible_asset::generate_mint_ref(constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(constructor_ref);
+        let transfer_ref = fungible_asset::generate_transfer_ref(constructor_ref);
+        let metadata_object_signer = object::generate_signer(constructor_ref);
+
+        move_to(
+            &metadata_object_signer,
+            ManagedFungibleAsset { mint_ref, transfer_ref, burn_ref }
+        );
+    }
+
+    /// @notice Mints `amount` tokens to `on_behalf_of`
+    /// @dev Only callable by the a_token_factory and variable_debt_token_factory module
+    /// @param caller The address performing the mint
+    /// @param on_behalf_of The address of the user that will receive the minted Tokens
+    /// @param amount The amount of tokens getting minted
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the Token
+    public(friend) fun mint_scaled(
+        caller: address,
+        on_behalf_of: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires ManagedFungibleAsset, UserStateMap, TokenMap {
+        let amount_scaled = wad_ray_math::ray_div(amount, index);
+        assert!(amount_scaled != 0, error_config::get_einvalid_mint_amount());
+        let scaled_balance = scaled_balance_of(on_behalf_of, metadata_address);
+
+        let user_state = get_user_state(on_behalf_of, metadata_address);
+        let balance_increase =
+            wad_ray_math::ray_mul(scaled_balance, index)
+                - wad_ray_math::ray_mul(
+                    scaled_balance, (user_state.additional_data as u256)
+                );
+        let new_balance = user_state.balance + (amount_scaled as u128);
+        set_user_state(
+            on_behalf_of,
+            metadata_address,
+            new_balance,
+            (index as u128)
+        );
+
+        // update scale total supply
+        let token_data = get_token_data(metadata_address);
+        let scaled_total_supply = token_data.scaled_total_supply + amount_scaled;
+        set_scaled_total_supply(metadata_address, scaled_total_supply);
+
+        // fungible asset mint
+        let asset = get_metadata(metadata_address);
+        let managed_fungible_asset = obtain_managed_asset_refs(asset);
+        let to_wallet =
+            primary_fungible_store::ensure_primary_store_exists(on_behalf_of, asset);
+        // freeze account
+        if (!fungible_asset::is_frozen(to_wallet)) {
+            fungible_asset::set_frozen_flag(
+                &managed_fungible_asset.transfer_ref, to_wallet, true
+            );
+        };
+
+        let fa =
+            fungible_asset::mint(
+                &managed_fungible_asset.mint_ref, (amount_scaled as u64)
+            );
+        fungible_asset::deposit_with_ref(
+            &managed_fungible_asset.transfer_ref, to_wallet, fa
+        );
+
+        let amount_to_mint = amount + balance_increase;
+        event::emit(Transfer { from: @0x0, to: on_behalf_of, value: amount_to_mint });
+        event::emit(
+            Mint {
+                caller,
+                on_behalf_of,
+                value: amount_to_mint,
+                balance_increase,
+                index
+            }
+        );
+    }
+
+    /// @notice Burns Tokens from `user`
+    /// @dev Only callable by the a_token_factory and variable_debt_token_factory module
+    /// @dev In some instances, the mint event could be emitted from a burn transaction
+    /// if the amount to burn is less than the interest that the user accrued
+    /// @param user The address from which the Tokens will be burned
+    /// @param target The address that will receive the underlying
+    /// @param amount The amount being burned
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the Token
+    public(friend) fun burn_scaled(
+        user: address,
+        target: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires ManagedFungibleAsset, UserStateMap, TokenMap {
+        let amount_scaled = wad_ray_math::ray_div(amount, index);
+        assert!(amount_scaled != 0, error_config::get_einvalid_mint_amount());
+        // get scale balance
+        let scaled_balance = scaled_balance_of(user, metadata_address);
+
+        let user_state = get_user_state(user, metadata_address);
+        let balance_increase =
+            wad_ray_math::ray_mul(scaled_balance, index)
+                - wad_ray_math::ray_mul(
+                    scaled_balance, (user_state.additional_data as u256)
+                );
+        let new_balance = user_state.balance - (amount_scaled as u128);
+        set_user_state(
+            user,
+            metadata_address,
+            new_balance,
+            (index as u128)
+        );
+
+        // update scale total supply
+        let token_data = get_token_data(metadata_address);
+        let scaled_total_supply = token_data.scaled_total_supply - amount_scaled;
+        set_scaled_total_supply(metadata_address, scaled_total_supply);
+
+        // burn fungible asset
+        let asset = get_metadata(metadata_address);
+        let burn_ref = &obtain_managed_asset_refs(asset).burn_ref;
+        let from_wallet = primary_fungible_store::primary_store(user, asset);
+        fungible_asset::burn_from(burn_ref, from_wallet, (amount_scaled as u64));
+
+        if (balance_increase > amount) {
+            let amount_to_mint = balance_increase - amount;
+            event::emit(Transfer { from: @0x0, to: user, value: amount_to_mint });
+            event::emit(
+                Mint {
+                    caller: user,
+                    on_behalf_of: user,
+                    value: amount_to_mint,
+                    balance_increase,
+                    index
+                }
+            );
+        } else {
+            let amount_to_burn = amount - balance_increase;
+            event::emit(Transfer { from: user, to: @0x0, value: amount_to_burn });
+            event::emit(
+                Burn {
+                    from: user,
+                    target,
+                    value: amount_to_burn,
+                    balance_increase,
+                    index
+                }
+            );
+        }
+    }
+
+    /// @notice Transfers Tokens from `sender` to `recipient`
+    /// @dev Only callable by the a_token_factory and user_logic module
+    /// @param sender The address from which the Tokens will be transferred
+    /// @param recipient The address that will receive the Tokens
+    /// @param amount The amount being transferred
+    /// @param index The next liquidity index of the reserve
+    /// @param metadata_address The address of the Token
+    public(friend) fun transfer(
+        sender: address,
+        recipient: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires ManagedFungibleAsset, UserStateMap {
+        let sender_scaled_balance = scaled_balance_of(sender, metadata_address);
+        let sender_user_state = get_user_state(sender, metadata_address);
+        let sender_balance_increase =
+            wad_ray_math::ray_mul(sender_scaled_balance, index)
+                - wad_ray_math::ray_mul(
+                    sender_scaled_balance, (sender_user_state.additional_data as u256)
+                );
+
+        let amount_ray_div = wad_ray_math::ray_div(amount, index);
+        let new_sender_balance = sender_user_state.balance - (amount_ray_div as u128);
+        set_user_state(
+            sender,
+            metadata_address,
+            new_sender_balance,
+            (index as u128)
+        );
+
+        let recipient_scaled_balance = scaled_balance_of(recipient, metadata_address);
+        let recipient_user_state = get_user_state(recipient, metadata_address);
+        let recipient_balance_increase =
+            wad_ray_math::ray_mul(recipient_scaled_balance, index)
+                - wad_ray_math::ray_mul(
+                    recipient_scaled_balance,
+                    (recipient_user_state.additional_data as u256)
+                );
+
+        let new_recipient_balance = recipient_user_state.balance
+            + (amount_ray_div as u128);
+        set_user_state(
+            recipient,
+            metadata_address,
+            new_recipient_balance,
+            (index as u128)
+        );
+        // transfer fungible asset
+        let asset = get_metadata(metadata_address);
+        let transfer_ref = &obtain_managed_asset_refs(asset).transfer_ref;
+        let from_wallet = primary_fungible_store::primary_store(sender, asset);
+        let to_wallet =
+            primary_fungible_store::ensure_primary_store_exists(recipient, asset);
+
+        // freeze account
+        if (!fungible_asset::is_frozen(to_wallet)) {
+            fungible_asset::set_frozen_flag(transfer_ref, to_wallet, true);
+        };
+
+        fungible_asset::transfer_with_ref(
+            transfer_ref,
+            from_wallet,
+            to_wallet,
+            (amount_ray_div as u64)
+        );
+
+        if (sender_balance_increase > 0) {
+            event::emit(
+                Transfer { from: @0x0, to: sender, value: sender_balance_increase }
+            );
+            event::emit(
+                Mint {
+                    caller: sender,
+                    on_behalf_of: sender,
+                    value: sender_balance_increase,
+                    balance_increase: sender_balance_increase,
+                    index
+                }
+            );
+        };
+
+        // if sender == recipient, the following logic will not execute, the event will not be emitted
+        if (sender != recipient && recipient_balance_increase > 0) {
+            event::emit(
+                Transfer { from: @0x0, to: recipient, value: recipient_balance_increase }
+            );
+            event::emit(
+                Mint {
+                    caller: sender,
+                    on_behalf_of: recipient,
+                    value: recipient_balance_increase,
+                    balance_increase: recipient_balance_increase,
+                    index
+                }
+            );
+        };
+
+        event::emit(Transfer { from: sender, to: recipient, value: amount });
+    }
+
+    public fun scaled_balance_of(
+        owner: address, metadata_address: address
+    ): u256 acquires UserStateMap {
+        let user_state_map = get_user_state(owner, metadata_address);
+        (user_state_map.balance as u256)
+    }
+
+    public fun scaled_total_supply(metadata_address: address): u256 acquires TokenMap {
+        let token_data = get_token_data(metadata_address);
+        token_data.scaled_total_supply
+    }
+
+    public fun get_scaled_user_balance_and_supply(
+        owner: address, metadata_address: address
+    ): (u256, u256) acquires UserStateMap, TokenMap {
+        (scaled_balance_of(owner, metadata_address),
+        scaled_total_supply(metadata_address))
+    }
+
+    public fun name(metadata_address: address): String {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::name(asset)
+    }
+
+    public fun symbol(metadata_address: address): String {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::symbol(asset)
+    }
+
+    public fun decimals(metadata_address: address): u8 {
+        let asset = get_metadata(metadata_address);
+        fungible_asset::decimals(asset)
+    }
+
+    fun get_metadata(metadata_address: address): Object<Metadata> {
+        object::address_to_object<Metadata>(metadata_address)
+    }
+
+    inline fun obtain_managed_asset_refs(
+        asset: Object<Metadata>
+    ): &ManagedFungibleAsset acquires ManagedFungibleAsset {
+        borrow_global<ManagedFungibleAsset>(object::object_address(&asset))
+    }
+
+    /// @notice Drops the token data from the token map
+    /// @dev Only callable by the a_token_factory and variable_debt_token_factory module
+    /// @param metadata_address The address of the Token
+    public(friend) fun drop_token(metadata_address: address) acquires TokenMap {
+        assert_token_exists(metadata_address);
+
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        smart_table::remove(&mut token_map.value, metadata_address);
+    }
+
+    public fun only_pool_admin(account: &signer) {
+        assert!(
+            acl_manage::is_pool_admin(signer::address_of(account)),
+            error_config::get_ecaller_not_pool_admin()
+        );
+    }
+
+    public fun only_token_admin(account: &signer) {
+        assert!(
+            signer::address_of(account) == @aave_pool,
+            error_config::get_enot_pool_owner()
+        )
+    }
+
+    #[test_only]
+    public fun test_init_module(signer: &signer) {
+        init_module(signer);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/sources/aave-tokens/variable_debt_token_factory.move
+++ b/tests/aptos-aave-v3/aave-core/sources/aave-tokens/variable_debt_token_factory.move
@@ -1,0 +1,350 @@
+module aave_pool::variable_debt_token_factory {
+    use std::option;
+    use std::signer;
+    use std::string;
+    use std::string::String;
+    use aptos_std::smart_table;
+    use aptos_std::smart_table::SmartTable;
+    use aptos_std::string_utils::format2;
+    use aptos_framework::event;
+    use aptos_framework::fungible_asset;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object;
+    use aptos_framework::object::Object;
+
+    use aave_acl::acl_manage;
+    use aave_config::error_config;
+
+    use aave_pool::token_base;
+
+    friend aave_pool::pool;
+    friend aave_pool::borrow_logic;
+    friend aave_pool::liquidation_logic;
+
+    #[test_only]
+    friend aave_pool::variable_debt_token_factory_tests;
+
+    #[test_only]
+    friend aave_pool::pool_configurator_tests;
+    #[test_only]
+    friend aave_pool::pool_tests;
+
+    const DEBT_TOKEN_REVISION: u256 = 0x1;
+
+    #[event]
+    /// @dev Emitted when a debt token is initialized
+    /// @param underlying_asset The address of the underlying asset
+    /// @param debt_token_decimals The decimals of the debt token
+    /// @param debt_token_name The name of the debt token
+    /// @param debt_token_symbol The symbol of the debt token
+    struct Initialized has store, drop {
+        underlying_asset: address,
+        debt_token_decimals: u8,
+        debt_token_name: String,
+        debt_token_symbol: String
+    }
+
+    struct TokenData has store, copy, drop {
+        underlying_asset: address
+    }
+
+    // variable debt token metadata_address => TokenData
+    struct TokenMap has key {
+        value: SmartTable<address, TokenData>,
+        count: u256
+    }
+
+    fun init_module(signer: &signer) {
+        token_base::only_token_admin(signer);
+        move_to(
+            signer,
+            TokenMap {
+                value: smart_table::new<address, TokenData>(),
+                count: 0
+            }
+        )
+    }
+
+    fun assert_token_exists(metadata_address: address) acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+        assert!(
+            smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_not_exist()
+        );
+    }
+
+    /// @notice Creates a new variable debt token.
+    /// @dev Only callable by the pool module
+    /// @param signer The signer of the caller
+    /// @param name The name of the variable debt token
+    /// @param symbol The symbol of the variable debt token
+    /// @param decimals The decimals of the variable debt token
+    /// @param icon_uri The icon URI of the variable debt token
+    /// @param project_uri The project URI of the variable debt token
+    /// @param underlying_asset The address of the underlying asset
+    /// @return The address of the variable debt token
+    public(friend) fun create_token(
+        signer: &signer,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        icon_uri: String,
+        project_uri: String,
+        underlying_asset: address
+    ): address acquires TokenMap {
+        only_asset_listing_or_pool_admins(signer);
+
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        validate_unique_token(token_map, name, symbol);
+
+        let token_count = token_map.count + 1;
+        let seed = *string::bytes(&format2(&b"{}_{}", symbol, token_count));
+        let user_signer_addr = signer::address_of(signer);
+        let metadata_address = object::create_object_address(&user_signer_addr, seed);
+
+        assert!(
+            !smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_already_exists()
+        );
+
+        let token_data = TokenData { underlying_asset };
+        smart_table::add(&mut token_map.value, metadata_address, token_data);
+
+        let constructor_ref = &object::create_named_object(signer, seed);
+        // create token
+        token_base::create_token(
+            constructor_ref,
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            project_uri
+        );
+
+        event::emit(
+            Initialized {
+                underlying_asset,
+                debt_token_decimals: decimals,
+                debt_token_name: name,
+                debt_token_symbol: symbol
+            }
+        );
+
+        metadata_address
+    }
+
+    /// @notice Mints debt token to the `on_behalf_of` address
+    /// @dev Only callable by the borrow_logic module
+    /// @param caller The address receiving the borrowed underlying, being the delegatee in case
+    /// of credit delegate, or same as `on_behalf_of` otherwise
+    /// @param on_behalf_of The address receiving the debt tokens
+    /// @param amount The amount of debt being minted
+    /// @param index The variable debt index of the reserve
+    /// @param metadata_address The address of the metadata object
+    public(friend) fun mint(
+        caller: address,
+        on_behalf_of: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+
+        token_base::mint_scaled(
+            caller,
+            on_behalf_of,
+            amount,
+            index,
+            metadata_address
+        );
+    }
+
+    /// @notice Burns user variable debt
+    /// @dev Only callable by the borrow_logic and liquidation_logic module
+    /// @dev In some instances, a burn transaction will emit a mint event
+    /// if the amount to burn is less than the interest that the user accrued
+    /// @param from The address from which the debt will be burned
+    /// @param amount The amount getting burned
+    /// @param index The variable debt index of the reserve
+    /// @param metadata_address The address of the metadata object
+    public(friend) fun burn(
+        from: address,
+        amount: u256,
+        index: u256,
+        metadata_address: address
+    ) acquires TokenMap {
+        assert_token_exists(metadata_address);
+
+        token_base::burn_scaled(from, @0x0, amount, index, metadata_address);
+    }
+
+    public fun get_token_data(metadata_address: address): TokenData acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+        assert!(
+            smart_table::contains(&token_map.value, metadata_address),
+            error_config::get_etoken_not_exist()
+        );
+
+        *smart_table::borrow(&token_map.value, metadata_address)
+    }
+
+    #[view]
+    public fun get_revision(): u256 {
+        DEBT_TOKEN_REVISION
+    }
+
+    #[view]
+    /// @notice Returns the address of the underlying asset of this debtToken (E.g. WETH for variableDebtWETH)
+    /// @param metadata_address The address of the metadata object
+    /// @return The address of the underlying asset
+    public fun get_underlying_asset_address(metadata_address: address): address acquires TokenMap {
+        let token_data = get_token_data(metadata_address);
+        token_data.underlying_asset
+    }
+
+    #[view]
+    /// @notice Returns last index interest was accrued to the user's balance
+    /// @param user The address of the user
+    /// @param metadata_address The address of the variable debt token
+    /// @return The last index interest was accrued to the user's balance, expressed in ray
+    public fun get_previous_index(
+        user: address, metadata_address: address
+    ): u256 {
+        token_base::get_previous_index(user, metadata_address)
+    }
+
+    #[view]
+    /// @notice Returns the scaled balance of the user.
+    /// @dev The scaled balance is the sum of all the updated stored balance divided by the reserve's liquidity index
+    /// at the moment of the update
+    /// @param owner The user whose balance is calculated
+    /// @param metadata_address The address of the variable debt token
+    /// @return The scaled balance of the user
+    public fun scaled_balance_of(
+        owner: address, metadata_address: address
+    ): u256 {
+        token_base::scaled_balance_of(owner, metadata_address)
+    }
+
+    #[view]
+    /// @notice Returns the scaled total supply of the scaled balance token. Represents sum(debt/index)
+    /// @param metadata_address The address of the variable debt token
+    /// @return The scaled total supply
+    public fun scaled_total_supply(metadata_address: address): u256 {
+        token_base::scaled_total_supply(metadata_address)
+    }
+
+    #[view]
+    /// @notice Returns the scaled balance of the user and the scaled total supply.
+    /// @param owner The address of the user
+    /// @param metadata_address The address of the variable debt token
+    /// @return The scaled balance of the user
+    /// @return The scaled total supply
+    public fun get_scaled_user_balance_and_supply(
+        owner: address, metadata_address: address
+    ): (u256, u256) {
+        token_base::get_scaled_user_balance_and_supply(owner, metadata_address)
+    }
+
+    #[view]
+    /// Get the name of the fungible asset from the `metadata` object.
+    public fun name(metadata_address: address): String {
+        token_base::name(metadata_address)
+    }
+
+    #[view]
+    /// Get the symbol of the fungible asset from the `metadata` object.
+    public fun symbol(metadata_address: address): String {
+        token_base::symbol(metadata_address)
+    }
+
+    #[view]
+    /// Get the decimals from the `metadata` object.
+    public fun decimals(metadata_address: address): u8 {
+        token_base::decimals(metadata_address)
+    }
+
+    /// @notice Validates that the variable debt token name and symbol are unique
+    /// @param token_map The variable debt token token map
+    /// @param name The name of the variable debt token
+    /// @param symbol The symbol of the variable debt token
+    fun validate_unique_token(
+        token_map: &TokenMap, name: String, symbol: String
+    ) {
+        smart_table::for_each_ref(
+            &token_map.value,
+            |metadata_address, _token_data| {
+                let asset_name = name(*metadata_address);
+                let asset_symbol = symbol(*metadata_address);
+                assert!(
+                    asset_name != name, error_config::get_etoken_name_already_exist()
+                );
+                assert!(
+                    asset_symbol != symbol,
+                    error_config::get_etoken_symbol_already_exist()
+                );
+            }
+        );
+    }
+
+    /// @notice Drops the variable debt token associated data
+    /// @dev Only callable by the pool module
+    /// @param metadata_address The address of the metadata object
+    public(friend) fun drop_token(metadata_address: address) acquires TokenMap {
+        assert_token_exists(metadata_address);
+
+        // Remove metadata_address from variable debt token map
+        let token_map = borrow_global_mut<TokenMap>(@aave_pool);
+        smart_table::remove(&mut token_map.value, metadata_address);
+
+        // Remove metadata_address from token_base module's token map
+        token_base::drop_token(metadata_address);
+    }
+
+    fun only_asset_listing_or_pool_admins(account: &signer) {
+        let account_address = signer::address_of(account);
+        assert!(
+            acl_manage::is_asset_listing_admin(account_address)
+                || acl_manage::is_pool_admin(account_address),
+            error_config::get_ecaller_not_asset_listing_or_pool_admin()
+        )
+    }
+
+    #[view]
+    public fun token_address(owner: address, symbol: String): address acquires TokenMap {
+        let token_map = borrow_global<TokenMap>(@aave_pool);
+
+        let address_found = option::none<address>();
+        smart_table::for_each_ref(
+            &token_map.value,
+            |metadata_address, _token_data| {
+                let token_metadata =
+                    object::address_to_object<Metadata>(*metadata_address);
+                if (object::owner(token_metadata) == owner) {
+                    let token_symbol = fungible_asset::symbol(token_metadata);
+                    if (token_symbol == symbol) {
+                        if (std::option::is_some(&address_found)) {
+                            abort(error_config::get_etoken_already_exists())
+                        };
+                        std::option::fill(&mut address_found, *metadata_address);
+                    };
+                }
+            }
+        );
+
+        if (std::option::is_none(&address_found)) {
+            abort(error_config::get_etoken_not_exist())
+        };
+        std::option::destroy_some(address_found)
+    }
+
+    #[view]
+    public fun asset_metadata(owner: address, symbol: String): Object<Metadata> acquires TokenMap {
+        object::address_to_object<Metadata>(token_address(owner, symbol))
+    }
+
+    #[test_only]
+    public fun test_init_module(signer: &signer) {
+        init_module(signer);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/borrow_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/borrow_logic_tests.move
@@ -1,0 +1,322 @@
+#[test_only]
+module aave_pool::borrow_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option::Self;
+    use std::signer;
+    use std::string::{utf8, String};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::timestamp::{set_time_has_started_for_testing};
+    use aave_acl::acl_manage::Self;
+    use aave_config::reserve_config;
+    use aave_config::user_config::is_using_as_collateral_or_borrowing;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy::Self;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::borrow_logic::Self;
+    use aave_pool::collector;
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::pool::{
+        get_reserve_data,
+        get_reserve_id,
+        get_reserve_liquidity_index,
+        get_user_configuration,
+        test_set_reserve_configuration
+    };
+    use aave_pool::pool_configurator;
+    use aave_pool::supply_logic::Self;
+    use aave_pool::token_base::Self;
+    use aave_pool::variable_debt_token_factory;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// Reserve allows borrowing and being used as collateral.
+    /// User config allows only borrowing for the reserve.
+    /// User supplies and withdraws parts of the supplied amount
+    fun test_supply_borrow(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_risk_admin(
+            aave_role_super_admin, signer::address_of(aave_oracle)
+        );
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_assets_symbols: vector<String> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets_symbols, symbol);
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_ltv(&mut reserve_config_new, 5000); // NOTE: set ltv
+            reserve_config::set_debt_ceiling(&mut reserve_config_new, 0); // NOTE: set no debt_ceiling
+            reserve_config::set_borrowable_in_isolation(&mut reserve_config_new, false); // NOTE: no borrowing in isolation
+            reserve_config::set_siloed_borrowing(&mut reserve_config_new, false); // NOTE: no siloed borrowing
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, false); // NOTE: no flashloans
+            reserve_config::set_borrowing_enabled(&mut reserve_config_new, true); // NOTE: enable borrowing
+            reserve_config::set_liquidation_threshold(&mut reserve_config_new, 4000); // NOTE: enable liq. threshold
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // =============== MINT UNDERLYING FOR USER & USER SUPPLIES ================= //
+        // mint 100 underlying tokens for the user
+        let mint_amount = 100;
+        let supplied_amount: u64 = 10;
+        let supply_receiver_address = signer::address_of(supply_user);
+        let mint_receiver_address = signer::address_of(supply_user);
+        for (i in 0..vector::length(&underlying_assets)) {
+            let underlying_token_address = *vector::borrow(&underlying_assets, i);
+
+            // mint tokens for the user
+            mock_underlying_token_factory::mint(
+                underlying_tokens_admin,
+                mint_receiver_address,
+                mint_amount,
+                underlying_token_address
+            );
+            let initial_user_balance =
+                mock_underlying_token_factory::balance_of(
+                    mint_receiver_address, underlying_token_address
+                );
+            // assert user balance of underlying
+            assert!(initial_user_balance == mint_amount, TEST_SUCCESS);
+            // assert underlying supply
+            assert!(
+                mock_underlying_token_factory::supply(underlying_token_address)
+                    == option::some((mint_amount as u128)),
+                TEST_SUCCESS
+            );
+
+            // init user config for reserve index
+            let reserve_data = get_reserve_data(underlying_token_address);
+
+            // let user supply
+            supply_logic::supply(
+                supply_user,
+                underlying_token_address,
+                (supplied_amount as u256),
+                supply_receiver_address,
+                0
+            );
+
+            let user_config_map = get_user_configuration(signer::address_of(supply_user));
+            assert!(
+                is_using_as_collateral_or_borrowing(
+                    &user_config_map, (get_reserve_id(&reserve_data) as u256)
+                ),
+                TEST_SUCCESS
+            );
+
+            // check supplier balance of underlying
+            let supplier_balance =
+                mock_underlying_token_factory::balance_of(
+                    mint_receiver_address, underlying_token_address
+                );
+            assert!(
+                supplier_balance == initial_user_balance - supplied_amount,
+                TEST_SUCCESS
+            );
+
+            // check underlying supply (must not have changed)
+            assert!(
+                mock_underlying_token_factory::supply(underlying_token_address)
+                    == option::some((mint_amount as u128)),
+                TEST_SUCCESS
+            );
+
+            // check a_token underlying balance
+            let a_token_address =
+                a_token_factory::token_address(
+                    signer::address_of(aave_pool),
+                    *vector::borrow(&atokens_symbols, i)
+                );
+            let atoken_account_address =
+                a_token_factory::get_token_account_address(a_token_address);
+            let underlying_account_balance =
+                mock_underlying_token_factory::balance_of(
+                    atoken_account_address, underlying_token_address
+                );
+            assert!(underlying_account_balance == supplied_amount, TEST_SUCCESS);
+            // check user a_token balance after supply
+            let supplied_amount_scaled =
+                wad_ray_math::ray_div(
+                    (supplied_amount as u256),
+                    (get_reserve_liquidity_index(&reserve_data) as u256)
+                );
+            let supplier_a_token_balance =
+                a_token_factory::scaled_balance_of(
+                    signer::address_of(supply_user), a_token_address
+                );
+            assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+        };
+
+        // register assets with oracle feed_ids
+        for (i in 0..vector::length(&underlying_assets)) {
+            let underlying_token_address = *vector::borrow(&underlying_assets, i);
+            aave_oracle::oracle::set_asset_feed_id(
+                aave_pool,
+                underlying_token_address,
+                aave_oracle::oracle_tests::get_test_feed_id()
+            );
+        };
+
+        // =============== USER BORROWS FIRST TWO ASSETS ================= //
+        // user supplies the underlying token
+        let borrow_receiver_address = signer::address_of(supply_user);
+        let borrowed_amount: u64 = 1;
+        for (i in 0..2) {
+            let underlying_token_address = *vector::borrow(&underlying_assets, i);
+            borrow_logic::borrow(
+                supply_user,
+                underlying_token_address,
+                (borrowed_amount as u256),
+                2, // variable interest rate mode
+                0, // referral
+                borrow_receiver_address
+            );
+        };
+
+        // check emitted events
+        let emitted_borrow_events = emitted_events<borrow_logic::Borrow>();
+        assert!(vector::length(&emitted_borrow_events) == 2, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/bridge_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/bridge_logic_tests.move
@@ -1,0 +1,897 @@
+#[test_only]
+module aave_pool::bridge_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option::Self;
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+    use aave_acl::acl_manage::Self;
+    use aave_config::reserve_config;
+    use aave_config::user_config::is_using_as_collateral_or_borrowing;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy::Self;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::bridge_logic::Self;
+    use aave_pool::collector;
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::pool;
+    use aave_pool::pool::{
+        get_reserve_data,
+        get_reserve_id,
+        get_reserve_liquidity_index,
+        test_set_reserve_configuration
+    };
+    use aave_pool::pool_configurator;
+    use aave_pool::pool_tests::create_user_config_for_reserve;
+    use aave_pool::supply_logic::Self;
+    use aave_pool::token_base::Self;
+    use aave_pool::variable_debt_token_factory;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens,
+            unbacked_tokens_minter = @0x43
+        )
+    ]
+    /// Mint unbacked a-tokens (no underlyings behind them) for a user
+    /// The user has already supplied hence not a first supply
+    fun test_minting_backed_after_supply(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer,
+        unbacked_tokens_minter: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_bridge(
+            aave_role_super_admin, signer::address_of(unbacked_tokens_minter)
+        );
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        let reserve_unbacked_mint_cap = 1000;
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            reserve_config::set_unbacked_mint_cap(
+                &mut reserve_config_new, reserve_unbacked_mint_cap
+            );
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // assert resreve has 0 unbacked
+        let reserve_mint_unbacked = pool::get_reserve_unbacked(&reserve_data);
+        assert!(reserve_mint_unbacked == 0, TEST_SUCCESS);
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(supply_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // =============== MINT UNDERLYING FOR A SUPPLY USER ================= //
+        // mint 100 underlying tokens for the user
+        let underlying_tokens_to_mint = 100;
+        let mint_receiver_address = signer::address_of(supply_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            underlying_tokens_to_mint,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == underlying_tokens_to_mint, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+
+        // =============== USER SUPPLY ================= //
+        // user supplies the underlying token
+        let supply_receiver_address = signer::address_of(supply_user);
+        let supplied_amount: u64 = 10;
+        supply_logic::supply(
+            supply_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+
+        // check supplier balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+
+        // check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+
+        // check a_token underlying balance
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let atoken_acocunt_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        let underlying_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_acocunt_address, underlying_token_address
+            );
+        assert!(underlying_acocunt_balance == supplied_amount, TEST_SUCCESS);
+
+        // check user a_token balance after supply
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+
+        // =============== MINT UNBACKED ATOKENS FOR A SUPPLY USER ================= //
+        let mint_unbacked_amount = 50;
+        let on_behalf_of = signer::address_of(unbacked_tokens_minter);
+        bridge_logic::mint_unbacked(
+            unbacked_tokens_minter,
+            underlying_token_address,
+            mint_unbacked_amount,
+            on_behalf_of,
+            0
+        );
+
+        // check emitted events
+        let emitted_supply_events = emitted_events<bridge_logic::MintUnbacked>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+
+        // check reserve
+        let reserve_data = get_reserve_data(underlying_token_address);
+        let reserve_mint_unbacked = pool::get_reserve_unbacked(&reserve_data);
+        assert!(mint_unbacked_amount == (reserve_mint_unbacked as u256), TEST_SUCCESS);
+
+        // check supplier a token balance
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(on_behalf_of, a_token_address);
+        // let supplied_a_token_amount_scaled =
+        //     wad_ray_math::ray_div(
+        //         mint_unbacked_amount + (supplied_amount as u256),
+        //         (get_reserve_liquidity_index(&reserve_data) as u256),
+        //     );
+        assert!(supplier_a_token_balance == mint_unbacked_amount, TEST_SUCCESS);
+
+        // check supplier underlying token balance
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+
+        // check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens,
+            unbacked_tokens_minter = @0x43
+        )
+    ]
+    #[expected_failure(abort_code = 6)]
+    /// Mint unbacked a-tokens (no underlyings behind them) for a user
+    /// The user has already supplied hence not a first supply
+    fun test_minting_backed_none_bridge_failure(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer,
+        unbacked_tokens_minter: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_bridge(
+            aave_role_super_admin, signer::address_of(unbacked_tokens_minter)
+        );
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        let reserve_unbacked_mint_cap = 1000;
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            reserve_config::set_unbacked_mint_cap(
+                &mut reserve_config_new, reserve_unbacked_mint_cap
+            );
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // assert resreve has 0 unbacked
+        let reserve_mint_unbacked = pool::get_reserve_unbacked(&reserve_data);
+        assert!(reserve_mint_unbacked == 0, TEST_SUCCESS);
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(supply_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // =============== MINT UNDERLYING FOR A SUPPLY USER ================= //
+        // mint 100 underlying tokens for the user
+        let underlying_tokens_to_mint = 100;
+        let mint_receiver_address = signer::address_of(supply_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            underlying_tokens_to_mint,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == underlying_tokens_to_mint, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+
+        // =============== USER SUPPLY ================= //
+        // user supplies the underlying token
+        let supply_receiver_address = signer::address_of(supply_user);
+        let supplied_amount: u64 = 10;
+        supply_logic::supply(
+            supply_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+
+        // check supplier balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+
+        // check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+
+        // check a_token underlying balance
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let atoken_acocunt_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        let underlying_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_acocunt_address, underlying_token_address
+            );
+        assert!(underlying_acocunt_balance == supplied_amount, TEST_SUCCESS);
+
+        // check user a_token balance after supply
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+
+        // =============== MINT UNBACKED ATOKENS FOR A SUPPLY USER ================= //
+        let mint_unbacked_amount = 50;
+        bridge_logic::mint_unbacked(
+            underlying_tokens_admin,
+            underlying_token_address,
+            mint_unbacked_amount,
+            signer::address_of(supply_user),
+            0
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens,
+            unbacked_tokens_minter = @0x43
+        )
+    ]
+    /// Mint unbacked a-tokens (no underlyings behind them) for a user
+    /// The user has not supplied before
+    fun test_minting_backed_first_supply(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer,
+        unbacked_tokens_minter: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_bridge(
+            aave_role_super_admin, signer::address_of(unbacked_tokens_minter)
+        );
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        let reserve_unbacked_mint_cap = 1000;
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            reserve_config::set_unbacked_mint_cap(
+                &mut reserve_config_new, reserve_unbacked_mint_cap
+            );
+            reserve_config::set_ltv(&mut reserve_config_new, 10000); // NOTE: set ltv here!
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // assert resreve has 0 unbacked
+        let reserve_mint_unbacked = pool::get_reserve_unbacked(&reserve_data);
+        assert!(reserve_mint_unbacked == 0, TEST_SUCCESS);
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(supply_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(false) // NOTE: user is not yet using as collateral
+        );
+
+        // =============== MINT UNDERLYING FOR A SUPPLY USER ================= //
+        // mint 100 underlying tokens for the user
+        let underlying_tokens_to_mint = 100;
+        let mint_receiver_address = signer::address_of(supply_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            underlying_tokens_to_mint,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+
+        // assert user balance of underlying
+        assert!(initial_user_balance == underlying_tokens_to_mint, TEST_SUCCESS);
+
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+
+        // check a_token underlying balance
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let atoken_acocunt_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        let underlying_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_acocunt_address, underlying_token_address
+            );
+        assert!(underlying_acocunt_balance == 0, TEST_SUCCESS);
+
+        // check user a_token balance
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == 0, TEST_SUCCESS);
+
+        // =============== MINT UNBACKED ATOKENS FOR A SUPPLY USER ================= //
+        let mint_unbacked_amount = 50;
+        let on_behalf_of = signer::address_of(unbacked_tokens_minter);
+        bridge_logic::mint_unbacked(
+            unbacked_tokens_minter,
+            underlying_token_address,
+            mint_unbacked_amount,
+            on_behalf_of,
+            0
+        );
+
+        // check emitted events
+        let emitted_supply_events = emitted_events<bridge_logic::MintUnbacked>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+        let emitted_reserve_used_as_collateral_events =
+            emitted_events<bridge_logic::ReserveUsedAsCollateralEnabled>();
+        assert!(
+            vector::length(&emitted_reserve_used_as_collateral_events) == 1,
+            TEST_SUCCESS
+        );
+
+        // check reserve
+        let reserve_data = get_reserve_data(underlying_token_address);
+        let reserve_mint_unbacked = pool::get_reserve_unbacked(&reserve_data);
+        assert!(mint_unbacked_amount == (reserve_mint_unbacked as u256), TEST_SUCCESS);
+
+        // check supplier a token balance
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(on_behalf_of, a_token_address);
+        // let supplied_a_token_amount_scaled =
+        //     wad_ray_math::ray_div(
+        //         mint_unbacked_amount, (get_reserve_liquidity_index(&reserve_data) as u256)
+        //     );
+        assert!(supplier_a_token_balance == mint_unbacked_amount, TEST_SUCCESS);
+
+        // check supplier underlying token balance
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(supplier_balance == initial_user_balance, TEST_SUCCESS);
+
+        // check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some((underlying_tokens_to_mint as u128)),
+            TEST_SUCCESS
+        );
+
+        // check the set using as collateral or borrowing flat is now set
+        let user_config = pool::get_user_configuration(on_behalf_of);
+        assert!(
+            is_using_as_collateral_or_borrowing(
+                &user_config, (get_reserve_id(&reserve_data) as u256)
+            ) == true,
+            TEST_SUCCESS
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/emode_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/emode_logic_tests.move
@@ -1,0 +1,507 @@
+#[test_only]
+module aave_pool::emode_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option::Self;
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aave_acl::acl_manage;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory;
+    use aave_pool::collector;
+    use aave_pool::emode_logic::{
+        configure_emode_category,
+        get_emode_category_data,
+        get_emode_category_liquidation_bonus,
+        get_emode_category_liquidation_threshold,
+        get_emode_category_price_source,
+        get_emode_configuration,
+        get_user_emode,
+        init_emode,
+        is_in_emode_category,
+        set_user_emode,
+        UserEModeSet
+    };
+    use aave_pool::mock_underlying_token_factory;
+    use aave_pool::pool::{get_reserve_data, get_reserve_id};
+    use aave_pool::pool_configurator;
+    use aave_pool::pool_tests::create_user_config_for_reserve;
+    use aave_pool::token_base;
+    use aave_pool::variable_debt_token_factory;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(pool = @aave_pool)]
+    #[expected_failure(abort_code = 16)]
+    fun zero_emode_id_failure(pool: &signer) {
+        // init the emode
+        init_emode(pool);
+
+        // configure an illegal emode category
+        let id: u8 = 0;
+        let ltv: u16 = 100;
+        let liquidation_threshold: u16 = 200;
+        let liquidation_bonus: u16 = 300;
+        let price_source: address = @0x01;
+        let label = utf8(b"MODE1");
+        configure_emode_category(
+            id,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            price_source,
+            label
+        );
+    }
+
+    #[test(pool = @aave_pool)]
+    fun get_nonexisting_emode_category(pool: &signer) {
+        // init the emode
+        init_emode(pool);
+
+        // get an non-existing emode category
+        let id: u8 = 3;
+        let (ltv, liquidation_threshold, emode_asset_price) = get_emode_configuration(id);
+        assert!(ltv == 0, TEST_SUCCESS);
+        assert!(liquidation_threshold == 0, TEST_SUCCESS);
+        assert!(emode_asset_price == 0, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform
+        )
+    ]
+    fun test_emode_config(
+        aave_pool: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer
+    ) {
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init the emode
+        init_emode(aave_pool);
+
+        // configure and assert two emode categories
+        let id1: u8 = 1;
+        let ltv1: u16 = 100;
+        let liquidation_threshold1: u16 = 200;
+        let liquidation_bonus1: u16 = 300;
+        let price_source1: address = signer::address_of(aave_oracle);
+        let label1 = utf8(b"MODE1");
+        configure_emode_category(
+            id1,
+            ltv1,
+            liquidation_threshold1,
+            liquidation_bonus1,
+            price_source1,
+            label1
+        );
+        let emode_data1 = get_emode_category_data(id1);
+        assert!(
+            get_emode_category_liquidation_bonus(&emode_data1) == liquidation_bonus1,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_emode_category_liquidation_threshold(&emode_data1)
+                == liquidation_threshold1,
+            TEST_SUCCESS
+        );
+        assert!(get_emode_category_price_source(&emode_data1) == @0x0, TEST_SUCCESS);
+        let (ltv, liquidation_threshold, _emode_asset_price) =
+            get_emode_configuration(id1);
+        assert!(ltv == (ltv1 as u256), TEST_SUCCESS);
+        assert!(liquidation_threshold == (liquidation_threshold1 as u256), TEST_SUCCESS);
+
+        let id2: u8 = 2;
+        let ltv2: u16 = 101;
+        let liquidation_threshold2: u16 = 201;
+        let liquidation_bonus2: u16 = 301;
+        let price_source2: address = signer::address_of(aave_oracle);
+        let label2 = utf8(b"MODE2");
+        configure_emode_category(
+            id2,
+            ltv2,
+            liquidation_threshold2,
+            liquidation_bonus2,
+            price_source2,
+            label2
+        );
+        let emode_data2 = get_emode_category_data(id2);
+        assert!(
+            get_emode_category_liquidation_bonus(&emode_data2) == liquidation_bonus2,
+            TEST_SUCCESS
+        );
+        assert!(
+            get_emode_category_liquidation_threshold(&emode_data2)
+                == liquidation_threshold2,
+            TEST_SUCCESS
+        );
+        assert!(get_emode_category_price_source(&emode_data2) == @0x0, TEST_SUCCESS);
+        let (ltv, liquidation_threshold, _emode_asset_price) =
+            get_emode_configuration(id2);
+        assert!(ltv == (ltv2 as u256), TEST_SUCCESS);
+        assert!(liquidation_threshold == (liquidation_threshold2 as u256), TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens,
+            user = @0x042
+        )
+    ]
+    fun test_legitimate_user_emode(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        user: &signer
+    ) {
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+
+            // create the underlying token
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare a and var tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // define an emode cat for reserve and user
+        let emode_cat_id: u8 = 1;
+        // configure an emode category
+        let ltv: u16 = 100;
+        let liquidation_threshold: u16 = 200;
+        let liquidation_bonus: u16 = 300;
+        let price_source: address = signer::address_of(aave_oracle);
+        let label = utf8(b"MODE1");
+        configure_emode_category(
+            emode_cat_id,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            price_source,
+            label
+        );
+
+        // get the reserve config
+        let underlying_asset_addr = *vector::borrow(&underlying_assets, 0);
+        let reserve_data = get_reserve_data(underlying_asset_addr);
+        pool_configurator::set_asset_emode_category(
+            aave_pool, underlying_asset_addr, emode_cat_id
+        );
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(true),
+            option::some(true)
+        );
+
+        // set user emode
+        set_user_emode(user, emode_cat_id);
+
+        // get and assert user emode
+        let user_emode = get_user_emode(signer::address_of(user));
+        assert!(user_emode == (emode_cat_id as u256), TEST_SUCCESS);
+
+        assert!(is_in_emode_category(user_emode, (emode_cat_id as u256)), TEST_SUCCESS);
+        assert!(
+            !is_in_emode_category(user_emode, (emode_cat_id + 1 as u256)), TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_events = emitted_events<UserEModeSet>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens,
+            user = @0x042
+        )
+    ]
+    #[expected_failure(abort_code = 58)]
+    fun test_user_emode_with_non_existing_user_emode(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        user: &signer
+    ) {
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prep a and var tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // define an emode cat for reserve and user
+        let emode_cat_id: u8 = 1;
+        // configure an emode category
+        let ltv: u16 = 100;
+        let liquidation_threshold: u16 = 200;
+        let liquidation_bonus: u16 = 300;
+        let price_source: address = signer::address_of(aave_oracle);
+        let label = utf8(b"MODE1");
+        configure_emode_category(
+            emode_cat_id,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            price_source,
+            label
+        );
+
+        // get the reserve config
+        let underlying_asset_addr = *vector::borrow(&underlying_assets, 0);
+        let reserve_data = get_reserve_data(underlying_asset_addr);
+        pool_configurator::set_asset_emode_category(
+            aave_pool, underlying_asset_addr, emode_cat_id
+        );
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(true),
+            option::some(true)
+        );
+
+        // set user emode
+        let non_existing_emode_id = emode_cat_id + 1;
+        set_user_emode(user, non_existing_emode_id);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/flash_loan_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/flash_loan_tests.move
@@ -1,0 +1,1456 @@
+#[test_only]
+module aave_pool::flashloan_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option::Self;
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+    use aave_acl::acl_manage::Self;
+    use aave_config::reserve_config::Self;
+    use aave_config::user_config;
+    use aave_math::math_utils::get_percentage_factor;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy::Self;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::collector;
+    use aave_pool::flashloan_logic::Self;
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::pool::{
+        Self,
+        get_reserve_liquidity_index,
+        test_set_reserve_configuration
+    };
+    use aave_pool::pool::{get_reserve_data, get_reserve_id};
+    use aave_pool::pool_configurator;
+    use aave_pool::pool_tests::create_user_config_for_reserve;
+    use aave_pool::supply_logic::Self;
+    use aave_pool::token_base::Self;
+    use aave_pool::variable_debt_token_factory;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            flashloan_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// User takes and repays a single asset flashloan
+    fun simple_flashloan_same_payer_receiver(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        flashloan_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // set flashloan premium
+        let flashloan_premium_total = get_percentage_factor() / 10; // 100/10 = 10%
+        let flashloan_premium_to_protocol = get_percentage_factor() / 20; // 100/20 = 5%
+        pool::set_flashloan_premiums_test(
+            (flashloan_premium_total as u128), (flashloan_premium_to_protocol as u128)
+        );
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // ----> mint underlying for the flashloan user
+        // mint 100 underlying tokens for the flashloan user
+        let mint_receiver_address = signer::address_of(flashloan_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            100,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == 100, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user supplies
+        // flashloan user supplies the underlying token to fill the pool before attempting to take a flashloan
+        let supply_receiver_address = signer::address_of(flashloan_user);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            flashloan_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+
+        // > check flashloan user (supplier) balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user takes a flashloan
+        let flashloan_amount = supplied_amount / 2; // half of the pool = 50/2 = 25
+        let flashloan_receipt =
+            flashloan_logic::flash_loan_simple(
+                flashloan_user,
+                signer::address_of(flashloan_user),
+                underlying_token_address,
+                (flashloan_amount as u256),
+                0 // referral code
+            );
+
+        // check intermediate underlying balance
+        let flashloan_taker_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_user), underlying_token_address
+            );
+        assert!(
+            flashloan_taker_underlying_balance == supplier_balance + flashloan_amount,
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user repays flashloan + premium
+        flashloan_logic::pay_flash_loan_simple(flashloan_user, flashloan_receipt);
+
+        // check intermediate underlying balance for flashloan user
+        let flashloan_taken_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_user), underlying_token_address
+            );
+        let flashloan_paid_premium = 3; // 10% * 25 = 2.5 = 3
+        assert!(
+            flashloan_taken_underlying_balance
+                == supplier_balance - flashloan_paid_premium,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_withdraw_events = emitted_events<flashloan_logic::FlashLoan>();
+        assert!(vector::length(&emitted_withdraw_events) == 1, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @std,
+            flashloan_payer = @0x042,
+            flashloan_receiver = @0x043,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// User takes a flashloan which is received by someone else. Either user or taker then repays a single asset flashloan
+    fun simple_flashloan_different_payer_receiver(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        flashloan_payer: &signer,
+        flashloan_receiver: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // set flashloan premium
+        let flashloan_premium_total = get_percentage_factor() / 10; // 100/10 = 10%
+        let flashloan_premium_to_protocol = get_percentage_factor() / 20; // 100/20 = 5%
+        pool::set_flashloan_premiums_test(
+            (flashloan_premium_total as u128), (flashloan_premium_to_protocol as u128)
+        );
+
+        // init user configs for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_payer),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_receiver),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // ----> mint underlying for flashloan payer and receiver
+        // mint 100 underlying tokens for flashloan payer and receiver
+        let mint_amount: u64 = 100;
+        let users = vector[
+            signer::address_of(flashloan_payer),
+            signer::address_of(flashloan_receiver)
+        ];
+        for (i in 0..vector::length(&users)) {
+            mock_underlying_token_factory::mint(
+                underlying_tokens_admin,
+                *vector::borrow(&users, i),
+                mint_amount,
+                underlying_token_address
+            );
+            let initial_user_balance =
+                mock_underlying_token_factory::balance_of(
+                    *vector::borrow(&users, i), underlying_token_address
+                );
+            // assert user balance of underlying
+            assert!(initial_user_balance == mint_amount, TEST_SUCCESS);
+        };
+
+        // ----> flashloan payer supplies
+        // flashloan payer supplies the underlying token to fill the pool before attempting to take a flashloan
+        let supply_receiver_address = signer::address_of(flashloan_payer);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            flashloan_payer,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check flashloan payer balance of underlying
+        let initial_payer_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_payer), underlying_token_address
+            );
+        assert!(
+            initial_payer_balance == mint_amount - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check flashloan payer a_token balance after supply
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(flashloan_payer), a_token_address
+            );
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+
+        let initial_receiver_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_receiver), underlying_token_address
+            );
+
+        // ----> flashloan payer takes a flashloan but receiver is different
+        let flashloan_amount = supplied_amount / 2; // half of the pool = 50/2 = 25
+        let flashloan_receipt =
+            flashloan_logic::flash_loan_simple(
+                flashloan_payer,
+                signer::address_of(flashloan_receiver), // now the receiver expects to receive the flashloan
+                underlying_token_address,
+                (flashloan_amount as u256),
+                0 // referral code
+            );
+
+        // check intermediate underlying balance for flashloan payer
+        let flashloan_payer_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_payer), underlying_token_address
+            );
+        assert!(
+            flashloan_payer_underlying_balance == initial_payer_balance, TEST_SUCCESS
+        ); // same balance as before
+
+        // check intermediate underlying balance for flashloan receiver
+        let flashloan_receiver_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_receiver), underlying_token_address
+            );
+        assert!(
+            flashloan_receiver_underlying_balance
+                == initial_receiver_balance + flashloan_amount,
+            TEST_SUCCESS
+        ); // increased balance due to flashloan
+
+        // ----> receiver repays flashloan + premium
+        flashloan_logic::pay_flash_loan_simple(flashloan_receiver, flashloan_receipt);
+
+        // check intermediate underlying balance for flashloan payer
+        let flashloan_payer_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_payer), underlying_token_address
+            );
+        assert!(
+            flashloan_payer_underlying_balance == initial_payer_balance, TEST_SUCCESS
+        );
+
+        // check intermediate underlying balance for flashloan receiver
+        let flashloan_receiver_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_receiver), underlying_token_address
+            );
+        let flashloan_paid_premium = 3; // 10% * 25 = 2.5 = 3
+        assert!(
+            flashloan_receiver_underlying_balance
+                == initial_receiver_balance - flashloan_paid_premium,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_withdraw_events = emitted_events<flashloan_logic::FlashLoan>();
+        assert!(vector::length(&emitted_withdraw_events) == 1, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            flashloan_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// User takes and repays a single asset flashloan
+    fun complex_flashloan_same_payer_receiver(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        flashloan_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // set flashloan premium
+        let flashloan_premium_total = get_percentage_factor() / 10; // 100/10 = 10%
+        let flashloan_premium_to_protocol = get_percentage_factor() / 20; // 100/20 = 5%
+        pool::set_flashloan_premiums_test(
+            (flashloan_premium_total as u128), (flashloan_premium_to_protocol as u128)
+        );
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // ----> mint underlying for the flashloan user
+        // mint 100 underlying tokens for the flashloan user
+        let mint_receiver_address = signer::address_of(flashloan_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            100,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == 100, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user supplies
+        // flashloan user supplies the underlying token to fill the pool before attempting to take a flashloan
+        let supply_receiver_address = signer::address_of(flashloan_user);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            flashloan_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+
+        // > check flashloan user (supplier) balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user takes a flashloan
+        let flashloan_amount = supplied_amount / 2; // half of the pool = 50/2 = 25
+        let flashloan_receipts =
+            flashloan_logic::flash_loan(
+                flashloan_user,
+                signer::address_of(flashloan_user),
+                vector[underlying_token_address],
+                vector[(flashloan_amount as u256)],
+                vector[user_config::get_interest_rate_mode_none()], // interest rate modes
+                signer::address_of(flashloan_user),
+                0 // referral code
+            );
+
+        // check intermediate underlying balance
+        let flashloan_taker_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_user), underlying_token_address
+            );
+        assert!(
+            flashloan_taker_underlying_balance == supplier_balance + flashloan_amount,
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user repays flashloan + premium
+        flashloan_logic::pay_flash_loan_complex(flashloan_user, flashloan_receipts);
+
+        // check intermediate underlying balance for flashloan user
+        let flashloan_taken_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_user), underlying_token_address
+            );
+        let flashloan_paid_premium = 3; // 10% * 25 = 2.5 = 3
+        assert!(
+            flashloan_taken_underlying_balance
+                == supplier_balance - flashloan_paid_premium,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_flashloan_events = emitted_events<flashloan_logic::FlashLoan>();
+        assert!(vector::length(&emitted_flashloan_events) == 1, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            flashloan_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// User takes and repays a single asset flashloan being authorized
+    fun complex_flashloan_same_payer_receiver_authorized(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        flashloan_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // grant the flashloan user an authorized borrower role
+        acl_manage::add_flash_borrower(
+            aave_role_super_admin, signer::address_of(flashloan_user)
+        );
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // set flashloan premium
+        let flashloan_premium_total = get_percentage_factor() / 10; // 100/10 = 10%
+        let flashloan_premium_to_protocol = get_percentage_factor() / 20; // 100/20 = 5%
+        pool::set_flashloan_premiums_test(
+            (flashloan_premium_total as u128), (flashloan_premium_to_protocol as u128)
+        );
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // ----> mint underlying for the flashloan user
+        // mint 100 underlying tokens for the flashloan user
+        let mint_receiver_address = signer::address_of(flashloan_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            100,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == 100, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user supplies
+        // flashloan user supplies the underlying token to fill the pool before attempting to take a flashloan
+        let supply_receiver_address = signer::address_of(flashloan_user);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            flashloan_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+
+        // > check flashloan user (supplier) balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user takes a flashloan
+        let flashloan_amount = supplied_amount / 2; // half of the pool = 50/2 = 25
+        let flashloan_receipts =
+            flashloan_logic::flash_loan(
+                flashloan_user,
+                signer::address_of(flashloan_user),
+                vector[underlying_token_address],
+                vector[(flashloan_amount as u256)],
+                vector[user_config::get_interest_rate_mode_none()], // interest rate modes
+                signer::address_of(flashloan_user),
+                0 // referral code
+            );
+
+        // check intermediate underlying balance
+        let flashloan_taker_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_user), underlying_token_address
+            );
+        assert!(
+            flashloan_taker_underlying_balance == supplier_balance + flashloan_amount,
+            TEST_SUCCESS
+        );
+
+        // ----> flashloan user repays flashloan + premium
+        flashloan_logic::pay_flash_loan_complex(flashloan_user, flashloan_receipts);
+
+        // check intermediate underlying balance for flashloan user
+        let flashloan_taken_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_user), underlying_token_address
+            );
+        let flashloan_paid_premium = 0; // because the user is authorized flash borrower
+        assert!(
+            flashloan_taken_underlying_balance
+                == supplier_balance - flashloan_paid_premium,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_flashloan_events = emitted_events<flashloan_logic::FlashLoan>();
+        assert!(vector::length(&emitted_flashloan_events) == 1, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @std,
+            flashloan_payer = @0x042,
+            flashloan_receiver = @0x043,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// User takes a complex flashloan which is received by someone else. Either user or taker then repays the complex flashloan
+    fun complex_flashloan_different_payer_receiver(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        flashloan_payer: &signer,
+        flashloan_receiver: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, true);
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // set flashloan premium
+        let flashloan_premium_total = get_percentage_factor() / 10; // 100/10 = 10%
+        let flashloan_premium_to_protocol = get_percentage_factor() / 20; // 100/20 = 5%
+        pool::set_flashloan_premiums_test(
+            (flashloan_premium_total as u128), (flashloan_premium_to_protocol as u128)
+        );
+
+        // init user configs for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_payer),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        create_user_config_for_reserve(
+            signer::address_of(flashloan_receiver),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // ----> mint underlying for flashloan payer and receiver
+        // mint 100 underlying tokens for flashloan payer and receiver
+        let mint_amount: u64 = 100;
+        let users = vector[
+            signer::address_of(flashloan_payer),
+            signer::address_of(flashloan_receiver)
+        ];
+        for (i in 0..vector::length(&users)) {
+            mock_underlying_token_factory::mint(
+                underlying_tokens_admin,
+                *vector::borrow(&users, i),
+                mint_amount,
+                underlying_token_address
+            );
+            let initial_user_balance =
+                mock_underlying_token_factory::balance_of(
+                    *vector::borrow(&users, i), underlying_token_address
+                );
+            // assert user balance of underlying
+            assert!(initial_user_balance == mint_amount, TEST_SUCCESS);
+        };
+
+        // ----> flashloan payer supplies
+        // flashloan payer supplies the underlying token to fill the pool before attempting to take a flashloan
+        let supply_receiver_address = signer::address_of(flashloan_payer);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            flashloan_payer,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check flashloan payer balance of underlying
+        let initial_payer_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_payer), underlying_token_address
+            );
+        assert!(
+            initial_payer_balance == mint_amount - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check flashloan payer a_token balance after supply
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(flashloan_payer), a_token_address
+            );
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+
+        let initial_receiver_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_receiver), underlying_token_address
+            );
+
+        // ----> flashloan payer takes a flashloan but receiver is different
+        let flashloan_amount = supplied_amount / 2; // half of the pool = 50/2 = 25
+        let flashloan_receipts =
+            flashloan_logic::flash_loan(
+                flashloan_payer,
+                signer::address_of(flashloan_receiver),
+                vector[underlying_token_address],
+                vector[(flashloan_amount as u256)],
+                vector[user_config::get_interest_rate_mode_none()], // interest rate modes
+                signer::address_of(flashloan_payer), // on behalf of
+                0 // referral code
+            );
+
+        // check intermediate underlying balance for flashloan payer
+        let flashloan_payer_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_payer), underlying_token_address
+            );
+        assert!(
+            flashloan_payer_underlying_balance == initial_payer_balance, TEST_SUCCESS
+        ); // same balance as before
+
+        // check intermediate underlying balance for flashloan receiver
+        let flashloan_receiver_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_receiver), underlying_token_address
+            );
+        assert!(
+            flashloan_receiver_underlying_balance
+                == initial_receiver_balance + flashloan_amount,
+            TEST_SUCCESS
+        ); // increased balance due to flashloan
+
+        // ----> receiver repays flashloan + premium
+        flashloan_logic::pay_flash_loan_complex(flashloan_receiver, flashloan_receipts);
+
+        // check intermediate underlying balance for flashloan payer
+        let flashloan_payer_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_payer), underlying_token_address
+            );
+        assert!(
+            flashloan_payer_underlying_balance == initial_payer_balance, TEST_SUCCESS
+        );
+
+        // check intermediate underlying balance for flashloan receiver
+        let flashloan_receiver_underlying_balance =
+            mock_underlying_token_factory::balance_of(
+                signer::address_of(flashloan_receiver), underlying_token_address
+            );
+        let flashloan_paid_premium = 3; // 10% * 25 = 2.5 = 3
+        assert!(
+            flashloan_receiver_underlying_balance
+                == initial_receiver_balance - flashloan_paid_premium,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_withdraw_events = emitted_events<flashloan_logic::FlashLoan>();
+        assert!(vector::length(&emitted_withdraw_events) == 1, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/generic_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/generic_logic_tests.move
@@ -1,0 +1,19 @@
+#[test_only]
+module aave_pool::generic_logic_tests {
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+    use std::features::change_feature_flags_for_testing;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(_pool = @aave_pool, aave_std = @std, aptos_framework = @0x1)]
+    fun test_generic_logic(
+        _pool: &signer, aave_std: &signer, aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/isolation_mode_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/isolation_mode_logic_tests.move
@@ -1,0 +1,20 @@
+#[test_only]
+module aave_pool::isolation_mode_logic_tests {
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+    use std::features::change_feature_flags_for_testing;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(_pool = @aave_pool, aave_std = @std, aptos_framework = @0x1)]
+    fun test_isolation_mode_logic(
+        _pool: &signer, aave_std: &signer, aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/liquidation_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/liquidation_logic_tests.move
@@ -1,0 +1,19 @@
+#[test_only]
+module aave_pool::liquidation_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(signer_account = @aave_pool, aave_std = @std, aptos_framework = @0x1)]
+    fun test_liquidation_logic(
+        signer_account: &signer, aave_std: &signer, aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/supply_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/supply_logic_tests.move
@@ -1,0 +1,947 @@
+#[test_only]
+module aave_pool::supply_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option::Self;
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+    use aave_acl::acl_manage::Self;
+    use aave_config::reserve_config;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy::Self;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::collector;
+    use aave_pool::emode_logic::{Self, configure_emode_category};
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::pool::{
+        get_reserve_data,
+        get_reserve_id,
+        get_reserve_liquidity_index,
+        test_set_reserve_configuration
+    };
+    use aave_pool::pool_configurator;
+    use aave_pool::pool_tests::create_user_config_for_reserve;
+    use aave_pool::supply_logic::Self;
+    use aave_pool::token_base::Self;
+    use aave_pool::variable_debt_token_factory;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// Reserve allows borrowing and being used as collateral.
+    /// User config allows only borrowing for the reserve.
+    /// User supplies and withdraws parts of the supplied amount
+    fun test_supply_partial_withdraw(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, false); // NOTE: disable flashloan enabled
+            reserve_config::set_ltv(&mut reserve_config_new, 5000); // NOTE: set ltv
+            reserve_config::set_debt_ceiling(&mut reserve_config_new, 0); // NOTE: set no debt ceiling
+            reserve_config::set_borrowable_in_isolation(&mut reserve_config_new, false); // NOTE: set no borrowable in isolation
+            reserve_config::set_siloed_borrowing(&mut reserve_config_new, false); // NOTE: set no sillowed borrowing
+            reserve_config::set_borrowing_enabled(&mut reserve_config_new, true); // NOTE: set borrowing enabled
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(supply_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(false),
+            option::some(true)
+        );
+
+        // =============== MINT UNDERLYING FOR USER ================= //
+        // mint 100 underlying tokens for the user
+        let mint_receiver_address = signer::address_of(supply_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            100,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == 100, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // =============== USER SUPPLY ================= //
+        // user supplies the underlying token
+        let supply_receiver_address = signer::address_of(supply_user);
+        let supplied_amount: u64 = 10;
+        supply_logic::supply(
+            supply_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+        // > check supplier balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+        // > check a_token underlying balance
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let atoken_acocunt_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        let underlying_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_acocunt_address, underlying_token_address
+            );
+        assert!(underlying_acocunt_balance == supplied_amount, TEST_SUCCESS);
+        // > check user a_token balance after supply
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+
+        // =============== USER WITHDRAWS ================= //
+        // user withdraws a small amount of the supplied amount
+        let amount_to_withdraw = 4;
+        supply_logic::withdraw(
+            supply_user,
+            underlying_token_address,
+            (amount_to_withdraw as u256),
+            supply_receiver_address
+        );
+
+        // > check a_token balance of underlying
+        let atoken_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_acocunt_address, underlying_token_address
+            );
+        assert!(
+            atoken_acocunt_balance == supplied_amount - amount_to_withdraw,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+        // > check user a_token balance after withdrawal
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount - amount_to_withdraw as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+        // > check users underlying tokens balance
+        let supplier_underlying_balance_after_withdraw =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_underlying_balance_after_withdraw
+                == initial_user_balance - supplied_amount + amount_to_withdraw,
+            TEST_SUCCESS
+        );
+        // > check emitted events
+        let emitted_withdraw_events = emitted_events<supply_logic::Withdraw>();
+        assert!(vector::length(&emitted_withdraw_events) == 1, TEST_SUCCESS);
+        let emitted_reserve_collecteral_disabled_events =
+            emitted_events<supply_logic::ReserveUsedAsCollateralDisabled>();
+        assert!(
+            vector::length(&emitted_reserve_collecteral_disabled_events) == 0,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// Reserve allows borrowing and being used as collateral.
+    /// User config allows borrowing and collateral.
+    /// User supplies and withdraws the entire amount
+    fun test_supply_full_collateral_withdraw(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // define an emode cat for reserve and user
+        let emode_cat_id: u8 = 1;
+        // configure an emode category
+        let ltv: u16 = 100;
+        let liquidation_threshold: u16 = 200;
+        let liquidation_bonus: u16 = 300;
+        let price_source: address = signer::address_of(aave_oracle);
+        let label = utf8(b"MODE1");
+        configure_emode_category(
+            emode_cat_id,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            price_source,
+            label
+        );
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, false); // NOTE: disable flashloan enabled
+            reserve_config::set_ltv(&mut reserve_config_new, 5000); // NOTE: set ltv
+            reserve_config::set_debt_ceiling(&mut reserve_config_new, 0); // NOTE: set no debt ceiling
+            reserve_config::set_borrowable_in_isolation(&mut reserve_config_new, false); // NOTE: set no borrowable in isolation
+            reserve_config::set_siloed_borrowing(&mut reserve_config_new, false); // NOTE: set no sillowed borrowing
+            reserve_config::set_borrowing_enabled(&mut reserve_config_new, true); // NOTE: set borrowing enabled
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // register asset with oracle feed_id
+        aave_oracle::oracle::set_asset_feed_id(
+            aave_pool,
+            underlying_token_address,
+            aave_oracle::oracle_tests::get_test_feed_id()
+        );
+
+        // set underlying emode category
+        pool_configurator::set_asset_emode_category(
+            aave_pool, underlying_token_address, emode_cat_id
+        );
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(supply_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(true),
+            option::some(true)
+        );
+
+        // =============== MINT UNDERLYING FOR USER ================= //
+        // set user emode
+        emode_logic::set_user_emode(supply_user, emode_cat_id);
+
+        // mint 100 underlying tokens for the user
+        let mint_receiver_address = signer::address_of(supply_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            100,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == 100, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // =============== USER SUPPLY ================= //
+        // user supplies the underlying token
+        let supply_receiver_address = signer::address_of(supply_user);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            supply_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+        // > check supplier balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+        // > check underlying balance of atoken
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let atoken_account_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        let underlying_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_account_address, underlying_token_address
+            );
+        assert!(underlying_acocunt_balance == supplied_amount, TEST_SUCCESS);
+        // > check user a_token balance after supply
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+
+        // =============== USER WITHDRAWS ================= //
+        // user withdraws his entire supply
+        let amount_to_withdraw = 50;
+        supply_logic::withdraw(
+            supply_user,
+            underlying_token_address,
+            (amount_to_withdraw as u256),
+            supply_receiver_address
+        );
+
+        // > check underlying balance of a_token account
+        let atoken_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_account_address, underlying_token_address
+            );
+        assert!(atoken_acocunt_balance == 0, TEST_SUCCESS);
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+        // > check user a_token balance after withdrawal
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == 0, TEST_SUCCESS);
+        // > check users underlying tokens balance
+        let supplier_underlying_balance_after_withdraw =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_underlying_balance_after_withdraw
+                == initial_user_balance - supplied_amount + amount_to_withdraw,
+            TEST_SUCCESS
+        );
+        // > check emitted events
+        let emitted_withdraw_events = emitted_events<supply_logic::Withdraw>();
+        assert!(vector::length(&emitted_withdraw_events) == 1, TEST_SUCCESS);
+        let emitted_reserve_collecteral_disabled_events =
+            emitted_events<supply_logic::ReserveUsedAsCollateralDisabled>();
+        assert!(
+            vector::length(&emitted_reserve_collecteral_disabled_events) == 1,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            aptos_std = @aptos_std,
+            supply_user = @0x042,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    /// Reserve allows borrowing and being used as collateral.
+    /// User config allows borrowing and collateral.
+    /// User supplies and withdraws the entire amount
+    /// with ltv and no debt ceiling, and not using as collateral already
+    fun test_supply_use_as_collateral(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        aptos_std: &signer,
+        supply_user: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_std);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aptos_std, vector[26], vector[]);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // define an emode cat for reserve and user
+        let emode_cat_id: u8 = 1;
+        // configure an emode category
+        let ltv: u16 = 100;
+        let liquidation_threshold: u16 = 200;
+        let liquidation_bonus: u16 = 300;
+        let price_source: address = signer::address_of(aave_oracle);
+        let label = utf8(b"MODE1");
+        configure_emode_category(
+            emode_cat_id,
+            ltv,
+            liquidation_threshold,
+            liquidation_bonus,
+            price_source,
+            label
+        );
+
+        // prepare pool reserves
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_assets = 3;
+        for (i in 0..num_assets) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            // prepare the data for reserve's atokens and variable tokens
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // create reserve configurations
+        for (j in 0..num_assets) {
+            let reserve_config_new = reserve_config::init();
+            let decimals = (
+                *vector::borrow(&underlying_asset_decimals, (j as u64)) as u256
+            );
+            reserve_config::set_decimals(&mut reserve_config_new, decimals);
+            reserve_config::set_active(&mut reserve_config_new, true);
+            reserve_config::set_frozen(&mut reserve_config_new, false);
+            reserve_config::set_paused(&mut reserve_config_new, false);
+            reserve_config::set_flash_loan_enabled(&mut reserve_config_new, false); // NOTE: disable flashloan enabled
+            reserve_config::set_ltv(&mut reserve_config_new, 5000); // NOTE: set ltv
+            reserve_config::set_debt_ceiling(&mut reserve_config_new, 0); // NOTE: set no debt ceiling
+            reserve_config::set_borrowable_in_isolation(&mut reserve_config_new, false); // NOTE: set no borrowable in isolation
+            reserve_config::set_siloed_borrowing(&mut reserve_config_new, false); // NOTE: set no sillowed borrowing
+            reserve_config::set_borrowing_enabled(&mut reserve_config_new, true); // NOTE: set borrowing enabled
+            test_set_reserve_configuration(
+                *vector::borrow(&underlying_assets, (j as u64)), reserve_config_new
+            );
+        };
+
+        // get one underlying asset data
+        let underlying_token_address = *vector::borrow(&underlying_assets, 0);
+
+        // set underlying emode category
+        pool_configurator::set_asset_emode_category(
+            aave_pool, underlying_token_address, emode_cat_id
+        );
+
+        // get the reserve config for it
+        let reserve_data = get_reserve_data(underlying_token_address);
+
+        // init user config for reserve index
+        create_user_config_for_reserve(
+            signer::address_of(supply_user),
+            (get_reserve_id(&reserve_data) as u256),
+            option::some(true),
+            option::some(false) // NOTE: not using any as collateral already
+        );
+
+        // =============== MINT UNDERLYING FOR USER ================= //
+        // mint 100 underlying tokens for the user
+        let mint_receiver_address = signer::address_of(supply_user);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            mint_receiver_address,
+            100,
+            underlying_token_address
+        );
+        let initial_user_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        // assert user balance of underlying
+        assert!(initial_user_balance == 100, TEST_SUCCESS);
+        // assert underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // =============== USER SUPPLY ================= //
+        // user supplies the underlying token
+        let supply_receiver_address = signer::address_of(supply_user);
+        let supplied_amount: u64 = 50;
+        supply_logic::supply(
+            supply_user,
+            underlying_token_address,
+            (supplied_amount as u256),
+            supply_receiver_address,
+            0
+        );
+
+        // > check emitted events
+        let emitted_supply_events = emitted_events<supply_logic::Supply>();
+        assert!(vector::length(&emitted_supply_events) == 1, TEST_SUCCESS);
+        let emitted_reserve_used_as_collateral_events =
+            emitted_events<supply_logic::ReserveUsedAsCollateralEnabled>();
+        assert!(
+            vector::length(&emitted_reserve_used_as_collateral_events) == 1,
+            TEST_SUCCESS
+        );
+        // > check supplier balance of underlying
+        let supplier_balance =
+            mock_underlying_token_factory::balance_of(
+                mint_receiver_address, underlying_token_address
+            );
+        assert!(
+            supplier_balance == initial_user_balance - supplied_amount,
+            TEST_SUCCESS
+        );
+        // > check underlying supply
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+        // > check a_token balance of underlying
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool),
+                *vector::borrow(&atokens_symbols, 0)
+            );
+        let atoken_account_address =
+            a_token_factory::get_token_account_address(a_token_address);
+        let atoken_acocunt_balance =
+            mock_underlying_token_factory::balance_of(
+                atoken_account_address, underlying_token_address
+            );
+        assert!(atoken_acocunt_balance == supplied_amount, TEST_SUCCESS);
+        // > check user a_token balance after supply
+        let supplied_amount_scaled =
+            wad_ray_math::ray_div(
+                (supplied_amount as u256),
+                (get_reserve_liquidity_index(&reserve_data) as u256)
+            );
+        let supplier_a_token_balance =
+            a_token_factory::scaled_balance_of(
+                signer::address_of(supply_user), a_token_address
+            );
+        assert!(supplier_a_token_balance == supplied_amount_scaled, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-logic/user_logic_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-logic/user_logic_tests.move
@@ -1,0 +1,19 @@
+#[test_only]
+module aave_pool::user_logic_tests {
+    use std::features::change_feature_flags_for_testing;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(_signer_account = @aave_pool, aave_std = @std, aptos_framework = @0x1)]
+    fun test_user_logic(
+        _signer_account: &signer, aave_std: &signer, aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-periphery/coin_migrator_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-periphery/coin_migrator_tests.move
@@ -1,0 +1,295 @@
+#[test_only]
+module aave_pool::coin_migrator_tests {
+    use std::signer;
+    use std::option;
+    use std::string::{Self, String};
+    use aptos_framework::account::{Self};
+    use aptos_framework::coin::{Self};
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::aggregator_factory::initialize_aggregator_factory_for_test;
+    use aptos_framework::object;
+    use aptos_framework::primary_fungible_store;
+    use aave_pool::coin_migrator::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    struct GenericAptosCoin {}
+
+    struct GenericAptosCoinRefs has key {
+        burn_ref: coin::BurnCapability<GenericAptosCoin>,
+        freeze_ref: coin::FreezeCapability<GenericAptosCoin>,
+        mint_ref: coin::MintCapability<GenericAptosCoin>
+    }
+
+    public fun initialize_aptos_coin(
+        framework: &signer,
+        coin_creator: &signer,
+        decimals: u8,
+        monitor_supply: bool,
+        coin_name: String,
+        coin_symbol: String
+    ) {
+        initialize_aggregator_factory_for_test(framework);
+
+        let (burn_ref, freeze_ref, mint_ref) =
+            coin::initialize<GenericAptosCoin>(
+                coin_creator,
+                coin_name,
+                coin_symbol,
+                decimals,
+                monitor_supply
+            );
+        move_to(
+            coin_creator,
+            GenericAptosCoinRefs { burn_ref, freeze_ref, mint_ref }
+        );
+    }
+
+    inline fun get_coin_refs(account: &signer): &GenericAptosCoinRefs {
+        borrow_global<GenericAptosCoinRefs>(signer::address_of(account))
+    }
+
+    #[
+        test(
+            framework = @aptos_framework,
+            aave_pool = @aave_pool,
+            alice = @0x123,
+            bob = @0x234
+        )
+    ]
+    fun test_coin_fa_conversion(
+        framework: &signer,
+        aave_pool: &signer,
+        alice: &signer,
+        bob: &signer
+    ) acquires GenericAptosCoinRefs {
+        // init a coin conversion map
+        coin::create_coin_conversion_map(framework);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(alice));
+        account::create_account_for_test(signer::address_of(bob));
+
+        // initialize old-style aptos coin
+        let coin_name = string::utf8(b"Generic Coin");
+        let coin_symbol = string::utf8(b"GCC");
+        let coin_decimals = 2;
+
+        initialize_aptos_coin(
+            framework,
+            aave_pool,
+            coin_decimals,
+            true,
+            coin_name,
+            coin_symbol
+        );
+
+        // register the alice and bob
+        coin::register<GenericAptosCoin>(alice);
+        coin::register<GenericAptosCoin>(bob);
+
+        // mint some coins
+        let alice_init_balance = 100;
+        let coins_minted =
+            coin::mint<GenericAptosCoin>(
+                alice_init_balance, &get_coin_refs(aave_pool).mint_ref
+            );
+
+        // deposit to alice
+        coin::deposit(signer::address_of(alice), coins_minted);
+
+        // now alice withdraws
+        let withdrawn_amount = 10;
+        let coin_to_wrap = coin::withdraw<GenericAptosCoin>(alice, withdrawn_amount);
+        assert!(coin::value(&coin_to_wrap) == withdrawn_amount, TEST_SUCCESS);
+        // assert Alice balance: before we have converted the coins to fa, the coins balance is correctly displayed
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(alice))
+                == alice_init_balance - withdrawn_amount,
+            TEST_SUCCESS
+        );
+
+        // ...and converts the coins into a fa
+        let wrapped_fa = coin::coin_to_fungible_asset<GenericAptosCoin>(coin_to_wrap);
+        assert!(fungible_asset::amount(&wrapped_fa) == withdrawn_amount, TEST_SUCCESS);
+
+        // get the metadata needed for the new fa, do assertions
+        let wrapped_fa_meta =
+            option::destroy_some(coin::paired_metadata<GenericAptosCoin>());
+        let wrapped_fa_address = object::object_address(&wrapped_fa_meta);
+        let wrapped_fa_meta2 = fungible_asset::metadata_from_asset(&wrapped_fa);
+        assert!(wrapped_fa_meta == wrapped_fa_meta2, TEST_SUCCESS);
+        let fa_supply = fungible_asset::supply(wrapped_fa_meta);
+        let fa_decimals = fungible_asset::decimals(wrapped_fa_meta);
+        let fa_symbol = fungible_asset::symbol(wrapped_fa_meta);
+        let fa_name = fungible_asset::name(wrapped_fa_meta);
+        let fa_balance = fungible_asset::balance(wrapped_fa_meta);
+        assert!(fa_supply == option::some((withdrawn_amount as u128)), TEST_SUCCESS);
+        assert!(fa_decimals == coin_decimals, TEST_SUCCESS);
+        assert!(fa_symbol == coin_symbol, TEST_SUCCESS);
+        assert!(fa_name == coin_name, TEST_SUCCESS);
+        assert!(fa_balance == 0, TEST_SUCCESS);
+
+        // get data for alice and bob wallet for the FungibleAsset
+        let alice_wallet =
+            primary_fungible_store::ensure_primary_store_exists(
+                signer::address_of(alice), wrapped_fa_meta
+            );
+        let bob_wallet =
+            primary_fungible_store::ensure_primary_store_exists(
+                signer::address_of(bob), wrapped_fa_meta
+            );
+
+        // deposit the wrapped FungibleAsset into Alice wallet
+        fungible_asset::deposit(alice_wallet, wrapped_fa);
+
+        // assert alice has both init balance coins and the converted fas
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(alice))
+                == alice_init_balance,
+            TEST_SUCCESS
+        );
+        assert!(
+            fungible_asset::balance(alice_wallet) == withdrawn_amount,
+            TEST_SUCCESS
+        );
+
+        // move 1 fa from Alice to bob wallet
+        let transfer_amount = 1;
+        fungible_asset::transfer(
+            alice,
+            alice_wallet,
+            bob_wallet,
+            transfer_amount
+        );
+
+        // assert alice has both 99 coins and 1 fa
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(alice))
+                == alice_init_balance - transfer_amount,
+            TEST_SUCCESS
+        );
+        assert!(
+            fungible_asset::balance(alice_wallet) == withdrawn_amount - transfer_amount,
+            TEST_SUCCESS
+        );
+
+        // assert bob has both 1 coin and 1 fa
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(bob)) == transfer_amount,
+            TEST_SUCCESS
+        );
+        assert!(
+            fungible_asset::balance(bob_wallet) == transfer_amount,
+            TEST_SUCCESS
+        );
+
+        // now bob transfers his 1 coin
+        // let coins_back = coin::withdraw<GenericAptosCoin>(bob, 1);
+        // print(&coin::balance<GenericAptosCoin>(signer::address_of(bob)));
+        // print(&fungible_asset::balance(bob_wallet));
+        // coin::deposit(signer::address_of(alice), coins_back);
+        // print(&coin::balance<GenericAptosCoin>(signer::address_of(alice)));
+        // print(&fungible_asset::balance(alice_wallet));
+
+        // now bob transfers his 1 fa
+        fungible_asset::transfer(bob, bob_wallet, alice_wallet, 1);
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(bob)) == 0,
+            TEST_SUCCESS
+        );
+        assert!(fungible_asset::balance(bob_wallet) == 0, TEST_SUCCESS);
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(alice))
+                == alice_init_balance,
+            TEST_SUCCESS
+        );
+        assert!(fungible_asset::balance(alice_wallet) == withdrawn_amount, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            framework = @aptos_framework,
+            aave_pool = @aave_pool,
+            alice = @0x123,
+            bob = @0x234
+        )
+    ]
+    fun test_coin_migrator(
+        framework: &signer,
+        aave_pool: &signer,
+        alice: &signer,
+        bob: &signer
+    ) acquires GenericAptosCoinRefs {
+
+        // init a coin conversion map
+        coin::create_coin_conversion_map(framework);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(alice));
+        account::create_account_for_test(signer::address_of(bob));
+
+        // initialize old-style aptos coin
+        let coin_name = string::utf8(b"Generic Coin");
+        let coin_symbol = string::utf8(b"GCC");
+        let coin_decimals = 2;
+
+        initialize_aptos_coin(
+            framework,
+            aave_pool,
+            coin_decimals,
+            true,
+            coin_name,
+            coin_symbol
+        );
+
+        // register the alice and bob
+        coin::register<GenericAptosCoin>(alice);
+        coin::register<GenericAptosCoin>(bob);
+
+        // mint some coins
+        let alice_init_balance = 100;
+        let coins_minted =
+            coin::mint<GenericAptosCoin>(
+                alice_init_balance, &get_coin_refs(aave_pool).mint_ref
+            );
+
+        // deposit to alice
+        coin::deposit(signer::address_of(alice), coins_minted);
+
+        // Alice converts her coins for fas
+        coin_migrator::coin_to_fa<GenericAptosCoin>(alice, alice_init_balance);
+
+        // use coin migrator to obtain the fa address
+        let fa_address = coin_migrator::get_fa_address<GenericAptosCoin>();
+
+        // get metadata and alice fung. asset store
+        let wrapped_fa_meta = object::address_to_object<Metadata>(fa_address);
+        let alice_wallet =
+            primary_fungible_store::ensure_primary_store_exists(
+                signer::address_of(alice), wrapped_fa_meta
+            );
+
+        // assert
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(alice))
+                == alice_init_balance,
+            TEST_SUCCESS
+        );
+        assert!(
+            fungible_asset::balance(alice_wallet) == alice_init_balance, TEST_SUCCESS
+        );
+
+        // now alice converts her fas back to coins
+        coin_migrator::fa_to_coin<GenericAptosCoin>(alice, alice_init_balance);
+
+        // assert
+        assert!(
+            coin::balance<GenericAptosCoin>(signer::address_of(alice))
+                == alice_init_balance,
+            TEST_SUCCESS
+        );
+        assert!(fungible_asset::balance(alice_wallet) == 0, TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-periphery/coin_wrapper_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-periphery/coin_wrapper_tests.move
@@ -1,0 +1,242 @@
+// #[test_only]
+// module aave_pool::coin_wrapper_tests {
+//     use std::signer;
+//     use aptos_framework::account::{Self};
+//     use aptos_framework::aptos_account;
+//     use aptos_framework::coin::{Self};
+//     use aptos_framework::fungible_asset::{Self};
+//     use aptos_framework::aggregator_factory::initialize_aggregator_factory_for_test;
+//     use std::string::{Self, String};
+//     use aave_pool::package_manager::Self;
+//     use std::option;
+//     use aave_pool::coin_wrapper::{
+//         initialize,
+//         test_unwrap,
+//         test_wrap,
+//         wrapper_address,
+//         test_get_original,
+//     };
+//
+//     const TEST_SUCCESS: u64 = 1;
+//     const TEST_FAILED: u64 = 2;
+//
+//     struct GenericAptosCoin {}
+//
+//     struct GenericAptosCoinRefs has key {
+//         burn_ref: coin::BurnCapability<GenericAptosCoin>,
+//         freeze_ref: coin::FreezeCapability<GenericAptosCoin>,
+//         mint_ref: coin::MintCapability<GenericAptosCoin>,
+//     }
+//
+//     public fun initialize_aptos_coin(
+//         framework: &signer,
+//         coin_creator: &signer,
+//         decimals: u8,
+//         monitor_supply: bool,
+//         _coin_name: String,
+//         _coin_symbol: String,
+//     ) {
+//         initialize_aggregator_factory_for_test(framework);
+//
+//         let (burn_ref, freeze_ref, mint_ref) =
+//             coin::initialize<GenericAptosCoin>(
+//                 coin_creator,
+//                 string::utf8(b"Generic Coin"),
+//                 string::utf8(b"GCC"),
+//                 decimals,
+//                 monitor_supply,
+//             );
+//         move_to(
+//             coin_creator,
+//             GenericAptosCoinRefs { burn_ref, freeze_ref, mint_ref, },
+//         );
+//     }
+//
+//     inline fun get_coin_refs(account: &signer,): &GenericAptosCoinRefs {
+//         borrow_global<GenericAptosCoinRefs>(signer::address_of(account))
+//     }
+//
+//     #[test(deployer = @resource_pm)]
+//     fun test_can_get_signer_package_manager(deployer: &signer) {
+//         package_manager::initialize_for_test(deployer);
+//         let package_deployer_address =
+//             signer::address_of(&package_manager::get_signer_test());
+//         assert!(package_deployer_address == signer::address_of(deployer), TEST_SUCCESS);
+//     }
+//
+//     #[test(deployer = @resource_pm)]
+//     public fun test_can_set_get_signer_package_manager(deployer: &signer) {
+//         package_manager::initialize_for_test(deployer);
+//         package_manager::add_address_test(string::utf8(b"test"), @0xdeadbeef);
+//         assert!(
+//             package_manager::get_address_test(string::utf8(b"test")) == @0xdeadbeef,
+//             TEST_SUCCESS,
+//         );
+//     }
+//
+//     #[test(framework = @aptos_framework, aave_periphery = @aave_pool, deployer = @resource_pm, _aave_pool = @aave_pool, coin_holder = @0x123, _receiver = @0x234)]
+//     fun test_coin_wrapper(
+//         framework: &signer,
+//         aave_periphery: &signer,
+//         deployer: &signer,
+//         _aave_pool: &signer,
+//         coin_holder: &signer,
+//         _receiver: &signer
+//     ) acquires GenericAptosCoinRefs {
+//         // init the package manager
+//         package_manager::initialize_for_test(deployer);
+//
+//         // init the coin wrapper package
+//         initialize();
+//
+//         // initialize old-style aptos coin
+//         let coinholder_addr = signer::address_of(coin_holder);
+//         account::create_account_for_test(coinholder_addr);
+//         let coin_name = string::utf8(b"Generic Coin");
+//         let coin_symbol = string::utf8(b"GCC");
+//         let coin_decimals = 2;
+//
+//         initialize_aptos_coin(
+//             framework,
+//             aave_periphery,
+//             coin_decimals,
+//             true,
+//             coin_name,
+//             coin_symbol,
+//         );
+//
+//         // register the holder
+//         coin::register<GenericAptosCoin>(coin_holder);
+//
+//         // mint some coins
+//         let token_holder_initial_balance = 100;
+//         let coins_minted =
+//             coin::mint<GenericAptosCoin>(
+//                 token_holder_initial_balance, &get_coin_refs(aave_periphery).mint_ref
+//             );
+//
+//         // deposit to holder
+//         coin::deposit(coinholder_addr, coins_minted);
+//
+//         // withdraw some of the generic coin
+//         let coin_withdraw_amount = 20;
+//         let withdrawn_coins =
+//             coin::withdraw<GenericAptosCoin>(coin_holder, coin_withdraw_amount);
+//         // check the coin balance
+//         assert!(coin::value(&withdrawn_coins) == coin_withdraw_amount, TEST_SUCCESS);
+//         assert!(
+//             coin::balance<GenericAptosCoin>(signer::address_of(coin_holder))
+//                 == token_holder_initial_balance - coin_withdraw_amount,
+//             TEST_SUCCESS,
+//         );
+//
+//         // coin holder now warps the coin using the wrapper and gets an equivalent fa
+//         let wrapped_fa = test_wrap<GenericAptosCoin>(withdrawn_coins);
+//         // check the wrapper address balance
+//         assert!(
+//             coin::balance<GenericAptosCoin>(wrapper_address()) == coin_withdraw_amount,
+//             TEST_SUCCESS,
+//         );
+//
+//         // run assertions on the generated equivalent fa
+//         assert!(fungible_asset::amount(&wrapped_fa) == coin_withdraw_amount, TEST_SUCCESS);
+//         let fa_metadata = fungible_asset::metadata_from_asset(&wrapped_fa);
+//         let fa_supply = fungible_asset::supply(fa_metadata);
+//         let fa_decimals = fungible_asset::decimals(fa_metadata);
+//         let fa_symbol = fungible_asset::symbol(fa_metadata);
+//         assert!(fa_supply == option::some((coin_withdraw_amount as u128)), TEST_SUCCESS);
+//         assert!(fa_decimals == coin_decimals, TEST_SUCCESS);
+//         assert!(fa_symbol == coin_symbol, TEST_SUCCESS);
+//
+//         // now unwrap the fa and get back the coin
+//         let unwrapped_coins = test_unwrap<GenericAptosCoin>(wrapped_fa);
+//
+//         // check the wrapper address balance
+//         assert!(coin::balance<GenericAptosCoin>(wrapper_address()) == 0, TEST_SUCCESS);
+//
+//         // run assertions on the coin
+//         assert!(coin::value(&unwrapped_coins) == coin_withdraw_amount, TEST_SUCCESS);
+//         assert!(coin::decimals<GenericAptosCoin>() == coin_decimals, TEST_SUCCESS);
+//         assert!(coin::symbol<GenericAptosCoin>() == coin_symbol, TEST_SUCCESS);
+//         assert!(
+//             coin::supply<GenericAptosCoin>()
+//                 == option::some((token_holder_initial_balance as u128)),
+//             TEST_SUCCESS,
+//         );
+//
+//         // send the coins back to the original coin holder
+//         aptos_account::deposit_coins(signer::address_of(coin_holder), unwrapped_coins);
+//         // check the original coin holder balance
+//         assert!(
+//             coin::balance<GenericAptosCoin>(signer::address_of(coin_holder))
+//                 == token_holder_initial_balance,
+//             TEST_SUCCESS,
+//         );
+//     }
+//
+//     #[test(framework = @aptos_framework, aave_periphery = @aave_pool, deployer = @resource_pm, _aave_pool = @aave_pool, coin_holder = @0x123, _receiver = @0x234)]
+//     fun test_get_orig(
+//         framework: &signer,
+//         aave_periphery: &signer,
+//         deployer: &signer,
+//         _aave_pool: &signer,
+//         coin_holder: &signer,
+//         _receiver: &signer
+//     ) acquires GenericAptosCoinRefs {
+//         // init the package manager
+//         package_manager::initialize_for_test(deployer);
+//
+//         // init the coin wrapper package
+//         initialize();
+//
+//         // initialize old-style aptos coin
+//         let coinholder_addr = signer::address_of(coin_holder);
+//         account::create_account_for_test(coinholder_addr);
+//         let coin_name = string::utf8(b"Generic Coin");
+//         let coin_symbol = string::utf8(b"GCC");
+//         let coin_decimals = 2;
+//
+//         initialize_aptos_coin(
+//             framework,
+//             aave_periphery,
+//             coin_decimals,
+//             true,
+//             coin_name,
+//             coin_symbol,
+//         );
+//
+//         // register the holder
+//         coin::register<GenericAptosCoin>(coin_holder);
+//
+//         // mint some coins
+//         let token_holder_initial_balance = 100;
+//         let coins_minted =
+//             coin::mint<GenericAptosCoin>(
+//                 token_holder_initial_balance,
+//                 &get_coin_refs(aave_periphery).mint_ref,
+//             );
+//
+//         // deposit to holder
+//         coin::deposit(coinholder_addr, coins_minted);
+//
+//         // withdraw some of the generic coin
+//         let coin_withdraw_amount = 20;
+//         let withdrawn_coins =
+//             coin::withdraw<GenericAptosCoin>(coin_holder, coin_withdraw_amount);
+//         // check the coin balance
+//         assert!(coin::value(&withdrawn_coins) == coin_withdraw_amount, TEST_SUCCESS);
+//         assert!(
+//             coin::balance<GenericAptosCoin>(signer::address_of(coin_holder))
+//                 == token_holder_initial_balance - coin_withdraw_amount,
+//             TEST_SUCCESS,
+//         );
+//
+//         // coin holder now warps the coin using the wrapper and gets an equivalent fa
+//         let wrapped_fa = test_wrap<GenericAptosCoin>(withdrawn_coins);
+//         let fa_metadata = fungible_asset::metadata_from_asset(&wrapped_fa);
+//
+//         test_get_original(fa_metadata);
+//         let unwrapped_coins = test_unwrap<GenericAptosCoin>(wrapped_fa);
+//         aptos_account::deposit_coins(signer::address_of(coin_holder), unwrapped_coins);
+//     }
+// }

--- a/tests/aptos-aave-v3/aave-core/tests/aave-periphery/collector_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-periphery/collector_tests.move
@@ -1,0 +1,151 @@
+// #[test_only]
+// module aave_pool::collector_tests {
+//     use aptos_framework::fungible_asset::{Self, Metadata};
+//     use aptos_framework::object::{Self, Object};
+//     use aptos_framework::primary_fungible_store;
+//     use aave_acl::acl_manage::{Self};
+//     use std::string::utf8;
+//     use aave_pool::standard_token::{Self};
+//     use std::signer;
+//     use aave_pool::collector::{
+//         Self,
+//         withdraw,
+//         init_module_test,
+//         deposit,
+//         get_collected_fees,
+//     };
+//
+//     const TEST_SUCCESS: u64 = 1;
+//     const TEST_FAILED: u64 = 2;
+//
+//     fun create_test_fa(creator: &signer): Object<Metadata> {
+//         let test_symbol = b"TEST";
+//         standard_token::initialize(
+//             creator,
+//             0,
+//             utf8(b"Test Token"),
+//             utf8(test_symbol),
+//             8,
+//             utf8(b"http://example.com/favicon.ico"),
+//             utf8(b"http://example.com"),
+//             vector[true, true, true],
+//             @0x1,
+//             false,
+//         );
+//         let metadata_address =
+//             object::create_object_address(&signer::address_of(creator), test_symbol);
+//         object::address_to_object<Metadata>(metadata_address)
+//     }
+//
+//     #[test(fa_creator = @aave_pool, aave_role_super_admin = @aave_acl, collector_account = @aave_pool, acl_fund_admin = @0x111, user_account = @0x222)]
+//     fun test_basic_flow(
+//         fa_creator: &signer,
+//         aave_role_super_admin: &signer,
+//         collector_account: &signer,
+//         acl_fund_admin: &signer,
+//         user_account: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         // set fund admin
+//         acl_manage::add_funds_admin(
+//             aave_role_super_admin, signer::address_of(acl_fund_admin)
+//         );
+//         // assert role is granted
+//         assert!(
+//             acl_manage::is_funds_admin(signer::address_of(acl_fund_admin)), TEST_SUCCESS
+//         );
+//
+//         // create test token
+//         let metadata = create_test_fa(fa_creator);
+//
+//         // mint coins to user
+//         let _creator_address = signer::address_of(fa_creator);
+//         let user_address = signer::address_of(user_account);
+//         standard_token::mint_to_primary_stores(
+//             fa_creator, metadata, vector[user_address], vector[100]
+//         );
+//         assert!(
+//             primary_fungible_store::balance(user_address, metadata) == 100, TEST_SUCCESS
+//         );
+//
+//         // user withdraws all fees he has
+//         let fa =
+//             standard_token::withdraw_from_primary_stores(
+//                 fa_creator,
+//                 metadata,
+//                 vector[user_address],
+//                 vector[100],
+//             );
+//         assert!(fungible_asset::amount(&fa) == 100, TEST_SUCCESS);
+//
+//         // initialize the collector
+//         init_module_test(collector_account);
+//
+//         // deposit the fee
+//         deposit(acl_fund_admin, fa);
+//
+//         // assert the fees are in the secondary store
+//         assert!(get_collected_fees(metadata) == 100, TEST_SUCCESS);
+//
+//         // transfer back half of the fees to the user
+//         withdraw(acl_fund_admin, metadata, user_address, 50);
+//
+//         // check user and collectpr's store balances
+//         assert!(get_collected_fees(metadata) == 50, 5);
+//         assert!(
+//             primary_fungible_store::balance(user_address, metadata) == 50, TEST_SUCCESS
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, collector_account = @aave_pool, acl_fund_admin = @0x111)]
+//     fun test_is_funds_admin_pass(
+//         aave_role_super_admin: &signer,
+//         collector_account: &signer,
+//         acl_fund_admin: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         // set fund admin
+//         acl_manage::add_funds_admin(
+//             aave_role_super_admin, signer::address_of(acl_fund_admin)
+//         );
+//         // assert role is granted
+//         assert!(
+//             acl_manage::is_funds_admin(signer::address_of(acl_fund_admin)), TEST_SUCCESS
+//         );
+//
+//         // initialize the collector
+//         init_module_test(collector_account);
+//
+//         // assert funds admin role is granted
+//         assert!(
+//             collector::check_is_funds_admin(signer::address_of(acl_fund_admin)),
+//             TEST_SUCCESS,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, collector_account = @aave_pool, acl_fund_admin = @0x111)]
+//     fun test_is_funds_admin_fail(
+//         aave_role_super_admin: &signer,
+//         collector_account: &signer,
+//         acl_fund_admin: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         // set fund admin
+//         let some_acl_funds_admin = @0x222;
+//         acl_manage::add_funds_admin(aave_role_super_admin, some_acl_funds_admin);
+//         // assert role is granted
+//         assert!(acl_manage::is_funds_admin(some_acl_funds_admin), TEST_SUCCESS);
+//
+//         // initialize the collector
+//         init_module_test(collector_account);
+//
+//         // assert funds admin role is granted
+//         assert!(
+//             !collector::check_is_funds_admin(signer::address_of(acl_fund_admin)),
+//             TEST_SUCCESS,
+//         );
+//     }
+// }

--- a/tests/aptos-aave-v3/aave-core/tests/aave-periphery/emission_manager_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-periphery/emission_manager_tests.move
@@ -1,0 +1,932 @@
+// #[test_only]
+// module aave_pool::emission_manager_tests {
+//     use aave_acl::acl_manage::{Self};
+//     use std::signer;
+//     use aave_pool::emission_manager::{
+//         initialize,
+//         set_pull_rewards_transfer_strategy,
+//         set_staked_token_transfer_strategy,
+//         set_emission_admin,
+//         get_emission_admin,
+//         set_rewards_controller,
+//         get_rewards_controller,
+//         configure_assets,
+//         set_distribution_end,
+//         set_emission_per_second,
+//         set_claimer
+//     };
+//     use std::vector;
+//     use std::string;
+//     use std::option::{Self, Option};
+//     use aave_pool::token_base::Self;
+//     use aave_pool::mock_underlying_token_factory::Self;
+//     use std::string::utf8;
+//     use aptos_std::string_utils::{Self};
+//
+//     const TEST_SUCCESS: u64 = 1;
+//     const TEST_FAILED: u64 = 2;
+//
+//     #[test(aave_role_super_admin = @aave_acl, _periphery_account = @aave_pool, _acl_fund_admin = @0x111, _user_account = @0x222, _creator = @0x1,)]
+//     fun test_initialize(
+//         aave_role_super_admin: &signer,
+//         _periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         _user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         let rewards_addr = signer::address_of(aave_role_super_admin);
+//
+//         initialize(aave_role_super_admin, rewards_addr);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_pull_rewards_transfer_strategy(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let pull_rewards_transfer_strategy =
+//             aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                 user_account_addr, user_account_addr, user_account_addr
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         set_pull_rewards_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             pull_rewards_transfer_strategy,
+//         );
+//
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_staked_token_transfer_strategy(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         set_staked_token_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             staked_token_transfer_strategy,
+//         );
+//
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, reward = @0x111, user_account = @0x222, new_admin = @0x1,)]
+//     fun test_set_get_emission_admin(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         reward: &signer,
+//         user_account: &signer,
+//         new_admin: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         set_staked_token_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             staked_token_transfer_strategy,
+//         );
+//
+//         let new_admin = signer::address_of(new_admin);
+//
+//         set_emission_admin(aave_role_super_admin, rewards_addr, new_admin);
+//
+//         assert!(
+//             get_emission_admin(rewards_addr) == new_admin,
+//             TEST_SUCCESS,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, reward = @0x111, user_account = @0x222, new_admin = @0x1,)]
+//     fun test_set_get_rewards_controller(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         reward: &signer,
+//         user_account: &signer,
+//         new_admin: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         set_staked_token_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             staked_token_transfer_strategy,
+//         );
+//
+//         let rewards_controller = signer::address_of(reward);
+//
+//         set_rewards_controller(aave_role_super_admin, rewards_controller);
+//
+//         assert!(
+//             get_rewards_controller() == rewards_controller,
+//             TEST_SUCCESS,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, reward = @0x111, user_account = @0x222, new_admin = @0x1, underlying_tokens_admin = @aave_acl, underlying_tokens_admin_2 = @underlying_tokens, aptos_framework = @0x1,)]
+//     fun test_configure_assets(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         reward: &signer,
+//         user_account: &signer,
+//         new_admin: &signer,
+//         underlying_tokens_admin: &signer,
+//         underlying_tokens_admin_2: &signer,
+//         aptos_framework: &signer,
+//     ) {
+//         aptos_framework::timestamp::set_time_has_started_for_testing(aptos_framework);
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         // mock_underlying_token_factory::test_init_module(periphery_account);
+//         token_base::test_init_module(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         // create a tokens admin account
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(underlying_tokens_admin_2)
+//         );
+//
+//         aave_pool::a_token_factory::create_token(
+//             underlying_tokens_admin_2,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             signer::address_of(underlying_tokens_admin_2),
+//             signer::address_of(underlying_tokens_admin_2),
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         let new_admin = signer::address_of(periphery_account);
+//
+//         set_emission_admin(aave_role_super_admin, rewards_addr, new_admin);
+//
+//         assert!(
+//             get_emission_admin(rewards_addr) == new_admin,
+//             TEST_SUCCESS,
+//         );
+//
+//         let rewards_admin = signer::address_of(underlying_tokens_admin_2);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin_2);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin_2);
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin_2);
+//
+//         let stake_contract =
+//             aave_pool::staked_token::create_mock_staked_token(underlying_token);
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//         // let staked_token_transfer_strategy = option::some(aave_pool::transfer_strategy::create_staked_token_transfer_strategy(rewards_admin, incentives_controller, stake_contract, underlying_token));
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let reward = rewards_addr;
+//
+//         let rewards_map = std::simple_map::new();
+//
+//         let available_rewards_count = 0;
+//
+//         let index = 0;
+//         let emission_per_second = 0;
+//         let last_update_timestamp = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards_map, reward, reward_data);
+//
+//         let asset_data =
+//             aave_pool::rewards_controller::create_asset_data(
+//                 rewards_map,
+//                 std::simple_map::new(),
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//         let asset =
+//             aptos_framework::object::create_object_address(
+//                 &signer::address_of(underlying_tokens_admin_2), *string::bytes(&symbol)
+//             );
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let config = vector::empty<aave_pool::transfer_strategy::RewardsConfigInput>();
+//         let rewards_config_input =
+//             aave_pool::transfer_strategy::create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//         vector::push_back(&mut config, rewards_config_input);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             signer::address_of(periphery_account),
+//         );
+//
+//         aave_pool::rewards_controller::add_asset(rewards_addr, asset, asset_data);
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, reward);
+//
+//         configure_assets(periphery_account, config);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, reward = @0x111, user_account = @0x222, new_admin = @0x1, underlying_tokens_admin = @aave_acl, underlying_tokens_admin_2 = @underlying_tokens, aptos_framework = @0x1,)]
+//     fun test_set_distribution_end(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         reward: &signer,
+//         user_account: &signer,
+//         new_admin: &signer,
+//         underlying_tokens_admin: &signer,
+//         underlying_tokens_admin_2: &signer,
+//         aptos_framework: &signer,
+//     ) {
+//         aptos_framework::timestamp::set_time_has_started_for_testing(aptos_framework);
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         // mock_underlying_token_factory::test_init_module(periphery_account);
+//         token_base::test_init_module(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         // create a tokens admin account
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(underlying_tokens_admin_2)
+//         );
+//
+//         aave_pool::a_token_factory::create_token(
+//             underlying_tokens_admin_2,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             signer::address_of(underlying_tokens_admin_2),
+//             signer::address_of(underlying_tokens_admin_2),
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         let new_admin = signer::address_of(periphery_account);
+//
+//         set_emission_admin(aave_role_super_admin, rewards_addr, new_admin);
+//
+//         let rewards_admin = signer::address_of(underlying_tokens_admin_2);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin_2);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin_2);
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin_2);
+//
+//         let stake_contract =
+//             aave_pool::staked_token::create_mock_staked_token(underlying_token);
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//         // let staked_token_transfer_strategy = option::some(aave_pool::transfer_strategy::create_staked_token_transfer_strategy(rewards_admin, incentives_controller, stake_contract, underlying_token));
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let reward = rewards_addr;
+//
+//         let rewards_map = std::simple_map::new();
+//
+//         let available_rewards_count = 0;
+//
+//         let index = 0;
+//         let emission_per_second = 0;
+//         let last_update_timestamp = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards_map, reward, reward_data);
+//
+//         let asset_data =
+//             aave_pool::rewards_controller::create_asset_data(
+//                 rewards_map,
+//                 std::simple_map::new(),
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//         let asset =
+//             aptos_framework::object::create_object_address(
+//                 &signer::address_of(underlying_tokens_admin_2), *string::bytes(&symbol)
+//             );
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let config = vector::empty<aave_pool::transfer_strategy::RewardsConfigInput>();
+//         let rewards_config_input =
+//             aave_pool::transfer_strategy::create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//         vector::push_back(&mut config, rewards_config_input);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             signer::address_of(periphery_account),
+//         );
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             reward,
+//         );
+//
+//         aave_pool::rewards_controller::add_asset(rewards_addr, asset, asset_data);
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, rewards_addr);
+//
+//         set_emission_admin(aave_role_super_admin, rewards_addr, rewards_addr);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_emission_admin_role(),
+//             rewards_addr,
+//         );
+//
+//         set_distribution_end(
+//             periphery_account,
+//             asset,
+//             rewards_addr,
+//             10,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, reward = @0x111, user_account = @0x222, new_admin = @0x1, underlying_tokens_admin = @aave_acl, underlying_tokens_admin_2 = @underlying_tokens, aptos_framework = @0x1,)]
+//     fun test_set_emission_per_second(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         reward: &signer,
+//         user_account: &signer,
+//         new_admin: &signer,
+//         underlying_tokens_admin: &signer,
+//         underlying_tokens_admin_2: &signer,
+//         aptos_framework: &signer,
+//     ) {
+//         aptos_framework::timestamp::set_time_has_started_for_testing(aptos_framework);
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         // mock_underlying_token_factory::test_init_module(periphery_account);
+//         token_base::test_init_module(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         // create a tokens admin account
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(underlying_tokens_admin_2)
+//         );
+//
+//         aave_pool::a_token_factory::create_token(
+//             underlying_tokens_admin_2,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             signer::address_of(underlying_tokens_admin_2),
+//             signer::address_of(underlying_tokens_admin_2),
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         let new_admin = signer::address_of(periphery_account);
+//
+//         set_emission_admin(aave_role_super_admin, rewards_addr, new_admin);
+//
+//         let rewards_admin = signer::address_of(underlying_tokens_admin_2);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin_2);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin_2);
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin_2);
+//
+//         let stake_contract =
+//             aave_pool::staked_token::create_mock_staked_token(underlying_token);
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//         // let staked_token_transfer_strategy = option::some(aave_pool::transfer_strategy::create_staked_token_transfer_strategy(rewards_admin, incentives_controller, stake_contract, underlying_token));
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let reward = rewards_addr;
+//
+//         let rewards_map = std::simple_map::new();
+//
+//         let available_rewards_count = 0;
+//
+//         let index = 0;
+//         let emission_per_second = 0;
+//         let last_update_timestamp = 1;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards_map, reward, reward_data);
+//
+//         let asset_data =
+//             aave_pool::rewards_controller::create_asset_data(
+//                 rewards_map,
+//                 std::simple_map::new(),
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//         let asset =
+//             aptos_framework::object::create_object_address(
+//                 &signer::address_of(underlying_tokens_admin_2), *string::bytes(&symbol)
+//             );
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let config = vector::empty<aave_pool::transfer_strategy::RewardsConfigInput>();
+//         let rewards_config_input =
+//             aave_pool::transfer_strategy::create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//         vector::push_back(&mut config, rewards_config_input);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             signer::address_of(periphery_account),
+//         );
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             reward,
+//         );
+//
+//         aave_pool::rewards_controller::add_asset(rewards_addr, asset, asset_data);
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, rewards_addr);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_emission_admin_role(),
+//             rewards_addr,
+//         );
+//
+//         let rewards_arg = vector[rewards_addr];
+//         let new_emissions_per_second_arg = vector[0];
+//
+//         set_emission_per_second(
+//             periphery_account,
+//             asset,
+//             rewards_arg,
+//             new_emissions_per_second_arg,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, reward = @0x111, user_account = @0x222, new_admin = @0x1, underlying_tokens_admin = @aave_acl, underlying_tokens_admin_2 = @underlying_tokens, aptos_framework = @0x1,)]
+//     fun test_set_claimer(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         reward: &signer,
+//         user_account: &signer,
+//         new_admin: &signer,
+//         underlying_tokens_admin: &signer,
+//         underlying_tokens_admin_2: &signer,
+//         aptos_framework: &signer,
+//     ) {
+//         aptos_framework::timestamp::set_time_has_started_for_testing(aptos_framework);
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         // mock_underlying_token_factory::test_init_module(periphery_account);
+//         token_base::test_init_module(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         // create a tokens admin account
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(underlying_tokens_admin_2)
+//         );
+//
+//         aave_pool::a_token_factory::create_token(
+//             underlying_tokens_admin_2,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             signer::address_of(underlying_tokens_admin_2),
+//             signer::address_of(underlying_tokens_admin_2),
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         initialize(periphery_account, rewards_addr);
+//
+//         let new_admin = signer::address_of(periphery_account);
+//
+//         set_emission_admin(aave_role_super_admin, rewards_addr, new_admin);
+//
+//         let rewards_admin = signer::address_of(underlying_tokens_admin_2);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin_2);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin_2);
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin_2);
+//
+//         let stake_contract =
+//             aave_pool::staked_token::create_mock_staked_token(underlying_token);
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//         // let staked_token_transfer_strategy = option::some(aave_pool::transfer_strategy::create_staked_token_transfer_strategy(rewards_admin, incentives_controller, stake_contract, underlying_token));
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let reward = rewards_addr;
+//
+//         let rewards_map = std::simple_map::new();
+//
+//         let available_rewards_count = 0;
+//
+//         let index = 0;
+//         let emission_per_second = 0;
+//         let last_update_timestamp = 1;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards_map, reward, reward_data);
+//
+//         let asset_data =
+//             aave_pool::rewards_controller::create_asset_data(
+//                 rewards_map,
+//                 std::simple_map::new(),
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//         let asset =
+//             aptos_framework::object::create_object_address(
+//                 &signer::address_of(underlying_tokens_admin_2), *string::bytes(&symbol)
+//             );
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let config = vector::empty<aave_pool::transfer_strategy::RewardsConfigInput>();
+//         let rewards_config_input =
+//             aave_pool::transfer_strategy::create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//         vector::push_back(&mut config, rewards_config_input);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             signer::address_of(periphery_account),
+//         );
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_rewards_controller_admin_role_for_testing(),
+//             reward,
+//         );
+//
+//         aave_pool::rewards_controller::add_asset(rewards_addr, asset, asset_data);
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, rewards_addr);
+//
+//         aave_acl::acl_manage::grant_role(
+//             aave_role_super_admin,
+//             aave_acl::acl_manage::get_emission_admin_role(),
+//             rewards_addr,
+//         );
+//
+//         let rewards_arg = vector[rewards_addr];
+//         let new_emissions_per_second_arg = vector[0];
+//
+//         set_emission_per_second(
+//             periphery_account,
+//             asset,
+//             rewards_arg,
+//             new_emissions_per_second_arg,
+//         );
+//
+//         aave_acl::acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(aave_role_super_admin)
+//         );
+//
+//         set_claimer(
+//             aave_role_super_admin,
+//             signer::address_of(aave_role_super_admin),
+//             signer::address_of(aave_role_super_admin),
+//         );
+//     }
+// }

--- a/tests/aptos-aave-v3/aave-core/tests/aave-periphery/rewards_controller_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-periphery/rewards_controller_tests.move
@@ -1,0 +1,2075 @@
+// #[test_only]
+// module aave_pool::rewards_controller_tests {
+//     use aave_acl::acl_manage::{Self};
+//     use std::signer;
+//     use std::vector;
+//     use std::option::{Self, Option};
+//     use std::string::utf8;
+//     use aptos_std::string_utils::{Self};
+//     use aptos_std::simple_map;
+//     use aptos_framework::object::{Self, Object};
+//     use aave_oracle::reward_oracle::{create_reward_oracle};
+//     use aptos_framework::timestamp::set_time_has_started_for_testing;
+//     use aave_pool::transfer_strategy::{
+//         RewardsConfigInput,
+//         create_staked_token_transfer_strategy,
+//         create_pull_rewards_transfer_strategy,
+//         create_rewards_config_input
+//     };
+//     use aave_pool::rewards_controller::{
+//         initialize,
+//         set_pull_rewards_transfer_strategy,
+//         set_staked_token_transfer_strategy,
+//         get_emission_manager,
+//         get_rewards_list,
+//         set_reward_oracle_internal,
+//         get_asset_decimals,
+//         add_asset,
+//         create_asset_data,
+//         configure_assets,
+//         claim_rewards,
+//         get_all_user_rewards,
+//         claim_all_rewards,
+//         rewards_controller_object,
+//         rewards_controller_address,
+//         RewardsControllerData,
+//         get_revision,
+//         get_reward_oracle,
+//         get_pull_rewards_transfer_strategy,
+//         get_staked_token_transfer_strategy,
+//         set_reward_oracle,
+//         set_emission_per_second,
+//         get_asset_index,
+//         set_claimer,
+//         get_claimer,
+//         test_claim_rewards_on_behalf,
+//         test_claim_rewards_to_self,
+//         get_user_rewards,
+//         set_distribution_end,
+//         get_distribution_end,
+//         test_claim_all_rewards_on_behalf,
+//         test_claim_all_rewards_to_self,
+//         add_to_rewards_list,
+//         test_handle_action
+//     };
+//
+//     #[test(aave_role_super_admin = @aave_acl, _periphery_account = @aave_pool, _acl_fund_admin = @0x111, _user_account = @0x222, _creator = @0x1,)]
+//     fun test_initialize(
+//         aave_role_super_admin: &signer,
+//         _periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         _user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         let rewards_addr = signer::address_of(aave_role_super_admin);
+//
+//         initialize(aave_role_super_admin, rewards_addr);
+//
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_distribution_end(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//         aave_pool::token_base::test_init_module(periphery_account);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let new_distribution_end = 10;
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             asset_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         let rewards = simple_map::create();
+//
+//         let index = 0;
+//         let last_update_timestamp = 1;
+//         let emission_per_second = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         set_distribution_end(
+//             periphery_account,
+//             a_token_address,
+//             a_token_address,
+//             new_distribution_end,
+//             rewards_addr,
+//         );
+//
+//         assert!(
+//             get_distribution_end(
+//                 a_token_address,
+//                 a_token_address,
+//                 rewards_addr,
+//             ) == 10,
+//             1,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_pull_rewards_transfer_strategy(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let pull_rewards_transfer_strategy =
+//             aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                 user_account_addr, user_account_addr, user_account_addr
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         set_pull_rewards_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             pull_rewards_transfer_strategy,
+//             rewards_addr,
+//         );
+//
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_pull_rewards_transfer_strategy(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let pull_rewards_transfer_strategy =
+//             aave_pool::transfer_strategy::create_pull_rewards_transfer_strategy(
+//                 user_account_addr, user_account_addr, user_account_addr
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         set_pull_rewards_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             pull_rewards_transfer_strategy,
+//             rewards_addr,
+//         );
+//
+//         assert!(
+//             get_pull_rewards_transfer_strategy(
+//                 signer::address_of(periphery_account), rewards_addr
+//             ) == pull_rewards_transfer_strategy,
+//             1,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_staked_token_transfer_strategy(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         set_staked_token_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             staked_token_transfer_strategy,
+//             rewards_addr,
+//         );
+//
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_staked_token_transfer_strategy(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         set_staked_token_transfer_strategy(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             staked_token_transfer_strategy,
+//             rewards_addr,
+//         );
+//
+//         assert!(
+//             get_staked_token_transfer_strategy(
+//                 signer::address_of(periphery_account), rewards_addr
+//             ) == staked_token_transfer_strategy,
+//             1,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_emission_manager(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let emission_manager = get_emission_manager(rewards_addr);
+//
+//         assert!(emission_manager == signer::address_of(periphery_account), 1);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_rewards_list(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let rewards_list = get_rewards_list(rewards_addr);
+//
+//         assert!(rewards_list == vector[], 1);
+//
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_reward_oracle_internal(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//     }
+//
+//     #[test(aptos_framework = @0x1, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_emission_per_second(
+//         aptos_framework: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // start the timer
+//         set_time_has_started_for_testing(aptos_framework);
+//
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//         aave_pool::token_base::test_init_module(periphery_account);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let rewards = simple_map::create();
+//
+//         let index = 0;
+//         let last_update_timestamp = 1;
+//         let emission_per_second = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             asset_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         set_emission_per_second(
+//             periphery_account,
+//             a_token_address,
+//             vector[a_token_address],
+//             vector[1],
+//             rewards_addr,
+//         )
+//     }
+//
+//     #[test(aptos_framework = @0x1, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_asset_index(
+//         aptos_framework: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // start the timer
+//         set_time_has_started_for_testing(aptos_framework);
+//
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//         aave_pool::token_base::test_init_module(periphery_account);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let rewards = simple_map::create();
+//
+//         let index = 0;
+//         let last_update_timestamp = 1;
+//         let emission_per_second = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             asset_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         get_asset_index(a_token_address, a_token_address, rewards_addr);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_set_reward_oracle(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         aave_acl::acl_manage::add_rewards_controller_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         set_reward_oracle(periphery_account, rewards_addr, reward_oracle, rewards_addr);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_asset_decimals(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let rewards = simple_map::create();
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, asset_addr, asset);
+//
+//         let res = get_asset_decimals(asset_addr, rewards_addr);
+//
+//         assert!(res == decimals, 1);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_claim_rewards(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let rewards = simple_map::create();
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, asset_addr, asset);
+//
+//         let res = get_asset_decimals(asset_addr, rewards_addr);
+//
+//         assert!(res == decimals, 1);
+//
+//         claim_rewards(
+//             periphery_account,
+//             vector[asset_addr],
+//             0,
+//             signer::address_of(periphery_account),
+//             signer::address_of(periphery_account),
+//             signer::address_of(periphery_account),
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_of_handle_action(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let rewards = simple_map::create();
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, asset_addr, asset);
+//
+//         let res = get_asset_decimals(asset_addr, rewards_addr);
+//
+//         assert!(res == decimals, 1);
+//
+//         test_handle_action(
+//             periphery_account,
+//             signer::address_of(periphery_account),
+//             0,
+//             0,
+//             rewards_addr,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_user_rewards(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let underlying_asset_address = @0x033;
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             // aave_role_super_admin,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             underlying_asset_address,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         let rewards = simple_map::create();
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let user_data = aave_pool::rewards_controller::create_user_data(0, 0);
+//
+//         std::simple_map::upsert(
+//             &mut users_data, signer::address_of(periphery_account), user_data
+//         );
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let distribution_end = 0;
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         get_user_rewards(
+//             vector[a_token_address],
+//             signer::address_of(periphery_account),
+//             a_token_address,
+//             rewards_addr,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_all_user_rewards(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let underlying_asset_address = @0x033;
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             // aave_role_super_admin,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             underlying_asset_address,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         let rewards = simple_map::create();
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_addr = signer::address_of(periphery_account);
+//
+//         let users_data = std::simple_map::new();
+//
+//         let user_data = aave_pool::rewards_controller::create_user_data(0, 0);
+//
+//         std::simple_map::upsert(&mut users_data, a_token_address, user_data);
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let distribution_end = 0;
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         add_to_rewards_list(a_token_address, rewards_addr);
+//
+//         let (addr_vec, amount_vec) =
+//             get_all_user_rewards(
+//                 vector[a_token_address],
+//                 a_token_address,
+//                 rewards_addr,
+//             );
+//
+//         assert!(vector::length(&addr_vec) != 0, 1);
+//         assert!(vector::length(&amount_vec) != 0, 1);
+//     }
+//
+//     #[test(aptos_framework = @0x1, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1, underlying_tokens_admin = @underlying_tokens,)]
+//     fun test_configure_assets(
+//         aptos_framework: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//         underlying_tokens_admin: &signer,
+//     ) {
+//         // start the timer
+//         set_time_has_started_for_testing(aptos_framework);
+//
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let underlying_asset_address = @0x033;
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin);
+//         let rewards_admin = signer::address_of(underlying_tokens_admin);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin);
+//         let treasury_address = @0x034;
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             // aave_role_super_admin,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             underlying_asset_address,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//         // let asset = underlying_token;
+//         // let reward = underlying_token;
+//         let asset = a_token_address;
+//         let reward = a_token_address;
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let rewards_config_input =
+//             create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//
+//         let rewards = simple_map::create();
+//
+//         let users_data = std::simple_map::new();
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_data =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         // let asset_addr = signer::address_of(periphery_account);
+//
+//         add_asset(rewards_addr, a_token_address, asset_data);
+//
+//         aave_acl::acl_manage::add_rewards_controller_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, reward);
+//
+//         configure_assets(periphery_account, vector[rewards_config_input], rewards_addr);
+//     }
+//
+//     #[test(aptos_framework = @0x1, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1, underlying_tokens_admin = @underlying_tokens,)]
+//     fun test_set_claimer(
+//         aptos_framework: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//         underlying_tokens_admin: &signer,
+//     ) {
+//         // start the timer
+//         set_time_has_started_for_testing(aptos_framework);
+//
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let underlying_asset_address = @0x033;
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin);
+//         let rewards_admin = signer::address_of(underlying_tokens_admin);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin);
+//         let treasury_address = @0x034;
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             // aave_role_super_admin,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             underlying_asset_address,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//         // let asset = underlying_token;
+//         // let reward = underlying_token;
+//         let asset = a_token_address;
+//         let reward = a_token_address;
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let rewards_config_input =
+//             create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//
+//         let rewards = simple_map::create();
+//
+//         let users_data = std::simple_map::new();
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_data =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         // let asset_addr = signer::address_of(periphery_account);
+//
+//         add_asset(rewards_addr, a_token_address, asset_data);
+//
+//         aave_acl::acl_manage::add_rewards_controller_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, reward);
+//
+//         acl_manage::add_emission_admin_role(aave_role_super_admin, a_token_address);
+//
+//         set_claimer(a_token_address, a_token_address, rewards_addr);
+//     }
+//
+//     #[test(aptos_framework = @0x1, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1, underlying_tokens_admin = @underlying_tokens,)]
+//     fun test_get_claimer(
+//         aptos_framework: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//         underlying_tokens_admin: &signer,
+//     ) {
+//         // start the timer
+//         set_time_has_started_for_testing(aptos_framework);
+//
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         let underlying_asset_address = @0x033;
+//
+//         let underlying_token = signer::address_of(underlying_tokens_admin);
+//         let rewards_vault = signer::address_of(underlying_tokens_admin);
+//         let rewards_admin = signer::address_of(underlying_tokens_admin);
+//         let incentives_controller = signer::address_of(underlying_tokens_admin);
+//         let treasury_address = @0x034;
+//
+//         let i = 0;
+//
+//         let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+//         let symbol = string_utils::format1(&b"U_{}", i);
+//         let decimals = 2 + i;
+//         let max_supply = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             // aave_role_super_admin,
+//             name,
+//             symbol,
+//             decimals,
+//             utf8(b""),
+//             utf8(b""),
+//             underlying_asset_address,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol
+//             );
+//
+//         let pull_rewards_transfer_strategy =
+//             option::some(
+//                 create_pull_rewards_transfer_strategy(
+//                     rewards_admin, incentives_controller, rewards_vault
+//                 ),
+//             );
+//
+//         let staked_token_transfer_strategy = option::none();
+//
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//         // let asset = underlying_token;
+//         // let reward = underlying_token;
+//         let asset = a_token_address;
+//         let reward = a_token_address;
+//
+//         let id = 1;
+//         let reward_oracle = aave_oracle::reward_oracle::create_reward_oracle(id);
+//
+//         let rewards_config_input =
+//             create_rewards_config_input(
+//                 emission_per_second,
+//                 total_supply,
+//                 distribution_end,
+//                 asset,
+//                 reward,
+//                 staked_token_transfer_strategy,
+//                 pull_rewards_transfer_strategy,
+//                 reward_oracle,
+//             );
+//
+//         let rewards = simple_map::create();
+//
+//         let users_data = std::simple_map::new();
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset_data =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         // let asset_addr = signer::address_of(periphery_account);
+//
+//         add_asset(rewards_addr, a_token_address, asset_data);
+//
+//         aave_acl::acl_manage::add_rewards_controller_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//         aave_pool::rewards_controller::enable_reward(rewards_addr, reward);
+//
+//         acl_manage::add_emission_admin_role(aave_role_super_admin, a_token_address);
+//
+//         set_claimer(a_token_address, a_token_address, rewards_addr);
+//
+//         assert!(
+//             get_claimer(a_token_address, rewards_addr) == a_token_address,
+//             1,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_claim_all_rewards(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         let i = 0;
+//
+//         let name_2 = string_utils::format1(&b"APTOS_UNDERLYING_2_{}", i);
+//         let symbol_2 = string_utils::format1(&b"U_2_{}", i);
+//         let decimals_2 = 2 + i;
+//         let max_supply_2 = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name_2,
+//             symbol_2,
+//             decimals_2,
+//             utf8(b"2"),
+//             utf8(b"2"),
+//             rewards_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol_2
+//             );
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//         let rewards = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         claim_all_rewards(
+//             periphery_account,
+//             vector[a_token_address],
+//             rewards_addr,
+//             rewards_addr,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_of_claim_all_rewards_on_behalf(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         let i = 0;
+//
+//         let name_2 = string_utils::format1(&b"APTOS_UNDERLYING_2_{}", i);
+//         let symbol_2 = string_utils::format1(&b"U_2_{}", i);
+//         let decimals_2 = 2 + i;
+//         let max_supply_2 = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name_2,
+//             symbol_2,
+//             decimals_2,
+//             utf8(b"2"),
+//             utf8(b"2"),
+//             rewards_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol_2
+//             );
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let user_data = aave_pool::rewards_controller::create_user_data(0, 1);
+//
+//         std::simple_map::upsert(
+//             &mut users_data, signer::address_of(periphery_account), user_data
+//         );
+//
+//         let rewards = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         acl_manage::add_emission_admin_role(aave_role_super_admin, rewards_addr);
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         set_claimer(
+//             signer::address_of(periphery_account),
+//             signer::address_of(periphery_account),
+//             rewards_addr,
+//         );
+//
+//         add_to_rewards_list(a_token_address, rewards_addr);
+//
+//         test_claim_all_rewards_on_behalf(
+//             periphery_account,
+//             vector[a_token_address],
+//             signer::address_of(periphery_account),
+//             rewards_addr,
+//             rewards_addr,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_of_test_claim_all_rewards_to_self(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         let i = 0;
+//
+//         let name_2 = string_utils::format1(&b"APTOS_UNDERLYING_2_{}", i);
+//         let symbol_2 = string_utils::format1(&b"U_2_{}", i);
+//         let decimals_2 = 2 + i;
+//         let max_supply_2 = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name_2,
+//             symbol_2,
+//             decimals_2,
+//             utf8(b"2"),
+//             utf8(b"2"),
+//             rewards_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol_2
+//             );
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//
+//         let user_data = aave_pool::rewards_controller::create_user_data(0, 1);
+//
+//         std::simple_map::upsert(
+//             &mut users_data, signer::address_of(periphery_account), user_data
+//         );
+//
+//         let rewards = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         acl_manage::add_emission_admin_role(aave_role_super_admin, rewards_addr);
+//
+//         acl_manage::add_emission_admin_role(
+//             aave_role_super_admin, signer::address_of(periphery_account)
+//         );
+//
+//         set_claimer(
+//             signer::address_of(periphery_account),
+//             signer::address_of(periphery_account),
+//             rewards_addr,
+//         );
+//
+//         add_to_rewards_list(a_token_address, rewards_addr);
+//
+//         test_claim_all_rewards_to_self(
+//             periphery_account, vector[a_token_address], rewards_addr
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_of_claim_rewards_on_behalf(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         let i = 0;
+//
+//         let name_2 = string_utils::format1(&b"APTOS_UNDERLYING_2_{}", i);
+//         let symbol_2 = string_utils::format1(&b"U_2_{}", i);
+//         let decimals_2 = 2 + i;
+//         let max_supply_2 = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name_2,
+//             symbol_2,
+//             decimals_2,
+//             utf8(b"2"),
+//             utf8(b"2"),
+//             rewards_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol_2
+//             );
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//         let rewards = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         acl_manage::add_emission_admin_role(aave_role_super_admin, rewards_addr);
+//
+//         set_claimer(rewards_addr, signer::address_of(periphery_account), rewards_addr);
+//
+//         test_claim_rewards_on_behalf(
+//             periphery_account,
+//             vector[a_token_address],
+//             0,
+//             rewards_addr,
+//             rewards_addr,
+//             rewards_addr,
+//             rewards_addr,
+//         );
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_of_claim_rewards_to_self(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//         aave_pool::token_base::test_init_module(periphery_account);
+//         aptos_framework::account::create_account_for_test(
+//             signer::address_of(periphery_account)
+//         );
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         let i = 0;
+//
+//         let name_2 = string_utils::format1(&b"APTOS_UNDERLYING_2_{}", i);
+//         let symbol_2 = string_utils::format1(&b"U_2_{}", i);
+//         let decimals_2 = 2 + i;
+//         let max_supply_2 = 10000;
+//         let treasury_address = @0x034;
+//
+//         aave_pool::a_token_factory::create_token(
+//             periphery_account,
+//             name_2,
+//             symbol_2,
+//             decimals_2,
+//             utf8(b"2"),
+//             utf8(b"2"),
+//             rewards_addr,
+//             treasury_address,
+//         );
+//
+//         let a_token_address =
+//             aave_pool::a_token_factory::token_address(
+//                 signer::address_of(periphery_account), symbol_2
+//             );
+//
+//         let index = 0;
+//         let last_update_timestamp = 0;
+//         let emission_per_second = 0;
+//         let total_supply = 0;
+//         let distribution_end = 0;
+//
+//         let users_data = std::simple_map::new();
+//         let rewards = std::simple_map::new();
+//
+//         let reward_data =
+//             aave_pool::rewards_controller::create_reward_data(
+//                 index,
+//                 emission_per_second,
+//                 last_update_timestamp,
+//                 distribution_end,
+//                 users_data,
+//             );
+//
+//         std::simple_map::upsert(&mut rewards, a_token_address, reward_data);
+//         let available_rewards = simple_map::create();
+//         let available_rewards_count = 0;
+//         let decimals = 10;
+//
+//         let asset =
+//             create_asset_data(
+//                 rewards,
+//                 available_rewards,
+//                 available_rewards_count,
+//                 decimals,
+//             );
+//
+//         add_asset(rewards_addr, a_token_address, asset);
+//
+//         acl_manage::add_emission_admin_role(aave_role_super_admin, rewards_addr);
+//
+//         set_claimer(rewards_addr, signer::address_of(periphery_account), rewards_addr);
+//
+//         test_claim_rewards_to_self(
+//             periphery_account,
+//             vector[a_token_address],
+//             0,
+//             rewards_addr,
+//             rewards_addr,
+//         );
+//     }
+//
+//     #[test(fa_creator = @aave_pool, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, acl_fund_admin = @0x111, user_account = @0x222)]
+//     fun test_rewards_controller_object(
+//         fa_creator: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         acl_fund_admin: &signer,
+//         user_account: &signer,
+//     ) {
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         assert!(
+//             rewards_controller_object()
+//                 == object::address_to_object<RewardsControllerData>(
+//                     rewards_controller_address()
+//                 ),
+//             1,
+//         );
+//     }
+//
+//     #[test(fa_creator = @aave_pool, aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, acl_fund_admin = @0x111, user_account = @0x222)]
+//     fun test_get_revision(
+//         fa_creator: &signer,
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         acl_fund_admin: &signer,
+//         user_account: &signer,
+//     ) {
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         assert!(get_revision() == 1, 1);
+//     }
+//
+//     #[test(aave_role_super_admin = @aave_acl, periphery_account = @aave_pool, _acl_fund_admin = @0x111, user_account = @0x222, _creator = @0x1,)]
+//     fun test_get_reward_oracle(
+//         aave_role_super_admin: &signer,
+//         periphery_account: &signer,
+//         _acl_fund_admin: &signer,
+//         user_account: &signer,
+//         _creator: &signer,
+//     ) {
+//         // init acl
+//         acl_manage::test_init_module(aave_role_super_admin);
+//
+//         aave_pool::rewards_controller::initialize(
+//             periphery_account, signer::address_of(periphery_account)
+//         );
+//
+//         let user_account_addr = signer::address_of(user_account);
+//
+//         let mock_staked_token =
+//             aave_pool::staked_token::create_mock_staked_token(user_account_addr);
+//
+//         let _staked_token_transfer_strategy =
+//             aave_pool::transfer_strategy::create_staked_token_transfer_strategy(
+//                 user_account_addr,
+//                 user_account_addr,
+//                 mock_staked_token,
+//                 user_account_addr,
+//             );
+//
+//         let rewards_addr = aave_pool::rewards_controller::rewards_controller_address();
+//
+//         let reward_oracle = create_reward_oracle(1);
+//
+//         set_reward_oracle_internal(rewards_addr, reward_oracle);
+//
+//         assert!(
+//             get_reward_oracle(rewards_addr, rewards_addr) == reward_oracle,
+//             1,
+//         );
+//     }
+// }

--- a/tests/aptos-aave-v3/aave-core/tests/aave-pool/pool_configurator_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-pool/pool_configurator_tests.move
@@ -1,0 +1,1046 @@
+#[test_only]
+module aave_pool::pool_configurator_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::signer;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    use aave_acl::acl_manage;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::collector::Self;
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::pool::{get_reserves_count, ReserveInitialized};
+    use aave_pool::pool_configurator::Self;
+    use aave_pool::token_base;
+    use aave_pool::variable_debt_token_factory::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    const TEST_ASSETS_COUNT: u8 = 3;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    fun test_add_reserves(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // check emitted events
+        let emitted_events = emitted_events<ReserveInitialized>();
+        // make sure event of type was emitted
+        assert!(
+            vector::length(&emitted_events) == (TEST_ASSETS_COUNT as u64), TEST_SUCCESS
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    #[expected_failure(abort_code = 5)]
+    fun test_add_reserves_wrong_sender(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        pool_configurator::init_reserves(
+            aave_oracle,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    #[expected_failure(abort_code = 1)]
+    fun test_drop_reserves_bad_signer(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+
+        // drop the first reserve
+        pool_configurator::drop_reserve(
+            aave_oracle, *vector::borrow(&underlying_assets, 0)
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    #[expected_failure(abort_code = 1)]
+    fun test_drop_reserves_with_0_supply(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+
+        // drop the first reserve
+        pool_configurator::drop_reserve(
+            aave_pool, *vector::borrow(&underlying_assets, 0)
+        );
+        // check emitted events
+        let emitted_events = emitted_events<pool_configurator::ReserveDropped>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+        // test reserves count
+        assert!(
+            get_reserves_count() == ((TEST_ASSETS_COUNT as u256) - 1),
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens,
+            caller = @0x42
+        )
+    ]
+    #[expected_failure(abort_code = 54)]
+    fun test_drop_reserves_with_nonzero_supply_atokens_failure(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        caller: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aave_std);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(aave_acl, @aave_pool);
+        acl_manage::add_pool_admin(aave_acl, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+
+        // ============= MINT ATOKENS ============== //
+        let a_token_symbol = *vector::borrow(&atokens_symbols, 0);
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool), a_token_symbol
+            );
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        let amount_to_mint_scaled = wad_ray_math::ray_div(amount_to_mint, reserve_index);
+
+        a_token_factory::mint(
+            signer::address_of(caller),
+            signer::address_of(caller),
+            amount_to_mint,
+            reserve_index,
+            a_token_address
+        );
+
+        // assert a token supply
+        assert!(
+            a_token_factory::scaled_total_supply(a_token_address)
+                == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+
+        // drop the first reserve
+        pool_configurator::drop_reserve(
+            aave_pool, *vector::borrow(&underlying_assets, 0)
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens,
+            caller = @0x42
+        )
+    ]
+    #[expected_failure(abort_code = 56)]
+    fun test_drop_reserves_with_nonzero_supply_variable_tokens_failure(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        caller: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aave_std);
+
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+
+        // ============= MINT VARIABLE TOKENS ============== //
+        let var_token_symbol = *vector::borrow(&var_tokens_symbols, 0);
+        let var_token_address =
+            variable_debt_token_factory::token_address(
+                signer::address_of(aave_pool), var_token_symbol
+            );
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        let amount_to_mint_scaled = wad_ray_math::ray_div(amount_to_mint, reserve_index);
+
+        variable_debt_token_factory::mint(
+            signer::address_of(caller),
+            signer::address_of(caller),
+            amount_to_mint,
+            reserve_index,
+            var_token_address
+        );
+
+        // assert var token supply
+        assert!(
+            variable_debt_token_factory::scaled_total_supply(var_token_address)
+                == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+
+        // drop the first reserve
+        pool_configurator::drop_reserve(
+            aave_pool, *vector::borrow(&underlying_assets, 0)
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens = @underlying_tokens,
+            aave_rate = @aave_rate
+        )
+    ]
+    fun test_reserve_setters_getters(
+        aave_pool: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens: &signer,
+        aave_rate: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(aave_acl, @aave_pool);
+        acl_manage::add_pool_admin(aave_acl, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        aave_pool::a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        aave_pool::variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlyings token factory
+        aave_pool::mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init rates - default strategy
+        aave_rate::default_reserve_interest_rate_strategy::init_interest_rate_strategy(
+            aave_rate
+        );
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create reserves using the pool admin
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // check emitted events
+        let emitted_events = emitted_events<ReserveInitialized>();
+        // make sure event of type was emitted
+        assert!(
+            vector::length(&emitted_events) == (TEST_ASSETS_COUNT as u64), TEST_SUCCESS
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-pool/pool_data_provider_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-pool/pool_data_provider_tests.move
@@ -1,0 +1,232 @@
+#[test_only]
+module aave_pool::pool_data_provider_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::signer;
+    use std::string::{utf8, String};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::account;
+    use aave_acl::acl_manage;
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::token_base;
+    use aave_pool::variable_debt_token_factory::Self;
+    use aave_pool::mock_underlying_token_factory::{Self};
+    use aave_pool::collector::{Self};
+    use aave_pool::pool::{get_reserves_count, ReserveInitialized};
+    use aave_pool::pool_configurator::Self;
+    use aave_pool::pool_data_provider::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    const TEST_ASSETS_COUNT: u8 = 3;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @underlying_tokens,
+            aave_rate = @aave_rate
+        )
+    ]
+    fun test_get_all_exposed_tokens(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        aave_rate: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        aave_pool::a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        aave_pool::variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlyings token factory
+        aave_pool::mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init rates - default strategy
+        aave_rate::default_reserve_interest_rate_strategy::init_interest_rate_strategy(
+            aave_rate
+        );
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens_admin,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // check emitted events
+        let emitted_events = emitted_events<ReserveInitialized>();
+        // make sure event of type was emitted
+        assert!(
+            vector::length(&emitted_events) == (TEST_ASSETS_COUNT as u64), TEST_SUCCESS
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+
+        // get all reserve tokens
+        let all_reserve_tokens = pool_data_provider::get_all_reserves_tokens();
+        assert!(
+            vector::length(&underlying_assets) == vector::length(&all_reserve_tokens),
+            TEST_SUCCESS
+        );
+        for (i in 0..vector::length(&underlying_assets)) {
+            let underlying_token_data = vector::borrow(&all_reserve_tokens, i);
+            let underlying_token_symbol =
+                pool_data_provider::get_reserve_token_symbol(underlying_token_data);
+            let underlying_token_address =
+                pool_data_provider::get_reserve_token_address(underlying_token_data);
+            assert!(
+                underlying_token_address
+                    == mock_underlying_token_factory::token_address(
+                        underlying_token_symbol
+                    ),
+                TEST_SUCCESS
+            );
+            assert!(
+                vector::contains(&underlying_assets, &underlying_token_address),
+                TEST_SUCCESS
+            );
+        };
+
+        // get all a tokens
+        let all_a_tokens = pool_data_provider::get_all_a_tokens();
+        assert!(
+            vector::length(&atokens_names) == vector::length(&all_a_tokens),
+            TEST_SUCCESS
+        );
+        for (i in 0..vector::length(&atokens_symbols)) {
+            let a_token_data = vector::borrow(&all_a_tokens, i);
+            let a_token_symbol =
+                pool_data_provider::get_reserve_token_symbol(a_token_data);
+            let a_token_address =
+                pool_data_provider::get_reserve_token_address(a_token_data);
+            assert!(
+                a_token_address
+                    == a_token_factory::token_address(
+                        signer::address_of(aave_pool), a_token_symbol
+                    ),
+                TEST_SUCCESS
+            );
+        };
+
+        // get all var tokens
+        let all_var_tokens = pool_data_provider::get_all_var_tokens();
+        assert!(
+            vector::length(&var_tokens_names) == vector::length(&all_var_tokens),
+            TEST_SUCCESS
+        );
+        for (i in 0..vector::length(&var_tokens_names)) {
+            let var_token_data = vector::borrow(&all_var_tokens, i);
+            let var_token_symbol =
+                pool_data_provider::get_reserve_token_symbol(var_token_data);
+            let var_token_address =
+                pool_data_provider::get_reserve_token_address(var_token_data);
+            assert!(
+                var_token_address
+                    == variable_debt_token_factory::token_address(
+                        signer::address_of(aave_pool), var_token_symbol
+                    ),
+                TEST_SUCCESS
+            );
+        };
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-pool/pool_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-pool/pool_tests.move
@@ -1,0 +1,867 @@
+#[test_only]
+module aave_pool::pool_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option;
+    use std::option::Option;
+    use std::signer::Self;
+    use std::string::{String, utf8};
+    use std::vector;
+    use aptos_std::string_utils;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+
+    use aave_acl::acl_manage::Self;
+    use aave_config::reserve_config::{
+        get_active,
+        get_borrow_cap,
+        get_borrowable_in_isolation,
+        get_borrowing_enabled,
+        get_debt_ceiling,
+        get_decimals,
+        get_emode_category,
+        get_flash_loan_enabled,
+        get_frozen,
+        get_liquidation_bonus,
+        get_liquidation_protocol_fee,
+        get_liquidation_threshold,
+        get_ltv,
+        get_paused,
+        get_reserve_factor,
+        get_siloed_borrowing,
+        get_supply_cap,
+        get_unbacked_mint_cap,
+        init,
+        set_active,
+        set_borrow_cap,
+        set_borrowable_in_isolation,
+        set_borrowing_enabled,
+        set_debt_ceiling,
+        set_decimals,
+        set_emode_category,
+        set_flash_loan_enabled,
+        set_frozen,
+        set_liquidation_bonus,
+        set_liquidation_protocol_fee,
+        set_liquidation_threshold,
+        set_ltv,
+        set_paused,
+        set_reserve_factor,
+        set_siloed_borrowing,
+        set_supply_cap,
+        set_unbacked_mint_cap
+    };
+    use aave_config::user_config::{
+        is_borrowing,
+        is_borrowing_any,
+        is_borrowing_one,
+        is_empty,
+        is_using_as_collateral,
+        is_using_as_collateral_any,
+        is_using_as_collateral_one,
+        is_using_as_collateral_or_borrowing,
+        set_borrowing,
+        set_using_as_collateral
+    };
+    use aave_math::wad_ray_math;
+    use aave_rate::default_reserve_interest_rate_strategy;
+    use aave_rate::interest_rate_strategy;
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::collector;
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::pool::{
+        get_bridge_protocol_fee,
+        get_flashloan_premium_to_protocol,
+        get_flashloan_premium_total,
+        get_reserve_a_token_address,
+        get_reserve_accrued_to_treasury,
+        get_reserve_address_by_id,
+        get_reserve_configuration,
+        get_reserve_configuration_by_reserve_data,
+        get_reserve_current_liquidity_rate,
+        get_reserve_current_variable_borrow_rate,
+        get_reserve_data,
+        get_reserve_data_and_reserves_count,
+        get_reserve_id,
+        get_reserve_isolation_mode_total_debt,
+        get_reserve_liquidity_index,
+        get_reserve_unbacked,
+        get_reserve_variable_borrow_index,
+        get_reserve_variable_debt_token_address,
+        get_reserves_count,
+        get_reserves_list,
+        get_user_configuration,
+        ReserveInitialized,
+        set_bridge_protocol_fee,
+        set_reserve_accrued_to_treasury,
+        set_reserve_current_liquidity_rate_for_testing,
+        set_reserve_current_variable_borrow_rate_for_testing,
+        set_reserve_isolation_mode_total_debt,
+        set_reserve_liquidity_index_for_testing,
+        set_reserve_unbacked,
+        set_reserve_variable_borrow_index_for_testing,
+        set_user_configuration,
+        test_init_reserve,
+        test_set_reserve_configuration,
+        update_flashloan_premiums
+    };
+    use aave_pool::pool_configurator;
+    use aave_pool::token_base::Self;
+    use aave_pool::variable_debt_token_factory::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+    const TEST_ASSETS_COUNT: u8 = 3;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens = @underlying_tokens
+        )
+    ]
+    fun test_default_state(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 6;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // check emitted events
+        let emitted_events = emitted_events<ReserveInitialized>();
+        // make sure event of type was emitted
+        assert!(
+            vector::length(&emitted_events) == (TEST_ASSETS_COUNT as u64), TEST_SUCCESS
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+
+        // get the reserve config for the first underlying and assert
+        let underlying_asset_addr = *vector::borrow(&underlying_assets, 0);
+        let underlying_asset_decimals = *vector::borrow(&underlying_asset_decimals, 0);
+        let reserve_config_map = get_reserve_configuration(underlying_asset_addr);
+
+        // test reserve config
+        assert!(get_ltv(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_liquidation_threshold(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_liquidation_bonus(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(
+            get_decimals(&reserve_config_map) == (underlying_asset_decimals as u256),
+            TEST_SUCCESS
+        );
+        assert!(get_active(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_frozen(&reserve_config_map) == false, TEST_SUCCESS);
+        assert!(get_paused(&reserve_config_map) == false, TEST_SUCCESS);
+        assert!(get_borrowable_in_isolation(&reserve_config_map) == false, TEST_SUCCESS);
+        assert!(get_siloed_borrowing(&reserve_config_map) == false, TEST_SUCCESS);
+        assert!(get_borrowing_enabled(&reserve_config_map) == false, TEST_SUCCESS);
+        assert!(get_reserve_factor(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_borrow_cap(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_supply_cap(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_debt_ceiling(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_liquidation_protocol_fee(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_unbacked_mint_cap(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_emode_category(&reserve_config_map) == 0, TEST_SUCCESS);
+        assert!(get_flash_loan_enabled(&reserve_config_map) == false, TEST_SUCCESS);
+
+        // get the reserve data
+        let reserve_data = get_reserve_data(underlying_asset_addr);
+        let reserve_config = get_reserve_configuration_by_reserve_data(&reserve_data);
+        assert!(reserve_config_map == reserve_config, TEST_SUCCESS);
+        let (reserve_data1, count) =
+            get_reserve_data_and_reserves_count(underlying_asset_addr);
+        assert!(count == (TEST_ASSETS_COUNT as u256), TEST_SUCCESS);
+        let reserve_id = get_reserve_id(&reserve_data);
+        let reserve_data2 = get_reserve_address_by_id((reserve_id as u256));
+        // assert counts
+        assert!(reserve_data == reserve_data1, TEST_SUCCESS);
+        assert!(reserve_data2 == underlying_asset_addr, TEST_SUCCESS);
+        assert!(count == get_reserves_count(), TEST_SUCCESS);
+        // assert reserves list
+        let reserves_list = get_reserves_list();
+        assert!(vector::length(&reserves_list) == (TEST_ASSETS_COUNT as u64), TEST_SUCCESS);
+        assert!(vector::contains(&reserves_list, &underlying_asset_addr), TEST_SUCCESS);
+
+        // test reserve data
+        let a_token_symbol = *vector::borrow(&atokens_symbols, 0);
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool), a_token_symbol
+            );
+
+        let var_token_symbol = *vector::borrow(&var_tokens_symbols, 0);
+        let var_token_address =
+            variable_debt_token_factory::token_address(
+                signer::address_of(aave_pool), var_token_symbol
+            );
+        assert!(
+            get_reserve_a_token_address(&reserve_data) == a_token_address, TEST_SUCCESS
+        );
+        assert!(get_reserve_accrued_to_treasury(&reserve_data) == 0, TEST_SUCCESS);
+        assert!(
+            get_reserve_variable_borrow_index(&reserve_data)
+                == (wad_ray_math::ray() as u128),
+            TEST_SUCCESS
+        );
+        assert!(
+            get_reserve_liquidity_index(&reserve_data) == (wad_ray_math::ray() as u128),
+            TEST_SUCCESS
+        );
+        assert!(get_reserve_current_liquidity_rate(&reserve_data) == 0, TEST_SUCCESS);
+        assert!(
+            get_reserve_current_variable_borrow_rate(&reserve_data) == 0, TEST_SUCCESS
+        );
+        assert!(
+            get_reserve_variable_debt_token_address(&reserve_data) == var_token_address,
+            TEST_SUCCESS
+        );
+        assert!(get_reserve_unbacked(&reserve_data) == 0, TEST_SUCCESS);
+        assert!(get_reserve_isolation_mode_total_debt(&reserve_data) == 0, TEST_SUCCESS);
+
+        // test default extended config
+        assert!(get_flashloan_premium_total() == 0, TEST_SUCCESS);
+        assert!(get_bridge_protocol_fee() == 0, TEST_SUCCESS);
+        assert!(get_flashloan_premium_to_protocol() == 0, TEST_SUCCESS);
+
+        // test default user config
+        let random_user = @0x42;
+        let user_config_map = get_user_configuration(random_user);
+        assert!(is_empty(&user_config_map), TEST_SUCCESS);
+        assert!(!is_borrowing_any(&user_config_map), TEST_SUCCESS);
+        assert!(!is_using_as_collateral_any(&user_config_map), TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens = @underlying_tokens
+        )
+    ]
+    fun test_modified_state(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        for (i in 0..TEST_ASSETS_COUNT) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+
+        // get tokens data
+        let underlying_asset_addr = *vector::borrow(&underlying_assets, 0);
+        let a_token_symbol = *vector::borrow(&atokens_symbols, 0);
+        let a_token_address =
+            a_token_factory::token_address(
+                signer::address_of(aave_pool), a_token_symbol
+            );
+
+        let var_token_symbol = *vector::borrow(&var_tokens_symbols, 0);
+        let var_token_address =
+            variable_debt_token_factory::token_address(
+                signer::address_of(aave_pool), var_token_symbol
+            );
+
+        // test reserve config
+        let reserve_config_new = init();
+        set_ltv(&mut reserve_config_new, 100);
+        set_liquidation_threshold(&mut reserve_config_new, 101);
+        set_liquidation_bonus(&mut reserve_config_new, 102);
+        set_decimals(&mut reserve_config_new, 103);
+        set_active(&mut reserve_config_new, true);
+        set_frozen(&mut reserve_config_new, true);
+        set_paused(&mut reserve_config_new, true);
+        set_borrowable_in_isolation(&mut reserve_config_new, true);
+        set_siloed_borrowing(&mut reserve_config_new, true);
+        set_borrowing_enabled(&mut reserve_config_new, true);
+        set_reserve_factor(&mut reserve_config_new, 104);
+        set_borrow_cap(&mut reserve_config_new, 105);
+        set_supply_cap(&mut reserve_config_new, 106);
+        set_debt_ceiling(&mut reserve_config_new, 107);
+        set_liquidation_protocol_fee(&mut reserve_config_new, 108);
+        set_unbacked_mint_cap(&mut reserve_config_new, 109);
+        set_emode_category(&mut reserve_config_new, 110);
+        set_flash_loan_enabled(&mut reserve_config_new, true);
+
+        // set the reserve configuration
+        test_set_reserve_configuration(underlying_asset_addr, reserve_config_new);
+
+        let reserve_data = get_reserve_data(underlying_asset_addr);
+        let reserve_config_map = get_reserve_configuration_by_reserve_data(&reserve_data);
+
+        assert!(get_ltv(&reserve_config_map) == 100, TEST_SUCCESS);
+        assert!(get_liquidation_threshold(&reserve_config_map) == 101, TEST_SUCCESS);
+        assert!(get_liquidation_bonus(&reserve_config_map) == 102, TEST_SUCCESS);
+        assert!(get_decimals(&reserve_config_map) == 103, TEST_SUCCESS);
+        assert!(get_active(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_frozen(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_paused(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_borrowable_in_isolation(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_siloed_borrowing(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_borrowing_enabled(&reserve_config_map) == true, TEST_SUCCESS);
+        assert!(get_reserve_factor(&reserve_config_map) == 104, TEST_SUCCESS);
+        assert!(get_borrow_cap(&reserve_config_map) == 105, TEST_SUCCESS);
+        assert!(get_supply_cap(&reserve_config_map) == 106, TEST_SUCCESS);
+        assert!(get_debt_ceiling(&reserve_config_map) == 107, TEST_SUCCESS);
+        assert!(get_liquidation_protocol_fee(&reserve_config_map) == 108, TEST_SUCCESS);
+        assert!(get_unbacked_mint_cap(&reserve_config_map) == 109, TEST_SUCCESS);
+        assert!(get_emode_category(&reserve_config_map) == 110, TEST_SUCCESS);
+        assert!(get_flash_loan_enabled(&reserve_config_map) == true, TEST_SUCCESS);
+
+        // test reserve data
+        set_reserve_isolation_mode_total_debt(
+            underlying_asset_addr, &mut reserve_data, 200
+        );
+        set_reserve_unbacked(underlying_asset_addr, &mut reserve_data, 201);
+        set_reserve_current_variable_borrow_rate_for_testing(underlying_asset_addr, 202);
+        set_reserve_current_liquidity_rate_for_testing(underlying_asset_addr, 204);
+        set_reserve_liquidity_index_for_testing(underlying_asset_addr, 205);
+        set_reserve_variable_borrow_index_for_testing(underlying_asset_addr, 206);
+        set_reserve_accrued_to_treasury(underlying_asset_addr, &mut reserve_data, 207);
+        let reserve_data = get_reserve_data(underlying_asset_addr);
+        assert!(
+            get_reserve_isolation_mode_total_debt(&reserve_data) == 200, TEST_SUCCESS
+        );
+        assert!(get_reserve_unbacked(&reserve_data) == 201, TEST_SUCCESS);
+        assert!(
+            get_reserve_current_variable_borrow_rate(&reserve_data) == 202,
+            TEST_SUCCESS
+        );
+        assert!(get_reserve_current_liquidity_rate(&reserve_data) == 204, TEST_SUCCESS);
+        assert!(get_reserve_liquidity_index(&reserve_data) == 205, TEST_SUCCESS);
+        assert!(get_reserve_variable_borrow_index(&reserve_data) == 206, TEST_SUCCESS);
+        assert!(get_reserve_accrued_to_treasury(&reserve_data) == 207, TEST_SUCCESS);
+        assert!(
+            get_reserve_a_token_address(&reserve_data) == a_token_address, TEST_SUCCESS
+        );
+        assert!(
+            get_reserve_variable_debt_token_address(&reserve_data) == var_token_address,
+            TEST_SUCCESS
+        );
+
+        // test reserve extended config
+        update_flashloan_premiums(1000, 2000);
+        assert!(get_flashloan_premium_total() == 1000, TEST_SUCCESS);
+        assert!(get_flashloan_premium_to_protocol() == 2000, TEST_SUCCESS);
+        set_bridge_protocol_fee(4000);
+        assert!(get_bridge_protocol_fee() == 4000, TEST_SUCCESS);
+
+        // test reserve user config
+        let random_user = @0x42;
+        let reserve_index = get_reserve_id(&reserve_data);
+        let user_config_map = get_user_configuration(random_user);
+        set_borrowing(&mut user_config_map, (reserve_index as u256), true);
+        set_using_as_collateral(&mut user_config_map, (reserve_index as u256), true);
+        set_user_configuration(random_user, user_config_map);
+        assert!(
+            is_borrowing(&user_config_map, (reserve_index as u256)) == true, TEST_SUCCESS
+        );
+        assert!(is_borrowing_any(&user_config_map) == true, TEST_SUCCESS);
+        assert!(is_borrowing_one(&user_config_map) == true, TEST_SUCCESS);
+        assert!(
+            is_using_as_collateral_or_borrowing(&user_config_map, (reserve_index as u256))
+                == true,
+            TEST_SUCCESS
+        );
+        assert!(
+            is_using_as_collateral(&user_config_map, (reserve_index as u256)) == true,
+            TEST_SUCCESS
+        );
+        assert!(is_using_as_collateral_any(&user_config_map) == true, TEST_SUCCESS);
+        assert!(is_using_as_collateral_one(&user_config_map) == true, TEST_SUCCESS);
+        assert!(
+            is_using_as_collateral_or_borrowing(&user_config_map, (reserve_index as u256))
+                == true,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_rate = @aave_rate,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aave_oracle = @aave_oracle,
+            publisher = @data_feeds,
+            platform = @platform,
+            underlying_tokens = @underlying_tokens
+        )
+    ]
+    fun test_add_drop_reserves(
+        aave_pool: &signer,
+        aave_rate: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aave_oracle: &signer,
+        publisher: &signer,
+        platform: &signer,
+        underlying_tokens: &signer
+    ) {
+        // create test accounts
+        account::create_account_for_test(signer::address_of(aave_pool));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        acl_manage::test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(aave_role_super_admin, @aave_pool);
+        acl_manage::add_pool_admin(aave_role_super_admin, @aave_pool);
+
+        // init collector
+        collector::init_module_test(aave_pool);
+        let collector_address = collector::collector_address();
+
+        // init token base (a tokens and var tokens)
+        token_base::test_init_module(aave_pool);
+
+        // init a token factory
+        a_token_factory::test_init_module(aave_pool);
+
+        // init debt token factory
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init the oracle module
+        aave_oracle::oracle_tests::config_oracle(aave_oracle, publisher, platform);
+
+        // init pool_configurator & reserves module
+        pool_configurator::test_init_module(aave_pool);
+
+        // init rate
+        interest_rate_strategy::test_init_module(aave_rate);
+
+        assert!(pool_configurator::get_revision() == 1, TEST_SUCCESS);
+
+        // init input data for creating pool reserves
+        let treasuries: vector<address> = vector[];
+
+        // create underlyings
+        let underlying_assets: vector<address> = vector[];
+        let underlying_asset_decimals: vector<u8> = vector[];
+        let atokens_names: vector<String> = vector[];
+        let atokens_symbols: vector<String> = vector[];
+        let var_tokens_names: vector<String> = vector[];
+        let var_tokens_symbols: vector<String> = vector[];
+        let num_reserves = 3;
+        for (i in 0..num_reserves) {
+            let name = string_utils::format1(&b"APTOS_UNDERLYING_{}", i);
+            let symbol = string_utils::format1(&b"U_{}", i);
+            let decimals = 2 + i;
+            let max_supply = 10000;
+            mock_underlying_token_factory::create_token(
+                underlying_tokens,
+                max_supply,
+                name,
+                symbol,
+                decimals,
+                utf8(b""),
+                utf8(b"")
+            );
+
+            let underlying_token_address =
+                mock_underlying_token_factory::token_address(symbol);
+
+            // init the default interest rate strategy for the underlying_token_address
+            let optimal_usage_ratio: u256 = wad_ray_math::get_half_ray_for_testing();
+            let base_variable_borrow_rate: u256 = 0;
+            let variable_rate_slope1: u256 = 0;
+            let variable_rate_slope2: u256 = 0;
+            default_reserve_interest_rate_strategy::set_reserve_interest_rate_strategy(
+                aave_pool,
+                underlying_token_address,
+                optimal_usage_ratio,
+                base_variable_borrow_rate,
+                variable_rate_slope1,
+                variable_rate_slope2
+            );
+
+            vector::push_back(&mut underlying_assets, underlying_token_address);
+            vector::push_back(&mut underlying_asset_decimals, decimals);
+            vector::push_back(&mut treasuries, collector_address);
+            vector::push_back(
+                &mut atokens_names, string_utils::format1(&b"APTOS_A_TOKEN_{}", i)
+            );
+            vector::push_back(&mut atokens_symbols, string_utils::format1(&b"A_{}", i));
+            vector::push_back(
+                &mut var_tokens_names, string_utils::format1(&b"APTOS_VAR_TOKEN_{}", i)
+            );
+            vector::push_back(
+                &mut var_tokens_symbols, string_utils::format1(&b"V_{}", i)
+            );
+        };
+
+        // create pool reserves
+        pool_configurator::init_reserves(
+            aave_pool,
+            underlying_assets,
+            treasuries,
+            atokens_names,
+            atokens_symbols,
+            var_tokens_names,
+            var_tokens_symbols
+        );
+        // test reserves count
+        assert!(get_reserves_count() == (num_reserves as u256), TEST_SUCCESS);
+
+        // drop some reserves
+        //test_drop_reserve(*vector::borrow(&underlying_assets, 0));
+        pool_configurator::drop_reserve(
+            aave_pool, *vector::borrow(&underlying_assets, 0)
+        );
+        pool_configurator::drop_reserve(
+            aave_pool, *vector::borrow(&underlying_assets, 1)
+        );
+
+        // check emitted events
+        let emitted_events = emitted_events<pool_configurator::ReserveDropped>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 2, TEST_SUCCESS);
+    }
+
+    public fun create_reserve_with_config(
+        account: &signer,
+        underlying_asset_addr: address,
+        underlying_asset_decimals: u256,
+        treasury: address,
+        a_token_name: String,
+        a_token_symbol: String,
+        variable_debt_token_name: String,
+        variable_debt_token_symbol: String,
+        ltv: Option<u256>,
+        liquidation_threshold: Option<u256>,
+        liquidation_bonus: Option<u256>,
+        decimals: Option<u256>,
+        active: Option<bool>,
+        frozen: Option<bool>,
+        paused: Option<bool>,
+        borrowable_in_isolation: Option<bool>,
+        siloed_borrowing: Option<bool>,
+        borrowing_enabled: Option<bool>,
+        reserve_factor: Option<u256>,
+        borrow_cap: Option<u256>,
+        supply_cap: Option<u256>,
+        debt_ceiling: Option<u256>,
+        liquidation_protocol_fee: Option<u256>,
+        unbacked_mint_cap: Option<u256>,
+        e_mode_category: Option<u256>,
+        flash_loan_enabled: Option<bool>
+    ): u256 {
+        // create a brand new reserve
+        test_init_reserve(
+            account,
+            underlying_asset_addr,
+            treasury,
+            a_token_name,
+            a_token_symbol,
+            variable_debt_token_name,
+            variable_debt_token_symbol
+        );
+
+        // create reserve configuration
+        let reserve_config_new = init();
+        set_ltv(&mut reserve_config_new, option::get_with_default(&ltv, 100));
+        set_liquidation_threshold(
+            &mut reserve_config_new,
+            option::get_with_default(&liquidation_threshold, 101)
+        );
+        set_liquidation_bonus(
+            &mut reserve_config_new, option::get_with_default(&liquidation_bonus, 102)
+        );
+        set_decimals(&mut reserve_config_new, option::get_with_default(&decimals, 103));
+        set_active(&mut reserve_config_new, option::get_with_default(&active, true));
+        set_frozen(&mut reserve_config_new, option::get_with_default(&frozen, false));
+        set_paused(&mut reserve_config_new, option::get_with_default(&paused, false));
+        set_borrowable_in_isolation(
+            &mut reserve_config_new,
+            option::get_with_default(&borrowable_in_isolation, false)
+        );
+        set_siloed_borrowing(
+            &mut reserve_config_new, option::get_with_default(&siloed_borrowing, false)
+        );
+        set_borrowing_enabled(
+            &mut reserve_config_new,
+            option::get_with_default(&borrowing_enabled, false)
+        );
+        set_reserve_factor(
+            &mut reserve_config_new, option::get_with_default(&reserve_factor, 104)
+        );
+        set_borrow_cap(
+            &mut reserve_config_new, option::get_with_default(&borrow_cap, 105)
+        );
+        set_supply_cap(
+            &mut reserve_config_new, option::get_with_default(&supply_cap, 106)
+        );
+        set_debt_ceiling(
+            &mut reserve_config_new, option::get_with_default(&debt_ceiling, 107)
+        );
+        set_liquidation_protocol_fee(
+            &mut reserve_config_new,
+            option::get_with_default(&liquidation_protocol_fee, 108)
+        );
+        set_unbacked_mint_cap(
+            &mut reserve_config_new, option::get_with_default(&unbacked_mint_cap, 109)
+        );
+        set_emode_category(
+            &mut reserve_config_new, option::get_with_default(&e_mode_category, 0)
+        );
+        set_flash_loan_enabled(
+            &mut reserve_config_new,
+            option::get_with_default(&flash_loan_enabled, true)
+        );
+
+        // set the reserve configuration
+        test_set_reserve_configuration(underlying_asset_addr, reserve_config_new);
+
+        let reserve_data = get_reserve_data(underlying_asset_addr);
+
+        (get_reserve_liquidity_index(&reserve_data) as u256)
+    }
+
+    public fun create_user_config_for_reserve(
+        user: address,
+        reserve_index: u256,
+        is_borrowing: Option<bool>,
+        is_using_as_collateral: Option<bool>
+    ) {
+        let user_config_map = get_user_configuration(user);
+        set_borrowing(
+            &mut user_config_map,
+            reserve_index,
+            option::get_with_default(&is_borrowing, false)
+        );
+        set_using_as_collateral(
+            &mut user_config_map,
+            reserve_index,
+            option::get_with_default(&is_using_as_collateral, false)
+        );
+        // set the user configuration
+        set_user_configuration(user, user_config_map);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-tokens/a_token_factory_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-tokens/a_token_factory_tests.move
@@ -1,0 +1,898 @@
+#[test_only]
+module aave_pool::a_token_factory_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::signer;
+    use std::string;
+    use std::string::utf8;
+    use std::vector::Self;
+    use aptos_std::string_utils::format2;
+    use aptos_framework::account;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    use aave_acl::acl_manage::{Self, test_init_module};
+    use aave_math::wad_ray_math;
+
+    use aave_pool::a_token_factory::Self;
+    use aave_pool::mock_underlying_token_factory::Self;
+    use aave_pool::token_base;
+    use aave_pool::token_base::{Burn, Mint, Transfer};
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            a_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1
+        )
+    ]
+    fun test_atoken_initialization(
+        aave_pool: &signer,
+        a_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create a tokens admin account
+        account::create_account_for_test(signer::address_of(a_tokens_admin));
+
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init a token
+        a_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(a_tokens_admin)
+        );
+
+        // create a tokens
+        let name = utf8(b"TEST_A_TOKEN_1");
+        let symbol = utf8(b"A1");
+        let decimals = 3;
+        let underlying_asset_address = @0x033;
+        let treasury_address = @0x034;
+        a_token_factory::create_token(
+            a_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+        // check emitted events
+        let emitted_events = emitted_events<a_token_factory::Initialized>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+
+        let a_token_address =
+            a_token_factory::token_address(signer::address_of(a_tokens_admin), symbol);
+        let a_token_metadata =
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol);
+        let seed = *string::bytes(&format2(&b"{}_{}", symbol, 1));
+        let resource_account =
+            account::create_resource_address(&signer::address_of(a_tokens_admin), seed);
+        assert!(
+            object::address_to_object<Metadata>(a_token_address) == a_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(a_token_factory::get_revision() == 1, TEST_SUCCESS);
+        assert!(a_token_factory::decimals(a_token_address) == decimals, TEST_SUCCESS);
+        assert!(a_token_factory::symbol(a_token_address) == symbol, TEST_SUCCESS);
+        assert!(a_token_factory::name(a_token_address) == name, TEST_SUCCESS);
+        assert!(
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol)
+                == a_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_underlying_asset_address(a_token_address)
+                == underlying_asset_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_reserve_treasury_address(a_token_address)
+                == treasury_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_token_account_address(a_token_address)
+                == resource_account,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            a_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1,
+            token_receiver = @0x42,
+            caller = @0x41,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    fun test_atoken_mint_burn_transfer(
+        aave_pool: &signer,
+        a_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer,
+        token_receiver: &signer,
+        caller: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create a tokens admin account
+        account::create_account_for_test(signer::address_of(a_tokens_admin));
+
+        // init token base
+        mock_underlying_token_factory::test_init_module(aave_pool);
+        token_base::test_init_module(aave_pool);
+
+        // init a token
+        a_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(a_tokens_admin)
+        );
+
+        let name = utf8(b"TOKEN_1");
+        let symbol = utf8(b"T1");
+        let decimals = 3;
+        let max_supply = 10000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens_admin,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+        let underlying_asset_address =
+            mock_underlying_token_factory::token_address(symbol);
+
+        // create a_tokens
+        let name = utf8(b"TEST_A_TOKEN_2");
+        let symbol = utf8(b"A2");
+        let decimals = 3;
+        let treasury_address = @0x034;
+
+        a_token_factory::create_token(
+            a_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+        // check emitted events
+        let emitted_events = emitted_events<a_token_factory::Initialized>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+
+        let a_token_address =
+            a_token_factory::token_address(signer::address_of(a_tokens_admin), symbol);
+        let a_token_metadata =
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol);
+        let seed = *string::bytes(&format2(&b"{}_{}", symbol, 1));
+        let resource_account =
+            account::create_resource_address(&signer::address_of(a_tokens_admin), seed);
+
+        assert!(
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol)
+                == a_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_underlying_asset_address(a_token_address)
+                == underlying_asset_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_reserve_treasury_address(a_token_address)
+                == treasury_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_token_account_address(a_token_address)
+                == resource_account,
+            TEST_SUCCESS
+        );
+
+        // mint resource_account
+        let amount_to_mint: u256 = 100;
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            a_token_factory::get_token_account_address(a_token_address),
+            (amount_to_mint as u64),
+            underlying_asset_address
+        );
+
+        // ============= MINT ATOKENS ============== //
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        a_token_factory::mint(
+            signer::address_of(caller),
+            signer::address_of(token_receiver),
+            amount_to_mint,
+            reserve_index,
+            a_token_address
+        );
+
+        // get atoken scaled amount
+        let atoken_amount_scaled = wad_ray_math::ray_div(amount_to_mint, reserve_index);
+
+        // assert a token supply
+        assert!(
+            a_token_factory::scaled_total_supply(a_token_address)
+                == atoken_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // assert a_tokens receiver balance
+        assert!(
+            a_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), a_token_address
+            ) == atoken_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 1, TEST_SUCCESS);
+        let emitted_mint_events = emitted_events<Mint>();
+        assert!(vector::length(&emitted_mint_events) == 1, TEST_SUCCESS);
+
+        // ============= BURN ATOKENS ============== //
+        // now burn the atokens
+        let amount_to_burn = amount_to_mint / 2;
+
+        // burn
+        a_token_factory::burn(
+            signer::address_of(token_receiver),
+            signer::address_of(token_receiver),
+            amount_to_burn,
+            reserve_index,
+            a_token_address
+        );
+
+        let remaining_amount = amount_to_mint - amount_to_burn;
+        let remaining_amount_scaled =
+            wad_ray_math::ray_div(remaining_amount, reserve_index);
+
+        // assert a token supply
+        assert!(
+            a_token_factory::scaled_total_supply(a_token_address)
+                == remaining_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // assert a_tokens receiver balance
+        assert!(
+            a_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), a_token_address
+            ) == remaining_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 2, TEST_SUCCESS);
+        let emitted_burn_events = emitted_events<Burn>();
+        assert!(vector::length(&emitted_burn_events) == 1, TEST_SUCCESS);
+
+        // ============= TRANSFER ATOKENS ============== //
+        let transfer_receiver = @0x45;
+        let transfer_amount: u256 = 20;
+        let transfer_receiver_amount_scaled =
+            wad_ray_math::ray_div(transfer_amount, reserve_index);
+
+        // assert transfer receiver
+        a_token_factory::transfer_on_liquidation(
+            signer::address_of(token_receiver),
+            transfer_receiver,
+            20,
+            reserve_index,
+            a_token_address
+        );
+        assert!(
+            a_token_factory::scaled_balance_of(transfer_receiver, a_token_address)
+                == transfer_receiver_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // assert token sender
+        let transfer_sender_scaled_balance =
+            wad_ray_math::ray_div(amount_to_burn - transfer_amount, reserve_index);
+        assert!(
+            a_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), a_token_address
+            ) == transfer_sender_scaled_balance,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 3, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            a_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1,
+            token_receiver = @0x42,
+            caller = @0x41
+        )
+    ]
+    fun test_atoken_transfer_on_liquidation(
+        aave_pool: &signer,
+        a_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer,
+        token_receiver: &signer,
+        caller: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init a token
+        a_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(a_tokens_admin)
+        );
+        // create a tokens admin account
+        account::create_account_for_test(signer::address_of(a_tokens_admin));
+
+        // create a_tokens
+        let name = utf8(b"TEST_A_TOKEN_3");
+        let symbol = utf8(b"A3");
+        let decimals = 3;
+        let underlying_asset_address = @0x033;
+        let treasury_address = @0x034;
+        a_token_factory::create_token(
+            a_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+
+        // check emitted events
+        let emitted_events = emitted_events<a_token_factory::Initialized>();
+
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+
+        // check addresses
+        let a_token_metadata =
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol);
+        let a_token_address =
+            a_token_factory::token_address(signer::address_of(a_tokens_admin), symbol);
+        let seed = *string::bytes(&format2(&b"{}_{}", symbol, 1));
+        let resource_account =
+            account::create_resource_address(&signer::address_of(a_tokens_admin), seed);
+
+        assert!(
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol)
+                == a_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_underlying_asset_address(a_token_address)
+                == underlying_asset_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_reserve_treasury_address(a_token_address)
+                == treasury_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_token_account_address(a_token_address)
+                == resource_account,
+            TEST_SUCCESS
+        );
+
+        // ============= MINT ATOKENS ============== //
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        let amount_to_mint_scaled = wad_ray_math::ray_div(amount_to_mint, reserve_index);
+
+        a_token_factory::mint(
+            signer::address_of(caller),
+            signer::address_of(token_receiver),
+            amount_to_mint,
+            reserve_index,
+            a_token_address
+        );
+
+        // assert a token supply
+        assert!(
+            a_token_factory::scaled_total_supply(a_token_address)
+                == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+
+        // assert a_tokens receiver balance
+        assert!(
+            a_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), a_token_address
+            ) == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), a_token_address
+            ) == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 1, TEST_SUCCESS);
+        let emitted_mint_events = emitted_events<Mint>();
+        assert!(vector::length(&emitted_mint_events) == 1, TEST_SUCCESS);
+
+        // ============= TRANSFER ATOKENS ON LIQUIDATION ============== //
+        let transfer_receiver = @0x45;
+        let transfer_amount: u256 = 20;
+        let transfer_receiver_amount_scaled =
+            wad_ray_math::ray_div(transfer_amount, reserve_index);
+        // assert transfer receiver
+        a_token_factory::transfer_on_liquidation(
+            signer::address_of(token_receiver),
+            transfer_receiver,
+            transfer_amount,
+            reserve_index,
+            a_token_address
+        );
+        assert!(
+            a_token_factory::scaled_balance_of(transfer_receiver, a_token_address)
+                == transfer_receiver_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // assert token sender
+        let transfer_sender_scaled_balance =
+            wad_ray_math::ray_div(amount_to_mint - transfer_amount, reserve_index);
+        assert!(
+            a_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), a_token_address
+            ) == transfer_sender_scaled_balance,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 2, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            a_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1
+        )
+    ]
+    fun test_atoken_mint_to_treasury(
+        aave_pool: &signer,
+        a_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create a tokens admin account
+        account::create_account_for_test(signer::address_of(a_tokens_admin));
+
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init a token
+        a_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(a_tokens_admin)
+        );
+
+        // create a tokens
+        let name = utf8(b"TEST_A_TOKEN_4");
+        let symbol = utf8(b"A4");
+        let decimals = 3;
+        let underlying_asset_address = @0x033;
+        let treasury_address = @0x034;
+        a_token_factory::create_token(
+            a_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+
+        // check emitted events
+        let emitted_events = emitted_events<a_token_factory::Initialized>();
+
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+        let a_token_address =
+            a_token_factory::token_address(signer::address_of(a_tokens_admin), symbol);
+        let _a_token_metadata =
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol);
+
+        // ============= MINT TO TREASURY ============== //
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        let amount_to_mint_scaled = wad_ray_math::ray_div(amount_to_mint, reserve_index);
+
+        // mint to treasury
+        a_token_factory::mint_to_treasury(
+            amount_to_mint, reserve_index, a_token_address
+        );
+
+        // check balances
+        assert!(
+            a_token_factory::scaled_balance_of(treasury_address, a_token_address)
+                == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+
+        assert!(
+            a_token_factory::scaled_balance_of(treasury_address, a_token_address)
+                == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            a_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    fun test_atoken_transfer_underlying_to(
+        aave_pool: &signer,
+        a_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create a tokens admin account
+        account::create_account_for_test(signer::address_of(a_tokens_admin));
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // create underlying token
+        let underlying_token_name = utf8(b"TOKEN_5");
+        let underlying_token_symbol = utf8(b"T5");
+        let underlying_token_decimals = 3;
+        let underlying_token_max_supply = 10000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens_admin,
+            underlying_token_max_supply,
+            underlying_token_name,
+            underlying_token_symbol,
+            underlying_token_decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+        let underlying_token_address =
+            mock_underlying_token_factory::token_address(underlying_token_symbol);
+
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init a token
+        a_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(a_tokens_admin)
+        );
+
+        // create a tokens
+        let name = utf8(b"TEST_A_TOKEN_6");
+        let symbol = utf8(b"A6");
+        let decimals = 3;
+        let treasury_address = @0x034;
+        a_token_factory::create_token(
+            a_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_token_address,
+            treasury_address
+        );
+
+        // check emitted events
+        let emitted_events = emitted_events<a_token_factory::Initialized>();
+
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+        let a_token_address =
+            a_token_factory::token_address(signer::address_of(a_tokens_admin), symbol);
+        let _a_token_metadata =
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol);
+
+        // =============== MINT UNDERLYING FOR ACCOUNT ================= //
+        // mint 100 underlying tokens for some address
+        let underlying_amount: u256 = 100;
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            a_token_factory::get_token_account_address(a_token_address),
+            (underlying_amount as u64),
+            underlying_token_address
+        );
+
+        // ============= TRANSFER THE UNDERLYING TIED TO THE ATOKENS ACCOUNT TO ANOTHER ACCOUNT ============== //
+        let underlying_receiver_address = @0x7;
+        let transfer_amount: u256 = 40;
+        a_token_factory::transfer_underlying_to(
+            underlying_receiver_address, transfer_amount, a_token_address
+        );
+
+        // check the receiver balance
+        assert!(
+            (
+                mock_underlying_token_factory::balance_of(
+                    underlying_receiver_address, underlying_token_address
+                ) as u256
+            ) == transfer_amount,
+            TEST_SUCCESS
+        );
+
+        // check the underlying account
+        assert!(
+            (
+                mock_underlying_token_factory::balance_of(
+                    a_token_factory::get_token_account_address(a_token_address),
+                    underlying_token_address
+                ) as u256
+            ) == underlying_amount - transfer_amount,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            a_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1,
+            rescue_receiver = @0x42,
+            caller = @0x41,
+            underlying_tokens_admin = @underlying_tokens
+        )
+    ]
+    fun test_atoken_rescue(
+        aave_pool: &signer,
+        a_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer,
+        rescue_receiver: &signer,
+        caller: &signer,
+        underlying_tokens_admin: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // create a tokens admin account
+        account::create_account_for_test(signer::address_of(a_tokens_admin));
+
+        // init the acl module and make aave_pool the asset listing/pool admin
+        test_init_module(aave_role_super_admin);
+        acl_manage::add_asset_listing_admin(
+            aave_role_super_admin, signer::address_of(aave_pool)
+        );
+        acl_manage::add_pool_admin(
+            aave_role_super_admin, signer::address_of(aave_pool)
+        );
+
+        // init mock underlying token
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init a token
+        a_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(a_tokens_admin)
+        );
+
+        // create a_tokens
+        let name = utf8(b"TEST_A_TOKEN");
+        let symbol = utf8(b"A");
+        let decimals = 3;
+        let treasury_address = @0x034;
+        let underlying_asset_address = @0x033;
+        a_token_factory::create_token(
+            a_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address,
+            treasury_address
+        );
+
+        // check emitted events
+        let emitted_events = emitted_events<a_token_factory::Initialized>();
+
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+        let a_token_address =
+            a_token_factory::token_address(signer::address_of(a_tokens_admin), symbol);
+        let a_token_metadata =
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol);
+        let seed = *string::bytes(&format2(&b"{}_{}", symbol, 1));
+        let resource_account =
+            account::create_resource_address(&signer::address_of(a_tokens_admin), seed);
+
+        // check addresses
+        assert!(
+            a_token_factory::asset_metadata(signer::address_of(a_tokens_admin), symbol)
+                == a_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_underlying_asset_address(a_token_address)
+                == underlying_asset_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_reserve_treasury_address(a_token_address)
+                == treasury_address,
+            TEST_SUCCESS
+        );
+        assert!(
+            a_token_factory::get_token_account_address(a_token_address)
+                == resource_account,
+            TEST_SUCCESS
+        );
+
+        // ============= RESCUE TRANSFER ATOKENS ============== //
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        let _amount_to_mint_scaled = wad_ray_math::ray_div(
+            amount_to_mint, reserve_index
+        );
+
+        let rescue_amount: u256 = 20;
+        let _rescue_amount_scaled = wad_ray_math::ray_div(rescue_amount, reserve_index);
+
+        // mint some tokens to the pool
+        a_token_factory::mint(
+            signer::address_of(caller),
+            signer::address_of(aave_pool),
+            amount_to_mint,
+            reserve_index,
+            a_token_address
+        );
+
+        // check events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 1, TEST_SUCCESS);
+        let emitted_mint_events = emitted_events<Mint>();
+        assert!(vector::length(&emitted_mint_events) == 1, TEST_SUCCESS);
+
+        // Create a new token
+        let name = utf8(b"TOKEN_1");
+        let symbol = utf8(b"T1");
+        let decimals = 3;
+        let max_supply = 10000000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens_admin,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+        // Transfer some tokens to the resource account
+        let new_underlying_asset_address =
+            mock_underlying_token_factory::token_address(symbol);
+        let mint_amount = 1000000;
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            a_token_factory::get_token_account_address(a_token_address),
+            mint_amount,
+            new_underlying_asset_address
+        );
+
+        // do rescue transfer. Singer is pool admin = aave_pool
+        a_token_factory::rescue_tokens(
+            aave_pool,
+            new_underlying_asset_address,
+            signer::address_of(rescue_receiver),
+            (mint_amount as u256),
+            a_token_address
+        );
+
+        // assert rescue receiver balance
+        // assert!(a_token_factory::scaled_balance_of(signer::address_of(rescue_receiver), a_token_address) == rescue_amount_scaled,
+        //     TEST_SUCCESS);
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-tokens/mock_underlying_token_factory_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-tokens/mock_underlying_token_factory_tests.move
@@ -1,0 +1,151 @@
+#[test_only]
+module aave_pool::mock_underlying_token_factory_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::option::Self;
+    use std::signer::Self;
+    use std::string::utf8;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+
+    use aave_pool::mock_underlying_token_factory::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            underlying_tokens_admin = @underlying_tokens,
+            aave_std = @std
+        )
+    ]
+    fun test_underlying_token_initialization(
+        underlying_tokens_admin: &signer, aave_pool: &signer, aave_std: &signer
+    ) {
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // create underlying tokens
+        let name = utf8(b"TOKEN_1");
+        let symbol = utf8(b"T1");
+        let decimals = 3;
+        let max_supply = 10000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens_admin,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+        let underlying_token_metadata =
+            mock_underlying_token_factory::get_metadata_by_symbol(symbol);
+        let underlying_token_address =
+            mock_underlying_token_factory::token_address(symbol);
+        assert!(
+            object::address_to_object<Metadata>(underlying_token_address)
+                == underlying_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(
+            mock_underlying_token_factory::get_token_account_address()
+                == signer::address_of(underlying_tokens_admin),
+            TEST_SUCCESS
+        );
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(0),
+            TEST_SUCCESS
+        );
+        assert!(
+            mock_underlying_token_factory::decimals(underlying_token_address)
+                == decimals,
+            TEST_SUCCESS
+        );
+        assert!(
+            mock_underlying_token_factory::maximum(underlying_token_address)
+                == option::some(max_supply),
+            TEST_SUCCESS
+        );
+        assert!(
+            mock_underlying_token_factory::symbol(underlying_token_address) == symbol,
+            TEST_SUCCESS
+        );
+        assert!(
+            mock_underlying_token_factory::name(underlying_token_address) == name,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            underlying_tokens_admin = @underlying_tokens,
+            aave_std = @std
+        )
+    ]
+    fun test_underlying_token_minting_burn(
+        aave_pool: &signer, underlying_tokens_admin: &signer, aave_std: &signer
+    ) {
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init underlying tokens
+        mock_underlying_token_factory::test_init_module(aave_pool);
+
+        // create underlying tokens
+        let name = utf8(b"TOKEN_1");
+        let symbol = utf8(b"T1");
+        let decimals = 3;
+        let max_supply = 10000;
+        mock_underlying_token_factory::create_token(
+            underlying_tokens_admin,
+            max_supply,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b"")
+        );
+        let underlying_token_address =
+            mock_underlying_token_factory::token_address(symbol);
+        let receiver_address = @0x42;
+
+        // mint 100 tokens
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            receiver_address,
+            100,
+            underlying_token_address
+        );
+        let user_balance =
+            mock_underlying_token_factory::balance_of(
+                receiver_address, underlying_token_address
+            );
+        assert!(user_balance == 100, TEST_SUCCESS);
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(100),
+            TEST_SUCCESS
+        );
+
+        // burn half of the tokens
+        mock_underlying_token_factory::burn(
+            receiver_address, 50, underlying_token_address
+        );
+        let user_balance =
+            mock_underlying_token_factory::balance_of(
+                receiver_address, underlying_token_address
+            );
+        assert!(user_balance == 50, TEST_SUCCESS);
+        assert!(
+            mock_underlying_token_factory::supply(underlying_token_address)
+                == option::some(50),
+            TEST_SUCCESS
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-tokens/standard_token_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-tokens/standard_token_tests.move
@@ -1,0 +1,146 @@
+#[test_only]
+module aave_pool::standard_token_tests {
+    use std::signer::Self;
+    use std::string::utf8;
+    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+
+    use aave_pool::standard_token::{
+        burn_from_primary_stores,
+        deposit_to_primary_stores,
+        initialize,
+        mint_to_primary_stores,
+        set_primary_stores_frozen_status,
+        transfer_between_primary_stores,
+        withdraw_from_primary_stores
+    };
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    fun create_test_mfa(creator: &signer): Object<Metadata> {
+        let test_symbol = b"TEST";
+        initialize(
+            creator,
+            0,
+            utf8(b"Test Token"), /* name */
+            utf8(test_symbol), /* symbol */
+            8, /* decimals */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
+            utf8(b"http://example.com"), /* project */
+            vector[true, true, true],
+            @0x123,
+            false
+        );
+        let metadata_address =
+            object::create_object_address(&signer::address_of(creator), test_symbol);
+        object::address_to_object<Metadata>(metadata_address)
+    }
+
+    #[test(creator = @aave_pool)]
+    fun test_basic_flow(creator: &signer) {
+        let metadata = create_test_mfa(creator);
+        let creator_address = signer::address_of(creator);
+        let aaron_address = @0x111;
+
+        mint_to_primary_stores(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            vector[100, 50]
+        );
+        assert!(
+            primary_fungible_store::balance(creator_address, metadata) == 100,
+            TEST_SUCCESS
+        );
+        assert!(
+            primary_fungible_store::balance(aaron_address, metadata) == 50, TEST_SUCCESS
+        );
+
+        set_primary_stores_frozen_status(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            true
+        );
+        assert!(
+            primary_fungible_store::is_frozen(creator_address, metadata), TEST_SUCCESS
+        );
+        assert!(
+            primary_fungible_store::is_frozen(aaron_address, metadata), TEST_SUCCESS
+        );
+
+        transfer_between_primary_stores(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            vector[aaron_address, creator_address],
+            vector[10, 5]
+        );
+        assert!(
+            primary_fungible_store::balance(creator_address, metadata) == 95,
+            TEST_SUCCESS
+        );
+        assert!(
+            primary_fungible_store::balance(aaron_address, metadata) == 55, TEST_SUCCESS
+        );
+
+        set_primary_stores_frozen_status(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            false
+        );
+        assert!(
+            !primary_fungible_store::is_frozen(creator_address, metadata),
+            TEST_SUCCESS
+        );
+        assert!(
+            !primary_fungible_store::is_frozen(aaron_address, metadata), TEST_SUCCESS
+        );
+
+        let fa =
+            withdraw_from_primary_stores(
+                creator,
+                metadata,
+                vector[creator_address, aaron_address],
+                vector[25, 15]
+            );
+        assert!(fungible_asset::amount(&fa) == 40, TEST_SUCCESS);
+        deposit_to_primary_stores(
+            creator,
+            &mut fa,
+            vector[creator_address, aaron_address],
+            vector[30, 10]
+        );
+        fungible_asset::destroy_zero(fa);
+
+        burn_from_primary_stores(
+            creator,
+            metadata,
+            vector[creator_address, aaron_address],
+            vector[100, 50]
+        );
+        assert!(
+            primary_fungible_store::balance(creator_address, metadata) == 0,
+            TEST_SUCCESS
+        );
+        assert!(
+            primary_fungible_store::balance(aaron_address, metadata) == 0, TEST_SUCCESS
+        );
+    }
+
+    #[test(creator = @aave_pool, aaron = @0x111)]
+    #[expected_failure(abort_code = 0x50001, location = aave_pool::standard_token)]
+    fun test_permission_denied(creator: &signer, aaron: &signer) {
+        let metadata = create_test_mfa(creator);
+        let creator_address = signer::address_of(creator);
+        mint_to_primary_stores(
+            aaron,
+            metadata,
+            vector[creator_address],
+            vector[100]
+        );
+    }
+}

--- a/tests/aptos-aave-v3/aave-core/tests/aave-tokens/variable_token_factory_tests.move
+++ b/tests/aptos-aave-v3/aave-core/tests/aave-tokens/variable_token_factory_tests.move
@@ -1,0 +1,228 @@
+#[test_only]
+module aave_pool::variable_debt_token_factory_tests {
+    use std::features::change_feature_flags_for_testing;
+    use std::signer::Self;
+    use std::string::utf8;
+    use std::vector::Self;
+    use aptos_framework::event::emitted_events;
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Self;
+    use aptos_framework::timestamp::set_time_has_started_for_testing;
+
+    use aave_acl::acl_manage::Self;
+    use aave_math::wad_ray_math;
+
+    use aave_pool::token_base::Self;
+    use aave_pool::token_base::{Burn, Mint, Transfer};
+    use aave_pool::variable_debt_token_factory::Self;
+
+    const TEST_SUCCESS: u64 = 1;
+    const TEST_FAILED: u64 = 2;
+
+    #[test(
+        aave_pool = @aave_pool, variable_tokens_admin = @aave_pool, aave_acl = @aave_acl
+    )]
+    fun test_variable_token_initialization(
+        aave_pool: &signer, variable_tokens_admin: &signer, aave_acl: &signer
+    ) {
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init debt token
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(variable_tokens_admin)
+        );
+
+        // create variable tokens
+        let name = utf8(b"TEST_VAR_TOKEN_1");
+        let symbol = utf8(b"VAR1");
+        let decimals = 3;
+        variable_debt_token_factory::create_token(
+            variable_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            @0x033
+        );
+        // check emitted events
+        let emitted_events = emitted_events<variable_debt_token_factory::Initialized>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+        let variable_token_address =
+            variable_debt_token_factory::token_address(
+                signer::address_of(variable_tokens_admin), symbol
+            );
+        let variable_token_metadata =
+            variable_debt_token_factory::asset_metadata(
+                signer::address_of(variable_tokens_admin), symbol
+            );
+        assert!(
+            object::address_to_object<Metadata>(variable_token_address)
+                == variable_token_metadata,
+            TEST_SUCCESS
+        );
+        assert!(variable_debt_token_factory::get_revision() == 1, TEST_SUCCESS);
+        assert!(
+            variable_debt_token_factory::scaled_total_supply(variable_token_address)
+                == 0,
+            TEST_SUCCESS
+        );
+        assert!(
+            variable_debt_token_factory::decimals(variable_token_address) == decimals,
+            TEST_SUCCESS
+        );
+        assert!(
+            variable_debt_token_factory::symbol(variable_token_address) == symbol,
+            TEST_SUCCESS
+        );
+        assert!(
+            variable_debt_token_factory::name(variable_token_address) == name,
+            TEST_SUCCESS
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            variable_tokens_admin = @aave_pool,
+            aave_acl = @aave_acl,
+            aave_std = @std,
+            aptos_framework = @0x1,
+            token_receiver = @0x42,
+            caller = @0x41
+        )
+    ]
+    fun test_variable_token_mint_burn(
+        aave_pool: &signer,
+        variable_tokens_admin: &signer,
+        aave_acl: &signer,
+        aave_std: &signer,
+        aptos_framework: &signer,
+        token_receiver: &signer,
+        caller: &signer
+    ) {
+        // start the timer
+        set_time_has_started_for_testing(aptos_framework);
+
+        // add the test events feature flag
+        change_feature_flags_for_testing(aave_std, vector[26], vector[]);
+
+        // init token base
+        token_base::test_init_module(aave_pool);
+
+        // init debt token
+        variable_debt_token_factory::test_init_module(aave_pool);
+
+        // set asset listing admin
+        acl_manage::test_init_module(aave_acl);
+        acl_manage::add_asset_listing_admin(
+            aave_acl, signer::address_of(variable_tokens_admin)
+        );
+
+        // create var tokens
+        let name = utf8(b"TEST_VAR_TOKEN_1");
+        let symbol = utf8(b"VAR1");
+        let decimals = 3;
+        let underlying_asset_address = @0x033;
+        variable_debt_token_factory::create_token(
+            variable_tokens_admin,
+            name,
+            symbol,
+            decimals,
+            utf8(b""),
+            utf8(b""),
+            underlying_asset_address
+        );
+        // check emitted events
+        let emitted_events = emitted_events<variable_debt_token_factory::Initialized>();
+        // make sure event of type was emitted
+        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
+        let var_token_address =
+            variable_debt_token_factory::token_address(
+                signer::address_of(variable_tokens_admin), symbol
+            );
+        let _var_token_metadata =
+            variable_debt_token_factory::asset_metadata(
+                signer::address_of(variable_tokens_admin), symbol
+            );
+
+        // ============= MINT ============== //
+        let amount_to_mint: u256 = 100;
+        let reserve_index: u256 = 1 * wad_ray_math::ray();
+        let amount_to_mint_scaled = wad_ray_math::ray_div(amount_to_mint, reserve_index);
+
+        variable_debt_token_factory::mint(
+            signer::address_of(caller),
+            signer::address_of(token_receiver),
+            amount_to_mint,
+            reserve_index,
+            var_token_address
+        );
+
+        // assert a token supply
+        assert!(
+            variable_debt_token_factory::scaled_total_supply(var_token_address)
+                == amount_to_mint_scaled,
+            TEST_SUCCESS
+        );
+
+        // assert var_tokens receiver balance
+        let var_token_amount_scaled = wad_ray_math::ray_div(
+            amount_to_mint, reserve_index
+        );
+        assert!(
+            variable_debt_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), var_token_address
+            ) == var_token_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 1, TEST_SUCCESS);
+        let emitted_mint_events = emitted_events<Mint>();
+        assert!(vector::length(&emitted_mint_events) == 1, TEST_SUCCESS);
+
+        // ============= BURN ============== //
+        // now burn the variable tokens
+        let amount_to_burn = amount_to_mint / 2;
+        variable_debt_token_factory::burn(
+            signer::address_of(token_receiver),
+            amount_to_burn,
+            reserve_index,
+            var_token_address
+        );
+
+        // assert var token supply
+        let expected_var_token_scaled_total_supply =
+            wad_ray_math::ray_div(amount_to_mint - amount_to_burn, reserve_index);
+        assert!(
+            variable_debt_token_factory::scaled_total_supply(var_token_address)
+                == expected_var_token_scaled_total_supply,
+            TEST_SUCCESS
+        );
+
+        // assert var_tokens receiver balance
+        let var_token_amount_scaled = wad_ray_math::ray_div(
+            amount_to_burn, reserve_index
+        );
+        assert!(
+            variable_debt_token_factory::scaled_balance_of(
+                signer::address_of(token_receiver), var_token_address
+            ) == var_token_amount_scaled,
+            TEST_SUCCESS
+        );
+
+        // check emitted events
+        let emitted_transfer_events = emitted_events<Transfer>();
+        assert!(vector::length(&emitted_transfer_events) == 2, TEST_SUCCESS);
+        let emitted_burn_events = emitted_events<Burn>();
+        assert!(vector::length(&emitted_burn_events) == 1, TEST_SUCCESS);
+    }
+}

--- a/tests/move-by-examples/advanced-todo-list/aptos/move/Move.toml
+++ b/tests/move-by-examples/advanced-todo-list/aptos/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-advanced_todo_list_addr = "_"
+advanced_todo_list_addr = "0x111"
 
 [dev-addresses]
 advanced_todo_list_addr = "0x111"

--- a/tests/move-by-examples/friend-tech/aptos/move/Move.toml
+++ b/tests/move-by-examples/friend-tech/aptos/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-aptos_friend_addr = "_"
+aptos_friend_addr = "0x111"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }

--- a/tests/move-by-examples/fungible-asset-launchpad/aptos/move/Move.toml
+++ b/tests/move-by-examples/fungible-asset-launchpad/aptos/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-launchpad_addr = '_'
+launchpad_addr = '0x111'
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework"}

--- a/tests/move-by-examples/fungible-asset-voting/aptos/move/Move.toml
+++ b/tests/move-by-examples/fungible-asset-voting/aptos/move/Move.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-voting_app_addr = "_"
-fa_obj_addr = "_"
+voting_app_addr = "0x111"
+fa_obj_addr = "0x111"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }

--- a/tests/move-by-examples/multidex-router/aptos/move/Move.toml
+++ b/tests/move-by-examples/multidex-router/aptos/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-multidex_router_addr = "_"
+multidex_router_addr = "0x111"
 
 [dev-addresses]
 multidex_router_addr = "0x803"

--- a/tests/move-by-examples/nft-launchpad/aptos/move/Move.toml
+++ b/tests/move-by-examples/nft-launchpad/aptos/move/Move.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-launchpad_addr = "_"
-minter = "_"
+launchpad_addr = "0x111"
+minter = "0x111"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }

--- a/tests/move-by-examples/nft-marketplace/aptos/move/Move.toml
+++ b/tests/move-by-examples/nft-marketplace/aptos/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-marketplace_addr = "_"
+marketplace_addr = "0x111"
 
 [dev-addresses]
 marketplace_addr = "0x111"

--- a/tests/move-by-examples/simple-todo-list/aptos/move/Move.toml
+++ b/tests/move-by-examples/simple-todo-list/aptos/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-simple_todo_list_addr = "_"
+simple_todo_list_addr = "0x111"
 
 [dev-addresses]
 simple_todo_list_addr = "0x111"

--- a/tests/move-by-examples/telegram-boilerplate-template-with-mizu-core/move/Move.toml
+++ b/tests/move-by-examples/telegram-boilerplate-template-with-mizu-core/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-counter_app_addr = "_"
+counter_app_addr = "0x111"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }

--- a/tests/move-by-examples/telegram-boilerplate-template/move/Move.toml
+++ b/tests/move-by-examples/telegram-boilerplate-template/move/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-counter_app_addr = "_"
+counter_app_addr = "0x1"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "mainnet", subdir = "aptos-move/framework/aptos-framework" }

--- a/tests/move-by-examples/telegram-boilerplate-template/move/sources/module.move
+++ b/tests/move-by-examples/telegram-boilerplate-template/move/sources/module.move
@@ -12,9 +12,7 @@ module counter_app_addr::counter_app {
     public entry fun click(sender: &signer) acquires Counter {
         let sender_addr = signer::address_of(sender);
         if (!exists<Counter>(sender_addr)) {
-            move_to(sender, Counter {
-                count: 0
-            })
+            move_to(sender, Counter { count: 0 })
         };
         let counter = borrow_global_mut<Counter>(sender_addr);
         counter.count = counter.count + 1

--- a/tests/symbols/sources/M1.move
+++ b/tests/symbols/sources/M1.move
@@ -3,11 +3,10 @@ module Symbols::M1 {
 
     struct SomeStruct has key, drop, store {
         some_field: u64,
-        some_field2: u64,
+        some_field2: u64
     }
 
     const SOME_CONST: u64 = 42;
-
 
     fun unpack(s: SomeStruct): u64 {
         let SomeStruct { some_field: value, some_field2: value2 } = s;
@@ -28,8 +27,6 @@ module Symbols::M1 {
         some_other_struct(SOME_CONST)
     }
 
-    
-
     fun other_mod_struct_import(): SomeOtherStruct {
         some_other_struct(6);
         some_other_struct(7)
@@ -44,8 +41,8 @@ module Symbols::M1 {
         multi_arg(SOME_CONST, SOME_CONST)
     }
 
-    fun vec(a:vector<SomeStruct>, b:vector<SomeOtherStruct>): vector<SomeStruct> {
-        let s = SomeStruct{ some_field: 7, some_field2: 1  };
+    fun vec(a: vector<SomeStruct>, b: vector<SomeOtherStruct>): vector<SomeStruct> {
+        let s = SomeStruct { some_field: 7, some_field2: 1 };
         let x = s.some_field2;
         a
     }
@@ -61,6 +58,7 @@ module Symbols::M1 {
         let tmp = 7;
         let r = &mut tmp;
         *r = SOME_CONST;
+
         tmp
     }
 }

--- a/tests/symbols/sources/receiver_style_call3.move
+++ b/tests/symbols/sources/receiver_style_call3.move
@@ -4,7 +4,9 @@ module 0x42::ReceiverStyleCall3 {
     use Symbols::M1;
     use Symbols::M2::{Self, SomeOtherStruct, some_other_struct, multi_arg};
 
-    struct S has drop { x: u64 }
+    struct S has drop {
+        x: u64
+    }
 
     fun plus_one<T>(self: &mut S): S {
         self.x = self.x + 1;


### PR DESCRIPTION
# Changelogs:

## 2025/4/30 v1.0.5
- add warning between `aptos-moveanalyzer::format enable` and `vscode::format on save`.[(#issue33)](https://github.com/movebit/aptos-move-analyzer/issues/35)
- try avoiding to truncating source code.[(#issue33)](https://github.com/movebit/aptos-move-analyzer/issues/32)
- optimize speed on InlayHInts.  [(#issue32)](https://github.com/movebit/aptos-move-analyzer/issues/32)
- optimize speed on foramt. [(#issue31)](https://github.com/movebit/aptos-move-analyzer/issues/31)
